### PR TITLE
TargetFrameworkをnet8.0-windowsに統一

### DIFF
--- a/TBird.IO.Pdf/TBird.IO.Pdf.csproj
+++ b/TBird.IO.Pdf/TBird.IO.Pdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
 	<UseWPF>true</UseWPF>
 	<OutputType>Exe</OutputType>
     <StartupObject></StartupObject>

--- a/TBird.IO/TBird.IO.csproj
+++ b/TBird.IO/TBird.IO.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
 	<UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/TBird.Wpf/TBird.Wpf.csproj
+++ b/TBird.Wpf/TBird.Wpf.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/wpftest/wpftest.csproj
+++ b/wpftest/wpftest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <!-- 
      Turns off reference assembly generation 


### PR DESCRIPTION
net7.0-windowsおよびnet8.0-windows8.0をnet8.0-windowsに統一。 TBird.WpfからSuppressTfmSupportBuildWarnings（net7.0時代の暫定対応）を削除。