### PR TITLE
ノベルビューア機能拡張: 縦書き/ソート/お気に入り/一括DL/ランキング

### DIFF
--- a/_Apps/App.xaml.cs
+++ b/_Apps/App.xaml.cs
@@ -1,5 +1,6 @@
 using LanobeReader.Helpers;
 using LanobeReader.Services;
+using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
 
 namespace LanobeReader;
@@ -11,13 +12,15 @@ public partial class App : Application
     private readonly EpisodeCacheRepository _cacheRepo;
     private readonly NovelRepository _novelRepo;
     private readonly UpdateCheckService _updateCheckService;
+    private readonly PrefetchService _prefetchService;
 
     public App(
         DatabaseService dbService,
         AppSettingsRepository settingsRepo,
         EpisodeCacheRepository cacheRepo,
         NovelRepository novelRepo,
-        UpdateCheckService updateCheckService)
+        UpdateCheckService updateCheckService,
+        PrefetchService prefetchService)
     {
         InitializeComponent();
 
@@ -26,6 +29,7 @@ public partial class App : Application
         _cacheRepo = cacheRepo;
         _novelRepo = novelRepo;
         _updateCheckService = updateCheckService;
+        _prefetchService = prefetchService;
 
         // Global exception handler
         AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
@@ -81,6 +85,19 @@ public partial class App : Application
                     catch (Exception ex)
                     {
                         LogHelper.Warn("App", $"Background update check failed: {ex.Message}");
+                    }
+                });
+
+                // 5. Scan unread+uncached episodes and enqueue for prefetch (Wi-Fi only)
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await _prefetchService.EnqueueAllUnreadAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        LogHelper.Warn("App", $"Prefetch scan failed: {ex.Message}");
                     }
                 });
             }

--- a/_Apps/Converters/BoolToGoldConverter.cs
+++ b/_Apps/Converters/BoolToGoldConverter.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace LanobeReader.Converters;
+
+public class BoolToGoldConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is true ? Color.FromArgb("#FFC107") : Color.FromArgb("#CCCCCC");
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/_Apps/Features/plan_2026-04-07_feature-expansion.md
+++ b/_Apps/Features/plan_2026-04-07_feature-expansion.md
@@ -1,0 +1,641 @@
+# 機能拡張 実装計画書
+
+| 項目 | 内容 |
+|---|---|
+| 作成日 | 2026-04-07 |
+| 対象ブランチ | `app-novelviewer` |
+| ステータス | **方針確定（着手可）** |
+| 対象機能 | 縦書き表示 / 一覧ソート変更 / お気に入り(作品＋話) / 一括ダウンロード / ランキング・ジャンルブラウズ |
+| 横断方針 | Wi-Fi接続時の積極先読み・通信間ディレイ・バックグラウンド遅延取得 |
+
+> 本書は実装着手前の計画書です。確認後に修正・着手します。コードはまだ変更していません。
+
+---
+
+## 0. 横断方針（全機能共通）
+
+### 0.1 通信ポリシー（NetworkPolicyService の新設）
+
+新規サービス `Services/Network/NetworkPolicyService.cs` を Singleton で導入し、HTTP リクエストを一元的にスロットリング・ゲートする。
+
+| 概念 | 内容 |
+|---|---|
+| **接続種別判定** | `Connectivity.Current.ConnectionProfiles` に `WiFi` が含まれるか |
+| **積極先読み（Aggressive Mode）** | Wi-Fi 接続時：未キャッシュ話を可能な限り全部取得 |
+| **節制モード（Conservative Mode）** | モバイル通信時：手動操作と更新チェックのみ。先読みは停止 |
+| **通信間ディレイ** | 同一サイトへの連続リクエスト間に既定 800ms（設定可能 500–2000ms）の `Task.Delay` を挿入 |
+| **同時実行制御** | サイト単位に `SemaphoreSlim(1,1)`。並列リクエストを禁止し、必ず直列＋ディレイで送出 |
+| **キャンセル** | アプリ停止・ネットワーク切断・モバイル切替時にバックグラウンドジョブを CancellationToken で停止 |
+| **失敗時** | 1リクエスト失敗で全停止せず、当該話のみ skip して継続。連続5失敗で当該ジョブ中断 |
+
+```csharp
+// イメージシグネチャ（実装はまだ）
+public interface INetworkPolicyService
+{
+    bool IsWifiConnected { get; }
+    bool IsOnline { get; }
+    event EventHandler<NetworkChangedEventArgs> NetworkChanged;
+
+    // サイト別ゲート。直列化＋ディレイを保証する
+    Task<T> ExecuteAsync<T>(SiteType site, Func<CancellationToken, Task<T>> action, CancellationToken ct);
+}
+```
+
+**重要**: 既存の `NarouApiService` / `KakuyomuApiService` の HTTP 呼び出しを `NetworkPolicyService.ExecuteAsync` でラップする。これにより既存の検索・話一覧取得・本文取得すべてが自動的にディレイ＋直列化される（通常操作の体感は微差、暴走防止が効く）。
+
+### 0.2 バックグラウンドジョブ基盤（BackgroundJobQueue）
+
+新規 `Services/Background/BackgroundJobQueue.cs`（Singleton）。
+
+- **キュー方式**: `Channel<BackgroundJob>` (Bounded, 容量100, FullMode=Wait)
+- **ワーカー**: アプリ起動時に 1 本だけ消費 Task を起動（Wi-Fi検出時に動作開始、切断時に一時停止）
+- **ジョブ種別**:
+  - `PrefetchEpisodesJob(novelId, fromEpisodeNo, toEpisodeNo)` — 未キャッシュ話の本文取得
+  - `RefreshNovelMetaJob(novelId)` — 既存の更新チェックを単発実行
+  - `FetchRankingJob(siteType, genreId, kind)` — ランキング取得
+- **永続化**: ジョブはメモリのみ。アプリ再起動時は「未読＆未キャッシュ」を起動時にスキャンして再投入
+- **優先度**: ユーザーが現在開いている小説 > お気に入い > その他
+- **進捗通知**: `IObservable<JobProgress>` でNovelListに進捗バッジ（任意、第二段で実装可）
+
+### 0.3 設定キー追加
+
+`SettingsKeys` / `DatabaseService.SeedSettingsAsync` に追加：
+
+| キー | 既定値 | 用途 |
+|---|---|---|
+| `prefetch_enabled` | "1" | Wi-Fi接続時にバックグラウンド先読みするかのON/OFF（モバイル通信時は本値に関わらず常に先読みしない） |
+| `request_delay_ms` | "800" | サイトへのリクエスト間ディレイ（500–2000ms、設定画面で変更可） |
+| `vertical_writing` | "0" | 縦書き表示 ON/OFF |
+| `novel_sort_key` | "updated_desc" | 小説一覧ソート（後述） |
+
+> **モバイル通信時の先読みポリシー（確定）**: モバイル通信時は `BackgroundJobQueue` の Prefetch 系ジョブを**常に**ディスパッチしない。`prefetch_enabled` 設定は「Wi-Fi 接続時に先読みするか」のON/OFFのみを制御する（モバイル時は設定値に関わらず不可）。手動操作（読書中の本文取得、検索、更新チェック）は通信種別に関わらず動作する。
+
+---
+
+## 1. 縦書き表示
+
+### 1.1 概要
+ReaderPage の本文を縦書き（右→左）でレンダリング。設定 ON/OFF をユーザーが切り替え可能。
+
+### 1.2 実装方式（確定：ハイブリッド）
+
+- **横書き時**: 既存の `ScrollView > Label` をそのまま使用（既読検知・スクロール挙動も現状維持）
+- **縦書き時のみ**: `WebView` に切り替え、HTML+CSS `writing-mode: vertical-rl;` で表示
+- ReaderPage のレイアウトには `Label` と `WebView` の両方を配置し、`IsVerticalWriting` で `IsVisible` を排他制御
+
+### 1.3 設計
+
+- **新規ファイル**: `Helpers/ReaderHtmlBuilder.cs`
+  - 入力: 本文(string), FontSize, LineHeight, BackgroundTheme
+  - 出力: 縦書き用の完全な HTML 文字列（インライン CSS）
+  - CSS: `html, body { writing-mode: vertical-rl; -webkit-writing-mode: vertical-rl; }` ＋テーマ別 `background` / `color` ＋フォント/行間
+- **ReaderPage.xaml**:
+  - 既存 `ScrollView > Label` はそのまま残す（`IsVisible="{Binding IsHorizontal}"`）
+  - 同階層に `WebView`（`IsVisible="{Binding IsVerticalWriting}"`）を追加
+- **ReaderPage.xaml.cs**:
+  - 横書き時: 従来の `OnScrolled`
+  - 縦書き時: `WebView.Navigated` 後に EvaluateJavaScriptAsync で scroll 監視を仕込む。スクロール左端到達で `lanobe://read-end` ナビゲーションを発火 → `Navigating` イベントで Cancel しつつ ReaderViewModel.MarkAsRead() を呼ぶ
+- **ReaderViewModel**:
+  - `[ObservableProperty] bool IsVerticalWriting`（InverseBoolConverter で `IsHorizontal` をXAML側で生成、または別プロパティ）
+  - `IsVerticalWriting` 変更時 / 本文変更時に HTML を再生成し WebView.Source を更新
+- **SettingsViewModel / SettingsPage**:
+  - 「縦書き表示」Switch を追加。プレビューも切り替え
+
+### 1.4 トレードオフ（受容）
+- WebView は縦書きON時のみロードされるためメモリ増は限定的
+- 縦書き時のテキスト選択UIは WebView 標準（横書き時の挙動には影響なし）
+- 既読検知の JS Bridge は縦書き時のみ。横書きは現行ロジックを温存
+
+### 1.5 影響範囲ファイル
+- 新規: `Helpers/ReaderHtmlBuilder.cs`
+- 修正: `Views/ReaderPage.xaml`, `Views/ReaderPage.xaml.cs`, `ViewModels/ReaderViewModel.cs`, `ViewModels/SettingsViewModel.cs`, `Views/SettingsPage.xaml`, `Helpers/SettingsKeys.cs`, `Services/Database/DatabaseService.cs`
+
+---
+
+## 2. 一覧内ソート変更
+
+### 2.1 ソート種別
+
+| キー | 表示名 | 内容 |
+|---|---|---|
+| `updated_desc` | 更新日時(新しい順) | 既定（現状） |
+| `updated_asc` | 更新日時(古い順) | |
+| `title_asc` | タイトル昇順 | OrderBy(Title) |
+| `title_desc` | タイトル降順 | |
+| `author_asc` | 作者昇順 | |
+| `unread_desc` | 未読話数(多い順) | |
+| `registered_desc` | 登録日時(新しい順) | |
+| `favorite_first` | お気に入り優先 + 更新日時順 | お気に入りが先頭、その後 updated_desc |
+
+### 2.2 設計
+
+- **NovelListViewModel**:
+  - `[ObservableProperty] string SortKey`（初期値は AppSettings から読込み）
+  - 変更時に LoadNovelsAsync() を再実行＋ AppSettingsRepository へ保存
+  - 並び替えは `Novels` を再構築せず、`NovelRepository.GetAllAsync(SortKey)` で SQL 側に任せる
+- **NovelRepository**:
+  - `GetAllAsync(string sortKey)` を追加。`switch` で `OrderBy` 句を切替
+  - 未読話数ソートは `episodes` との集計が必要 → サブクエリ（`SELECT n.*, (SELECT COUNT(*) FROM episodes WHERE novel_id=n.id AND is_read=0) AS unread FROM novels n ORDER BY unread DESC`）
+- **NovelListPage.xaml**:
+  - ツールバー右に `ToolbarItem`（並び替えアイコン）を追加
+  - タップで Picker / ActionSheet（`DisplayActionSheet`）でソート選択
+
+### 2.3 リスク
+- **disadvantage**: 未読数ソートはサブクエリで N+1 にはならないが、登録小説 1000件超で多少遅くなる（許容範囲）
+
+### 2.4 影響範囲ファイル
+- 修正: `Services/Database/NovelRepository.cs`, `ViewModels/NovelListViewModel.cs`, `Views/NovelListPage.xaml`, `Helpers/SettingsKeys.cs`
+
+---
+
+## 3. お気に入り（作品＋話）
+
+### 3.1 データモデル
+
+#### 作品お気に入り — `novels` に列追加
+```sql
+ALTER TABLE novels ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE novels ADD COLUMN favorited_at TEXT NULL;
+```
+
+#### 話お気に入り — `episodes` に列追加
+```sql
+ALTER TABLE episodes ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE episodes ADD COLUMN favorited_at TEXT NULL;
+```
+
+- **マイグレーション**: 現状機構なし。`DatabaseService.InitializeAsync` で `PRAGMA table_info(novels)` / `PRAGMA table_info(episodes)` を実行し、対象列がなければ ALTER を発行する簡易マイグレーションを追加
+- `Models/Novel.cs` に `IsFavorite`(int), `FavoritedAt`(string?)
+- `Models/Episode.cs` に `IsFavorite`(int), `FavoritedAt`(string?)
+
+### 3.2 UI（作品お気に入り）
+
+- **NovelListPage**: カードに星アイコン（`★`/`☆`）。タップでトグル。SwipeView 右スワイプにも「お気に入り切替」追加
+- **EpisodeListPage**: ToolbarItem に星ボタン（その作品をお気に入り切替）
+- **ソート連動**: `favorite_first` ソートでお気に入り優先表示
+
+### 3.3 UI（話お気に入り）
+
+- **EpisodeListPage**:
+  - 各話行の右側に星アイコンを追加（タップでトグル）
+  - お気に入りの話のみを絞り込む「★」フィルタトグルを ToolbarItem に追加
+- **ReaderPage**:
+  - フッターまたはヘッダーに星ボタンを追加。現在表示中の話をお気に入りトグル
+  - `[ObservableProperty] bool IsCurrentEpisodeFavorite` を ReaderViewModel に追加
+- **EpisodeRepository**:
+  - `SetFavoriteAsync(int episodeId, bool isFavorite)` を追加
+  - `GetFavoritesByNovelIdAsync(int novelId)` を追加（お気に入り一覧取得）
+
+### 3.4 ユースケース
+
+- 「印象的なシーンを後で読み返したい」用途
+- 章単位ではなく話単位で抜粋管理可能
+- 将来：お気に入り話のエクスポート機能の素地になる
+
+### 3.5 挙動連動
+
+- **更新チェック優先度**: お気に入り作品は UpdateCheckService で先頭から処理
+- **先読み優先度**: BackgroundJobQueue でお気に入り作品ジョブを優先キューへ
+- **話お気に入り削除耐性**: キャッシュ自動削除（期限切れ）でも話お気に入りフラグは維持（フラグは episodes テーブル、本文は episode_cache テーブル）
+
+### 3.6 影響範囲ファイル
+- 修正: `Models/Novel.cs`, `Models/Episode.cs`, `Services/Database/DatabaseService.cs`, `Services/Database/NovelRepository.cs`, `Services/Database/EpisodeRepository.cs`, `ViewModels/NovelListViewModel.cs`, `ViewModels/EpisodeListViewModel.cs`, `ViewModels/ReaderViewModel.cs`, `Views/NovelListPage.xaml`, `Views/EpisodeListPage.xaml`, `Views/ReaderPage.xaml`, `Services/UpdateCheckService.cs`
+
+---
+
+## 4. 一括ダウンロード（および全体の積極先読み）
+
+### 4.1 対象範囲
+
+| トリガ | 動作 |
+|---|---|
+| **手動：エピソード一覧の「全話DL」ボタン** | 当該小説の未キャッシュ話をすべてキューに投入 |
+| **手動：エピソード長押し → 範囲選択DL** | 選択範囲をキューに投入（第二段で実装、本計画は未着手枠） |
+| **自動：登録直後** | 新規登録小説の全話を Wi-Fi接続時のみ自動キューイング |
+| **自動：更新チェックで新話検出時** | 検出した新話を自動キューイング |
+| **自動：起動時スキャン** | 「未読 ＆ 未キャッシュ」を Wi-Fi接続時にバックグラウンド投入 |
+
+### 4.2 設計
+
+- **新規**: `Services/Background/PrefetchService.cs`
+  - `Task EnqueueNovelAsync(int novelId, CancellationToken ct)` — 未キャッシュ話を全件キューへ
+  - `Task EnqueueEpisodesAsync(IEnumerable<int> episodeIds, CancellationToken ct)`
+- **BackgroundJobQueue ワーカー**:
+  - `PrefetchEpisodesJob` を取り出し
+  - サイトごとに `NetworkPolicyService.ExecuteAsync(...)` 経由で本文取得（自動ディレイ）
+  - 取得した本文を `EpisodeCacheRepository.InsertAsync`
+  - **モバイル通信時は Prefetch ジョブを一切実行しない（設定不可・固定）**。Wi-Fi 切断で一時停止、Wi-Fi 再接続で自動レジューム
+  - 設定 `prefetch_enabled` が OFF の場合は Wi-Fi 接続中であっても Prefetch を停止
+- **エピソード一覧 UI**:
+  - ToolbarItem「全話DL」追加
+  - タップで `PrefetchService.EnqueueNovelAsync` を呼び、Snackbar で「N話をバックグラウンドで取得します」と通知
+  - 各話の右端に「キャッシュ済み●」インジケータ（`EpisodeCacheRepository` で取得済みID集合を保持して bind）
+
+### 4.3 リソース・マナー配慮（重要）
+
+- 通信間ディレイ（既定800ms）は `NetworkPolicyService` が保証
+- 同時 1 リクエスト/サイト
+- 1 ジョブあたり最大 200 話で区切り、間に 5 秒のクールダウン
+- HTTP エラーで連続 5 回失敗 → ジョブ中断
+- **disadvantage**: Wi-Fi切断のたびジョブ停止／再開のため、移動中の利用では完了が遅れる
+- **disadvantage**: なろう/カクヨムのサーバー規約上、過度な取得は望ましくない。800ms ディレイは"個人読書範囲"として穏当な値だが、運用次第で 1500ms 程度に上げるべき
+
+### 4.4 影響範囲ファイル
+- 新規: `Services/Network/NetworkPolicyService.cs`, `Services/Background/BackgroundJobQueue.cs`, `Services/Background/PrefetchService.cs`, `Services/Background/BackgroundJob.cs`
+- 修正: `Services/Narou/NarouApiService.cs`, `Services/Kakuyomu/KakuyomuApiService.cs`（HTTP呼び出しを NetworkPolicyService 経由へ）, `MauiProgram.cs`（DI登録）, `App.xaml.cs`（起動時スキャン）, `ViewModels/EpisodeListViewModel.cs`, `Views/EpisodeListPage.xaml`, `Services/Database/EpisodeCacheRepository.cs`（取得済みID一覧API追加）, `Services/UpdateCheckService.cs`（新話検出後にキューイング）
+
+---
+
+## 5. ランキング・ジャンルブラウズ
+
+### 5.1 サイト別の取得方法
+
+#### なろう
+- **API**: `https://api.syosetu.com/rank/rankget/?out=json&rtype={YYYYMMDD-d|w|m|q}` でランキング取得
+- **ジャンル**: `https://api.syosetu.com/novelapi/api/?out=json&genre={id}&order={hyoka|daily|weekly|...}` で取得可能
+- ジャンルID: 公式定義（恋愛/ファンタジー/SF/その他/ノンジャンル × サブジャンル）を `Models/NarouGenres.cs` に静的定義
+
+#### カクヨム
+- **API**: 公式 API なし。ランキングページ HTML をスクレイピング
+  - `https://kakuyomu.jp/rankings/all/{daily|weekly|monthly|yearly|entire}`
+  - ジャンル別: `https://kakuyomu.jp/rankings/{genre}/{period}` （genre は `fantasy`, `sf`, `love_story` など）
+- カテゴリ定義は `Models/KakuyomuGenres.cs` に静的定義
+
+### 5.2 サービス追加
+
+`INovelService` を拡張：
+
+```csharp
+Task<List<SearchResult>> FetchRankingAsync(string genreId, RankingPeriod period, CancellationToken ct);
+IReadOnlyList<GenreInfo> GetGenres();
+```
+
+- `RankingPeriod`: enum (Daily, Weekly, Monthly, Quarterly, Yearly, All)
+- `GenreInfo`: { Id, Name }
+- 既存 `NarouApiService` / `KakuyomuApiService` に実装。HTTP 呼び出しは `NetworkPolicyService.ExecuteAsync` 経由
+
+### 5.3 UI
+
+- **SearchPage 改修** または **新規 BrowsePage**
+  - **採用**: SearchPage にタブを追加（既存「キーワード検索」＋新「ランキング」「ジャンル」）
+  - `TabbedPage` ではなく、上部に `SegmentedControl` 風の Border+Buttons を置きコンテンツ切替
+- **ランキングタブ**:
+  - サイト選択（なろう/カクヨム/両方）
+  - 期間選択 Picker（日/週/月/四半期/年/累計）
+  - ジャンル選択 Picker（「全て」もあり）
+  - 結果は既存の SearchResult カードをそのまま再利用
+- **ジャンルタブ**:
+  - サイト選択 → ジャンル一覧（CollectionView）→ タップで該当ジャンルの新着 or ランキングへ
+
+### 5.4 キャッシュ
+
+- ランキング結果は短期メモリキャッシュ（10分）。`Dictionary<string, (DateTime fetchedAt, List<SearchResult> data)>` を SearchViewModel に保持
+- DB には保存しない（鮮度優先）
+
+### 5.5 リスク
+- **disadvantage**: カクヨムランキングは HTML スクレイピングのためサイト構造変更で壊れやすい（既存話一覧と同じリスク）
+- **disadvantage**: なろうランキングAPIは結果が ncode のみのため、続けて novelapi で詳細取得が必要 → ディレイにより一覧表示が秒単位で遅くなる。**対策**: 1リクエストで複数 ncode 指定可能（`ncode=N1234AA-N5678BB`）の仕様を活用してまとめ取得
+
+### 5.6 影響範囲ファイル
+- 新規: `Models/NarouGenres.cs`, `Models/KakuyomuGenres.cs`, `Models/RankingPeriod.cs`, `Models/GenreInfo.cs`
+- 修正: `Services/INovelService.cs`, `Services/Narou/NarouApiService.cs`, `Services/Kakuyomu/KakuyomuApiService.cs`, `ViewModels/SearchViewModel.cs`, `Views/SearchPage.xaml`
+
+---
+
+## 6. 実装順序（推奨）
+
+| Step | 内容 | 理由 |
+|---|---|---|
+| **S1** | NetworkPolicyService（ディレイ＋直列化）と既存サービスへの組み込み | 他機能の前提。先に入れて既存動作の安定性を確認 |
+| **S2** | BackgroundJobQueue + PrefetchService 基盤 | 一括DLとランキングの両方が依存 |
+| **S3** | お気に入り（DBマイグレーション含む） | 小規模・独立性高く検証しやすい |
+| **S4** | 一覧ソート変更 | お気に入り後にやると `favorite_first` が自然に組み込める |
+| **S5** | 一括ダウンロード（UI＋自動先読み発火） | S1/S2 の上に乗るだけ |
+| **S6** | 縦書き表示（ReaderPage の WebView化） | リーダー画面に大きく手を入れるので独立した PR が望ましい |
+| **S7** | ランキング・ジャンルブラウズ | 最後。他機能に依存しない独立タブ追加 |
+
+---
+
+## 7. 残課題・確認事項
+
+ユーザー確認をお願いしたい点：
+
+1. **WebView化のトレードオフ**: ReaderPage を縦書き対応のため WebView に置換することを許容するか？（横書き時は現行 Label のままにするハイブリッド案を本書では推奨）
+→ハイブリッド案で
+2. **DBマイグレーション方針**: 簡易ALTER方式で進めて良いか？（`PRAGMA table_info` で列の有無を見て ALTER を発行する独自実装）
+→OK
+3. **通信ディレイの既定値**: 800ms で良いか？（カクヨム HTML スクレイピング多用なら 1500ms 推奨）
+→デフォ800msで設定変更できるようにする
+4. **モバイル通信時の挙動**: 「先読みは Wi-Fi 限定」を既定にするが、ユーザーがOFFにできる設定を出して良いか？
+→Wifiでも先読みしないってこと？であればOFFにできる設定を出してよい。モバイル通信時も先読み可能にするかどうかの設定は不要→モバイル通信は先読み絶対不可
+5. **ランキング機能のサイト**: 第一弾はなろうのみに絞るか？（カクヨムは公式APIなしで脆い）
+→どっちも
+6. **PR 分割**: 上記 S1〜S7 を個別 PR にするか、まとめて1本にするか？
+→まとめて1本
+
+追加要望→作品内のお気に入り話を設定できるようにしてほしい
+---
+
+## 8. 着手前チェックリスト
+
+- [x] 上記 7 の確認事項にユーザー回答を得る（2026-04-07 完了）
+- [ ] `app-novelviewer` から派生ブランチを作成（CLAUDE.md ルール準拠）
+- [ ] S1〜S7 を 1本の PR にまとめる方針で実装。Step 単位ではコミット粒度を分ける
+- [ ] requirements_lanovereader.md の該当セクションは本実装後に追記更新
+
+## 9. 確定事項サマリ（2026-04-07 ユーザー回答）
+
+| 項目 | 確定内容 |
+|---|---|
+| 縦書き実装 | ハイブリッド（横書き=Label / 縦書き=WebView） |
+| DBマイグレーション | PRAGMA + ALTER 簡易方式 |
+| 通信ディレイ | 既定 800ms。設定画面で 500–2000ms 可変 |
+| モバイル通信時の先読み | **絶対不可（設定項目なし、固定）**。`prefetch_enabled` は Wi-Fi時のON/OFFのみ |
+| ランキング対応サイト | なろう＋カクヨム両方 |
+| PR 構成 | S1〜S7 まとめて 1 本 |
+| 追加要望 | **作品内のお気に入り話**機能を追加（§3 に統合済） |
+
+---
+
+## 10. 事前調査結果（実装時の追加調査不要レベル）
+
+調査日: 2026-04-07。本節の情報は実装時にそのまま参照可能。
+
+### 10.1 既存 HTTP 通信ポイント（S1 NetworkPolicyService 組込先）
+
+| サービス | メソッド | 行 | 呼出 | TO | 連続 |
+|---|---|---|---|---|---|
+| NarouApiService | SearchAsync | 40 | GetStringAsync | 5s | 単発 |
+| NarouApiService | FetchEpisodeListAsync | 82 | GetStringAsync (while ループ) | 10s | **複数(?p=1,2,...)** |
+| NarouApiService | FetchEpisodeContentAsync | 141 | GetStringAsync | 5s | 単発 |
+| NarouApiService | FetchNovelInfoAsync | 164 | GetStringAsync | 30s | 単発 |
+| KakuyomuApiService | SearchAsync | 32 | GetStringAsync | 5s | 単発 |
+| KakuyomuApiService | FetchEpisodeListAsync | 75 | GetStringAsync | 10s | 単発 |
+| KakuyomuApiService | FetchEpisodeContentAsync | 197/208 | GetStringAsync | 10s | **2回(TOC→本文)** |
+| KakuyomuApiService | FetchNovelInfoAsync | 236 | GetStringAsync | 30s | 単発 |
+
+**ディレイ挿入対象（重要）**:
+- NarouApiService.cs:82 の while ループ内、ページ取得後に `await NetworkPolicyService.DelayAsync(SiteType.Narou, ct)` を挿入
+- KakuyomuApiService.cs:208 の 2 回目 GetStringAsync 直前に同様
+
+**実装方針**: 各 `_httpClient.GetStringAsync(url, cts.Token)` 呼出を `_networkPolicy.GetStringAsync(SiteType.X, url, cts.Token)` に置換するラッパ方式が最小侵襲。`NetworkPolicyService` 内部で SemaphoreSlim ＋ Delay を実施。
+
+### 10.2 DB マイグレーション（S3 お気に入り）
+
+#### sqlite-net-pcl の挙動確認済み事項
+- `CreateTableAsync<T>()` は `CreateFlags.None` 既定。**既存テーブルへの列追加は行わない**
+- ALTER TABLE は `_db.ExecuteAsync("ALTER TABLE ... ADD COLUMN ...")` で直接発行可
+- PRAGMA は `_db.QueryAsync<ColumnInfo>("PRAGMA table_info(novels)")` で取得可
+
+#### 実装する Helper（DatabaseService 内に private 追加）
+```csharp
+private class ColumnInfo { public int cid; public string name; public string type; public int notnull; public string? dflt_value; public int pk; }
+
+private async Task EnsureColumnAsync(string table, string column, string ddlSuffix)
+{
+    var cols = await _db.QueryAsync<ColumnInfo>($"PRAGMA table_info({table})");
+    if (!cols.Any(c => string.Equals(c.name, column, StringComparison.OrdinalIgnoreCase)))
+        await _db.ExecuteAsync($"ALTER TABLE {table} ADD COLUMN {column} {ddlSuffix}");
+}
+```
+
+#### InitializeAsync に追加する呼出（CreateTableAsync の後、SeedSettingsAsync の前）
+```csharp
+await EnsureColumnAsync("novels",   "is_favorite",  "INTEGER NOT NULL DEFAULT 0");
+await EnsureColumnAsync("novels",   "favorited_at", "TEXT NULL");
+await EnsureColumnAsync("episodes", "is_favorite",  "INTEGER NOT NULL DEFAULT 0");
+await EnsureColumnAsync("episodes", "favorited_at", "TEXT NULL");
+```
+
+#### 既存テーブル定義（追加列の参考）
+- `Novel` (Models/Novel.cs): Id/SiteType/NovelId/Title/Author/TotalEpisodes/IsCompleted/LastUpdatedAt/RegisteredAt/HasUnconfirmedUpdate/HasCheckError、`[Table("novels")]`
+- `Episode` (Models/Episode.cs): Id/NovelId([Indexed])/EpisodeNo/ChapterName?/Title/IsRead/ReadAt?/PublishedAt?、`[Table("episodes")]`
+- いずれも `[Column("snake_case")]` で命名
+
+### 10.3 ソート用 SQL（S4 一覧ソート変更）
+
+`NovelRepository.GetAllAsync(string sortKey)` の switch 実装案：
+
+| sortKey | クエリ |
+|---|---|
+| `updated_desc` | `Table<Novel>().OrderByDescending(n => n.LastUpdatedAt)` |
+| `updated_asc` | `OrderBy(n => n.LastUpdatedAt)` |
+| `title_asc` | `OrderBy(n => n.Title)` |
+| `title_desc` | `OrderByDescending(n => n.Title)` |
+| `author_asc` | `OrderBy(n => n.Author)` |
+| `registered_desc` | `OrderByDescending(n => n.RegisteredAt)` |
+| `unread_desc` | 生SQL: `SELECT n.*, (SELECT COUNT(*) FROM episodes e WHERE e.novel_id=n.id AND e.is_read=0) AS unread FROM novels n ORDER BY unread DESC, n.last_updated_at DESC` |
+| `favorite_first` | 生SQL: `SELECT * FROM novels ORDER BY is_favorite DESC, last_updated_at DESC` |
+
+unread_desc は `_db.QueryAsync<Novel>(sql)` で実行（unread 列は Novel に `[Ignore]` 付き UnreadCount を設けて受ける、または専用 DTO）。
+
+### 10.4 ReaderPage 既読検知（S6 縦書き対応）
+
+#### 現状（横書き Label）
+- ReaderPage.xaml.cs:15-24 `OnScrolled`: `scrollView.ScrollY + Height >= ContentSize.Height - 10` で MarkAsReadCommand 発火（毎フレーム呼ばれるため ViewModel 側で IsRead 重複防止）
+
+#### 縦書き WebView の追加実装
+- **HTML ロード**: `webView.Source = new HtmlWebViewSource { Html = ReaderHtmlBuilder.Build(...) };`（`Microsoft.Maui.Controls.HtmlWebViewSource`）
+- **JS → C# 通信**: `Navigating` イベント＋カスタムスキーム方式（HybridWebView 不要）
+  ```csharp
+  webView.Navigating += (s, e) => {
+      if (e.Url?.StartsWith("lanobe://read-end") == true) {
+          e.Cancel = true;
+          _viewModel.MarkAsReadCommand.Execute(null);
+      }
+  };
+  ```
+- **JS 側スクロール監視**（HTML テンプレートに埋め込み）:
+  ```js
+  window.addEventListener('scroll', function() {
+      // 縦書きは scrollLeft が負値。左端到達 = scrollLeft が最小値
+      var el = document.scrollingElement;
+      var maxNeg = -(el.scrollWidth - el.clientWidth);
+      if (el.scrollLeft <= maxNeg + 10) {
+          window.location.href = 'lanobe://read-end';
+      }
+  }, { passive: true });
+  ```
+- **Android WebView での `writing-mode: vertical-rl` サポート**: Android System WebView 70+ (Android 9 以降) で問題なし。本アプリの最低 API 34（Android 14）は十分カバー
+- **WebView インスタンス**: 1 ページで `Source` を差し替える方式（毎話 new しない）
+
+#### ReaderPage.xaml への追加
+既存 `ScrollView`（行 31 付近）と同じ Grid 行に WebView を並べ、IsVisible で排他：
+```xml
+<ScrollView IsVisible="{Binding IsHorizontal}" .../>
+<WebView    IsVisible="{Binding IsVerticalWriting}" x:Name="VerticalWebView" Navigating="OnWebViewNavigating"/>
+```
+
+### 10.5 Wi-Fi 検出と WorkManager 制約（S1/S2/S5）
+
+#### MAUI Connectivity（前景・ViewModel 側）
+- 名前空間: `Microsoft.Maui.Networking`
+- Wi-Fi 判定: `Connectivity.Current.ConnectionProfiles.Contains(ConnectionProfile.WiFi)`
+- 変化検知: `Connectivity.ConnectivityChanged += (s,e) => { ... }`（`e.ConnectionProfiles`）
+- パーミッション: `ACCESS_NETWORK_STATE`（既に AndroidManifest.xml に記載済み）
+
+#### Android ConnectivityManager（バックグラウンド・Worker 側で確実に動かす場合）
+```csharp
+var cm = (ConnectivityManager)context.GetSystemService(Context.ConnectivityService);
+var caps = cm.GetNetworkCapabilities(cm.ActiveNetwork);
+bool isWifi = caps?.HasTransport(TransportType.Wifi) ?? false;
+```
+本アプリの BackgroundJobQueue は MAUI 起動済プロセス内で動くので **MAUI Connectivity で十分**。WorkManager Worker 内のみ、保険として直接 API を使うか検討。
+
+#### WorkManager の Wi-Fi 限定化
+- 現状: `UpdateCheckScheduler.cs:11-13` で `NetworkType.Connected`
+- **更新チェックそのものはモバイル通信でも動かしたい**ため、`NetworkType.Connected` のままで OK（変更不要）
+- 一方、Prefetch 系のジョブは BackgroundJobQueue（インプロセス）の責任で「Wi-Fi なら走る／そうでなければ走らない」を判定する。WorkManager の制約変更は不要
+
+### 10.6 なろうランキング・ジャンル（S7）
+
+#### ランキング API
+- URL: `https://api.syosetu.com/rank/rankget/`
+- 必須: `out=json`, `gzip=5`, `rtype=YYYYMMDD-{d|w|m|q}`
+- 制約:
+  - `d` = 日間（任意の日付）
+  - `w` = 週間（**火曜日のみ**）
+  - `m` = 月間（**毎月1日のみ**）
+  - `q` = 四半期（**毎月1日のみ**）
+- レスポンス: `[{ ncode, pt, rank }, ...]` 最大300件（**作品メタ情報なし**）
+- gzip 必須（HTTP圧縮ではなくレスポンスボディ自体）→ `GZipStream` で解凍
+
+```csharp
+// 実装スケッチ
+using var stream = await _http.GetStreamAsync(url, ct);
+using var gz = new GZipStream(stream, CompressionMode.Decompress);
+using var sr = new StreamReader(gz);
+var json = await sr.ReadToEndAsync();
+```
+
+#### 直近確定日の決定
+- 日間: 当日 08:00 以降 → 前日。それ以前 → 2 日前
+- 週間: `DateTime.Today` から直近の火曜日へ後退
+- 月間/四半期: 当月 1 日
+
+#### ジャンルメタの取得（rankget の結果を novelapi で詳細取得）
+- URL: `https://api.syosetu.com/novelapi/api/`
+- 複数 ncode: `ncode=N1234AB-N5678CD-N9999EF`（ハイフン区切り）
+- `lim` 最大500、`of=t-n-w-s-bg-g-k` でタイトル/ncode/作者/あらすじ/biggenre/genre/キーワード
+- レート制限: 80,000 req/24h/IP、400MB/24h/IP。`gzip=5` 必須
+
+#### ジャンル ID（実装時にそのまま定数化可能）
+| 大ジャンル biggenre | 値 |
+|---|---|
+| 恋愛 | 1 |
+| ファンタジー | 2 |
+| 文芸 | 3 |
+| SF | 4 |
+| その他 | 99 |
+| ノンジャンル | 98 |
+
+| サブジャンル genre | 値 |
+|---|---|
+| 異世界恋愛 | 101 |
+| 現実世界恋愛 | 102 |
+| ハイファンタジー | 201 |
+| ローファンタジー | 202 |
+| 純文学 | 301 |
+| ヒューマンドラマ | 302 |
+| 歴史 | 303 |
+| 推理 | 304 |
+| ホラー | 305 |
+| アクション | 306 |
+| コメディー | 307 |
+| VRゲーム | 401 |
+| 宇宙 | 402 |
+| 空想科学 | 403 |
+| パニック | 404 |
+| 童話 | 9901 |
+| 詩 | 9902 |
+| エッセイ | 9903 |
+| リプレイ | 9904 |
+| その他 | 9999 |
+| ノンジャンル | 9801 |
+
+#### `order` 値（ジャンルブラウズで使用想定）
+`new` / `favnovelcnt` / `hyoka` / `dailypoint` / `weeklypoint` / `monthlypoint` / `quarterpoint` / `yearlypoint` / `lengthdesc`
+
+### 10.7 カクヨムランキング（S7）
+
+#### URL パターン
+`https://kakuyomu.jp/rankings/{genre}/{period}`
+
+| period | 値 |
+|---|---|
+| 日間 | `daily` |
+| 週間 | `weekly` |
+| 月間 | `monthly` |
+| 年間 | `yearly` |
+| 累計 | `entire` |
+
+| genre slug | 表示名 |
+|---|---|
+| `all` | 総合 |
+| `fantasy` | 異世界ファンタジー |
+| `action` | 現代ファンタジー |
+| `sf` | SF |
+| `love_story` | 恋愛 |
+| `romance` | ラブコメ |
+| `drama` | 現代ドラマ |
+| `horror` | ホラー |
+| `mystery` | ミステリー |
+| `nonfiction` | エッセイ・ノンフィクション |
+| `history` | 歴史・時代・伝奇 |
+| `criticism` | 創作論・評論 |
+| `others` | 詩・童話・その他 |
+
+オプションクエリ: `?work_variation=long`（長編絞込）、`&page=N`（ページネーション、1始まり）
+
+#### HTML 解析方針
+- `__NEXT_DATA__` は **無し**（既存の作品ページとは違い SSR HTML）
+- AngleSharp で `a[href^="/works/"]` を全取得 → href から workId を正規表現抽出
+- タイトル: アンカーのテキスト
+- 作者: 同カード内の `a[href^="/users/"]` のテキスト
+- カクヨム既存 SearchAsync の DOM 解析パターンを踏襲
+
+#### リダイレクト
+HTTP→HTTPS、または work_variation 付与で 302 が発生する場合あり。HttpClient はデフォルトで自動追従するため特別対応不要。
+
+### 10.8 SearchPage タブ追加位置（S7）
+
+現在の構造（SearchPage.xaml）：
+- `Grid RowDefinitions="Auto,Auto,*"`：(0)検索バー (1)サイトCheckBox (2)結果
+
+**改修案**: 最上部に `RowDefinitions="Auto,Auto,Auto,*"` でセグメント切替バーを追加し、表示モード（キーワード/ランキング/ジャンル）を切替。各モードのコンテンツは `Grid` を 3 つ重ねて IsVisible で排他。
+
+### 10.9 SettingsPage 追加項目位置（S6/S1）
+
+`SettingsPage.xaml` の構造は ScrollView > VerticalStackLayout に各設定セクションが BoxView で区切られている。
+- **「読書設定」セクション内**に：縦書き表示 Switch を追加
+- **「更新設定」セクションの後**に新セクション「通信設定」を追加：
+  - リクエスト間ディレイ Slider（500–2000ms）
+  - Wi-Fi 接続時の先読み Switch (`prefetch_enabled`)
+- **「読書設定」内**に：小説一覧の並び順 Picker（`novel_sort_key`）
+
+`SettingsViewModel.cs` の partial void OnXxxChanged パターンに合わせ、新設定も fire-and-forget で `_settingsRepo.SetValueAsync` を呼ぶ。
+
+### 10.10 BackgroundJobQueue 起動位置（S2）
+
+- DI: `MauiProgram.cs:42` の後に `AddSingleton<BackgroundJobQueue>()` / `AddSingleton<NetworkPolicyService>()` / `AddSingleton<PrefetchService>()`
+- 起動: `App.xaml.cs:49 InitializeAppAsync` の DB 初期化後、`_ = backgroundJobQueue.StartAsync()` を Task.Run で開始
+- 起動時の未読＆未キャッシュスキャン: 同 InitializeAppAsync 末尾で `Task.Run(() => prefetchService.EnqueueAllUnreadAsync())`
+- 停止: アプリ終了時の特別処理は不要（プロセス終了で自動）。CancellationTokenSource を Singleton で保持し `App.OnSleep` で Cancel
+
+### 10.11 既存 ViewModel パターン（参考）
+
+- `[ObservableProperty] private bool _isLoading;` ＋ `[NotifyCanExecuteChangedFor(nameof(XxxCommand))]`
+- `[RelayCommand(CanExecute = nameof(CanXxx))] private async Task XxxAsync()`
+- `partial void OnXxxChanged(T value) => _ = _repo.SetValueAsync(...)` （fire-and-forget）
+- ナビゲーション引数は `IQueryAttributable.ApplyQueryAttributes` で受け取り、`_ = InitializeAsync()` で発火
+- 全 VM/Page は Transient、Service/Repo は Singleton
+
+### 10.12 影響を受けないことを確認した既存機能
+
+- 既存の更新チェック（UpdateCheckService）はモバイル通信時も動作継続（Prefetch とは別経路）
+- ReaderPage 横書きモードの既読判定ロジックは無変更（縦書き時のみ JS Bridge を使用）
+- WorkManager の `NetworkType.Connected` 制約は変更不要
+
+---
+
+**現状**: 本書作成のみ。コードは未変更。指示を受けてから着手します。

--- a/_Apps/Helpers/ReaderHtmlBuilder.cs
+++ b/_Apps/Helpers/ReaderHtmlBuilder.cs
@@ -1,0 +1,51 @@
+using System.Text;
+
+namespace LanobeReader.Helpers;
+
+/// <summary>
+/// 縦書き WebView 用の HTML 文字列を生成するビルダー。
+/// </summary>
+public static class ReaderHtmlBuilder
+{
+    public static string Build(string content, double fontSizePx, double lineHeight, int backgroundTheme)
+    {
+        var (bg, fg) = backgroundTheme switch
+        {
+            1 => ("#121212", "#E0E0E0"),
+            2 => ("#F5E6C8", "#3E2C1C"),
+            _ => ("#FFFFFF", "#212121"),
+        };
+
+        var sb = new StringBuilder();
+        sb.Append("<!doctype html><html lang=\"ja\"><head><meta charset=\"utf-8\">");
+        sb.Append("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+        sb.Append("<style>");
+        sb.Append("html,body{margin:0;padding:0;height:100%;}");
+        sb.Append($"body{{background:{bg};color:{fg};font-family:serif;");
+        sb.Append($"writing-mode:vertical-rl;-webkit-writing-mode:vertical-rl;");
+        sb.Append($"font-size:{fontSizePx.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)}px;");
+        sb.Append($"line-height:{lineHeight.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)};");
+        sb.Append("padding:16px;box-sizing:border-box;overflow-x:auto;overflow-y:hidden;");
+        sb.Append("-webkit-tap-highlight-color:transparent;}");
+        sb.Append("p{margin:0 0 1em 0;text-indent:1em;}");
+        sb.Append("</style></head><body>");
+
+        foreach (var line in content.Split('\n'))
+        {
+            sb.Append("<p>");
+            sb.Append(System.Net.WebUtility.HtmlEncode(line));
+            sb.Append("</p>");
+        }
+
+        sb.Append("<script>");
+        sb.Append("(function(){var fired=false;function check(){if(fired)return;");
+        sb.Append("var el=document.scrollingElement||document.documentElement;");
+        sb.Append("var maxNeg=-(el.scrollWidth-el.clientWidth);");
+        sb.Append("if(el.scrollLeft<=maxNeg+10){fired=true;location.href='lanobe://read-end';}}");
+        sb.Append("window.addEventListener('scroll',check,{passive:true});setTimeout(check,100);})();");
+        sb.Append("</script>");
+        sb.Append("</body></html>");
+
+        return sb.ToString();
+    }
+}

--- a/_Apps/Helpers/SettingsKeys.cs
+++ b/_Apps/Helpers/SettingsKeys.cs
@@ -8,4 +8,8 @@ public static class SettingsKeys
     public const string BACKGROUND_THEME = "background_theme";
     public const string LINE_SPACING = "line_spacing";
     public const string EPISODES_PER_PAGE = "episodes_per_page";
+    public const string PREFETCH_ENABLED = "prefetch_enabled";
+    public const string REQUEST_DELAY_MS = "request_delay_ms";
+    public const string VERTICAL_WRITING = "vertical_writing";
+    public const string NOVEL_SORT_KEY = "novel_sort_key";
 }

--- a/_Apps/MauiProgram.cs
+++ b/_Apps/MauiProgram.cs
@@ -1,7 +1,9 @@
 using LanobeReader.Services;
+using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
 using LanobeReader.Services.Kakuyomu;
 using LanobeReader.Services.Narou;
+using LanobeReader.Services.Network;
 using LanobeReader.ViewModels;
 using LanobeReader.Views;
 using Microsoft.Extensions.Logging;
@@ -34,6 +36,11 @@ public static class MauiProgram
 
         // HttpClient
         builder.Services.AddSingleton<HttpClient>();
+
+        // Network / Background
+        builder.Services.AddSingleton<NetworkPolicyService>();
+        builder.Services.AddSingleton<BackgroundJobQueue>();
+        builder.Services.AddSingleton<PrefetchService>();
 
         // API Services
         builder.Services.AddSingleton<NarouApiService>();

--- a/_Apps/Models/Episode.cs
+++ b/_Apps/Models/Episode.cs
@@ -30,4 +30,10 @@ public class Episode
 
     [Column("published_at")]
     public string? PublishedAt { get; set; }
+
+    [Column("is_favorite")]
+    public int IsFavorite { get; set; }
+
+    [Column("favorited_at")]
+    public string? FavoritedAt { get; set; }
 }

--- a/_Apps/Models/GenreInfo.cs
+++ b/_Apps/Models/GenreInfo.cs
@@ -1,0 +1,3 @@
+namespace LanobeReader.Models;
+
+public record GenreInfo(string Id, string Name);

--- a/_Apps/Models/KakuyomuGenres.cs
+++ b/_Apps/Models/KakuyomuGenres.cs
@@ -1,0 +1,30 @@
+namespace LanobeReader.Models;
+
+public static class KakuyomuGenres
+{
+    public static readonly IReadOnlyList<GenreInfo> Genres = new List<GenreInfo>
+    {
+        new("all", "総合"),
+        new("fantasy", "異世界ファンタジー"),
+        new("action", "現代ファンタジー"),
+        new("sf", "SF"),
+        new("love_story", "恋愛"),
+        new("romance", "ラブコメ"),
+        new("drama", "現代ドラマ"),
+        new("horror", "ホラー"),
+        new("mystery", "ミステリー"),
+        new("nonfiction", "エッセイ・ノンフィクション"),
+        new("history", "歴史・時代・伝奇"),
+        new("criticism", "創作論・評論"),
+        new("others", "詩・童話・その他"),
+    };
+
+    public static readonly IReadOnlyList<GenreInfo> Periods = new List<GenreInfo>
+    {
+        new("daily", "日間"),
+        new("weekly", "週間"),
+        new("monthly", "月間"),
+        new("yearly", "年間"),
+        new("entire", "累計"),
+    };
+}

--- a/_Apps/Models/NarouGenres.cs
+++ b/_Apps/Models/NarouGenres.cs
@@ -1,0 +1,41 @@
+namespace LanobeReader.Models;
+
+public static class NarouGenres
+{
+    public static readonly IReadOnlyList<GenreInfo> BigGenres = new List<GenreInfo>
+    {
+        new("", "すべて"),
+        new("1", "恋愛"),
+        new("2", "ファンタジー"),
+        new("3", "文芸"),
+        new("4", "SF"),
+        new("99", "その他"),
+        new("98", "ノンジャンル"),
+    };
+
+    public static readonly IReadOnlyList<GenreInfo> SubGenres = new List<GenreInfo>
+    {
+        new("", "すべて"),
+        new("101", "異世界恋愛"),
+        new("102", "現実世界恋愛"),
+        new("201", "ハイファンタジー"),
+        new("202", "ローファンタジー"),
+        new("301", "純文学"),
+        new("302", "ヒューマンドラマ"),
+        new("303", "歴史"),
+        new("304", "推理"),
+        new("305", "ホラー"),
+        new("306", "アクション"),
+        new("307", "コメディー"),
+        new("401", "VRゲーム"),
+        new("402", "宇宙"),
+        new("403", "空想科学"),
+        new("404", "パニック"),
+        new("9901", "童話"),
+        new("9902", "詩"),
+        new("9903", "エッセイ"),
+        new("9904", "リプレイ"),
+        new("9999", "その他"),
+        new("9801", "ノンジャンル"),
+    };
+}

--- a/_Apps/Models/Novel.cs
+++ b/_Apps/Models/Novel.cs
@@ -39,6 +39,12 @@ public class Novel
     [Column("has_check_error")]
     public int HasCheckError { get; set; }
 
+    [Column("is_favorite")]
+    public int IsFavorite { get; set; }
+
+    [Column("favorited_at")]
+    public string? FavoritedAt { get; set; }
+
     [Ignore]
     public SiteType SiteTypeEnum
     {

--- a/_Apps/Models/RankingPeriod.cs
+++ b/_Apps/Models/RankingPeriod.cs
@@ -1,0 +1,11 @@
+namespace LanobeReader.Models;
+
+public enum RankingPeriod
+{
+    Daily,
+    Weekly,
+    Monthly,
+    Quarterly,
+    Yearly,
+    All,
+}

--- a/_Apps/Platforms/Android/UpdateCheckWorker.cs
+++ b/_Apps/Platforms/Android/UpdateCheckWorker.cs
@@ -23,15 +23,13 @@ public class UpdateCheckWorker : Worker
             var dbService = IPlatformApplication.Current?.Services.GetService<DatabaseService>();
             var novelRepo = IPlatformApplication.Current?.Services.GetService<NovelRepository>();
             var episodeRepo = IPlatformApplication.Current?.Services.GetService<EpisodeRepository>();
-            var serviceFactory = IPlatformApplication.Current?.Services.GetService<INovelServiceFactory>();
+            var updateCheckService = IPlatformApplication.Current?.Services.GetService<UpdateCheckService>();
 
-            if (dbService is null || novelRepo is null || episodeRepo is null || serviceFactory is null)
+            if (dbService is null || novelRepo is null || episodeRepo is null || updateCheckService is null)
             {
                 LogHelper.Error(nameof(UpdateCheckWorker), "Failed to resolve services");
                 return Result.InvokeFailure();
             }
-
-            var updateCheckService = new UpdateCheckService(novelRepo, episodeRepo, serviceFactory);
 
             var updates = Task.Run(() => updateCheckService.CheckAllAsync()).GetAwaiter().GetResult();
 

--- a/_Apps/Services/Background/BackgroundJob.cs
+++ b/_Apps/Services/Background/BackgroundJob.cs
@@ -1,0 +1,26 @@
+namespace LanobeReader.Services.Background;
+
+/// <summary>
+/// バックグラウンドジョブ基底。ジョブ種別ごとに派生。
+/// </summary>
+public abstract class BackgroundJob
+{
+    public int Priority { get; init; }
+    public DateTime EnqueuedAt { get; } = DateTime.UtcNow;
+
+    public abstract string Description { get; }
+}
+
+/// <summary>
+/// 未キャッシュ話を取得してキャッシュ保存するジョブ。
+/// </summary>
+public class PrefetchEpisodeJob : BackgroundJob
+{
+    public int NovelDbId { get; init; }
+    public int EpisodeDbId { get; init; }
+    public int SiteType { get; init; }
+    public string SiteNovelId { get; init; } = string.Empty;
+    public int EpisodeNo { get; init; }
+
+    public override string Description => $"Prefetch novel={NovelDbId} ep={EpisodeNo}";
+}

--- a/_Apps/Services/Background/BackgroundJobQueue.cs
+++ b/_Apps/Services/Background/BackgroundJobQueue.cs
@@ -1,0 +1,176 @@
+using System.Collections.Concurrent;
+using LanobeReader.Helpers;
+using LanobeReader.Models;
+using LanobeReader.Services.Database;
+using LanobeReader.Services.Network;
+
+namespace LanobeReader.Services.Background;
+
+/// <summary>
+/// インプロセスのバックグラウンドジョブキュー。
+/// - Wi-Fi接続時のみ稼働、モバイル通信時や切断時は自動停止（レジューム対応）
+/// - 設定 prefetch_enabled が OFF の場合も停止
+/// - ジョブは優先度付きで直列処理（NetworkPolicyService 経由で適切にディレイ）
+/// - 連続5失敗で同セッションの処理を中断
+/// </summary>
+public class BackgroundJobQueue
+{
+    private readonly ConcurrentQueue<PrefetchEpisodeJob> _highPriority = new();
+    private readonly ConcurrentQueue<PrefetchEpisodeJob> _normalPriority = new();
+    private readonly NetworkPolicyService _network;
+    private readonly AppSettingsRepository _settingsRepo;
+    private readonly EpisodeCacheRepository _cacheRepo;
+    private readonly EpisodeRepository _episodeRepo;
+    private readonly INovelServiceFactory _serviceFactory;
+
+    private readonly object _startLock = new();
+    private CancellationTokenSource? _workerCts;
+    private Task? _workerTask;
+    private int _consecutiveFailures;
+    private readonly HashSet<int> _enqueuedEpisodeIds = new();
+
+    public BackgroundJobQueue(
+        NetworkPolicyService network,
+        AppSettingsRepository settingsRepo,
+        EpisodeCacheRepository cacheRepo,
+        EpisodeRepository episodeRepo,
+        INovelServiceFactory serviceFactory)
+    {
+        _network = network;
+        _settingsRepo = settingsRepo;
+        _cacheRepo = cacheRepo;
+        _episodeRepo = episodeRepo;
+        _serviceFactory = serviceFactory;
+
+        _network.WifiConnected += (_, _) => EnsureWorkerStarted();
+        _network.WifiDisconnected += (_, _) => StopWorker();
+    }
+
+    public int PendingCount => _highPriority.Count + _normalPriority.Count;
+
+    public void Enqueue(PrefetchEpisodeJob job)
+    {
+        lock (_enqueuedEpisodeIds)
+        {
+            if (!_enqueuedEpisodeIds.Add(job.EpisodeDbId)) return;
+        }
+
+        if (job.Priority > 0) _highPriority.Enqueue(job);
+        else _normalPriority.Enqueue(job);
+
+        EnsureWorkerStarted();
+    }
+
+    public void EnsureWorkerStarted()
+    {
+        lock (_startLock)
+        {
+            if (_workerTask is not null && !_workerTask.IsCompleted) return;
+            if (!_network.IsWifiConnected) return;
+            if (PendingCount == 0) return;
+
+            _workerCts = new CancellationTokenSource();
+            var ct = _workerCts.Token;
+            _workerTask = Task.Run(() => WorkerLoopAsync(ct));
+        }
+    }
+
+    public void StopWorker()
+    {
+        lock (_startLock)
+        {
+            try { _workerCts?.Cancel(); } catch { }
+        }
+    }
+
+    private async Task WorkerLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            // Gate check
+            var enabled = await _settingsRepo.GetIntValueAsync(SettingsKeys.PREFETCH_ENABLED, 1).ConfigureAwait(false);
+            if (enabled == 0)
+            {
+                LogHelper.Info(nameof(BackgroundJobQueue), "Prefetch disabled by setting");
+                return;
+            }
+
+            _consecutiveFailures = 0;
+            int batchCount = 0;
+
+            while (!ct.IsCancellationRequested)
+            {
+                if (!_network.IsWifiConnected)
+                {
+                    LogHelper.Info(nameof(BackgroundJobQueue), "Wi-Fi disconnected, stopping");
+                    break;
+                }
+
+                if (!TryDequeue(out var job))
+                {
+                    break;
+                }
+
+                try
+                {
+                    await ProcessJobAsync(job!, ct).ConfigureAwait(false);
+                    _consecutiveFailures = 0;
+                    batchCount++;
+
+                    // 200件ごとに 5秒クールダウン
+                    if (batchCount % 200 == 0)
+                    {
+                        await Task.Delay(5000, ct).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    _consecutiveFailures++;
+                    LogHelper.Warn(nameof(BackgroundJobQueue), $"Job failed ({_consecutiveFailures}): {ex.Message}");
+                    if (_consecutiveFailures >= 5)
+                    {
+                        LogHelper.Warn(nameof(BackgroundJobQueue), "Too many consecutive failures, aborting");
+                        break;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Error(nameof(BackgroundJobQueue), $"Worker loop crashed: {ex.Message}");
+        }
+    }
+
+    private bool TryDequeue(out PrefetchEpisodeJob? job)
+    {
+        if (_highPriority.TryDequeue(out job)) return true;
+        if (_normalPriority.TryDequeue(out job)) return true;
+        job = null;
+        return false;
+    }
+
+    private async Task ProcessJobAsync(PrefetchEpisodeJob job, CancellationToken ct)
+    {
+        try
+        {
+            // 既にキャッシュ済みならスキップ
+            var cached = await _cacheRepo.GetByEpisodeIdAsync(job.EpisodeDbId).ConfigureAwait(false);
+            if (cached is not null) return;
+
+            var service = _serviceFactory.GetService((SiteType)job.SiteType);
+            var content = await service.FetchEpisodeContentAsync(job.SiteNovelId, job.EpisodeNo, ct).ConfigureAwait(false);
+
+            await _cacheRepo.InsertAsync(new EpisodeCache
+            {
+                EpisodeId = job.EpisodeDbId,
+                Content = content,
+                CachedAt = DateTime.UtcNow.ToString("o"),
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_enqueuedEpisodeIds) { _enqueuedEpisodeIds.Remove(job.EpisodeDbId); }
+        }
+    }
+}

--- a/_Apps/Services/Background/PrefetchService.cs
+++ b/_Apps/Services/Background/PrefetchService.cs
@@ -1,0 +1,87 @@
+using LanobeReader.Helpers;
+using LanobeReader.Services.Database;
+
+namespace LanobeReader.Services.Background;
+
+/// <summary>
+/// 先読み（プリフェッチ）のエントリポイント。
+/// 未キャッシュ話を BackgroundJobQueue に積むだけ。実通信は Queue 側で直列処理。
+/// </summary>
+public class PrefetchService
+{
+    private readonly BackgroundJobQueue _queue;
+    private readonly NovelRepository _novelRepo;
+    private readonly EpisodeRepository _episodeRepo;
+    private readonly EpisodeCacheRepository _cacheRepo;
+
+    public PrefetchService(
+        BackgroundJobQueue queue,
+        NovelRepository novelRepo,
+        EpisodeRepository episodeRepo,
+        EpisodeCacheRepository cacheRepo)
+    {
+        _queue = queue;
+        _novelRepo = novelRepo;
+        _episodeRepo = episodeRepo;
+        _cacheRepo = cacheRepo;
+    }
+
+    /// <summary>
+    /// 指定小説の全未キャッシュ話をキューイング。
+    /// </summary>
+    public async Task<int> EnqueueNovelAsync(int novelDbId, bool highPriority = false)
+    {
+        var novel = await _novelRepo.GetByIdAsync(novelDbId).ConfigureAwait(false);
+        if (novel is null) return 0;
+
+        var episodes = await _episodeRepo.GetByNovelIdAsync(novelDbId).ConfigureAwait(false);
+        var cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(novelDbId).ConfigureAwait(false);
+
+        int enqueued = 0;
+        foreach (var ep in episodes)
+        {
+            if (cachedIds.Contains(ep.Id)) continue;
+            _queue.Enqueue(new PrefetchEpisodeJob
+            {
+                NovelDbId = novel.Id,
+                EpisodeDbId = ep.Id,
+                EpisodeNo = ep.EpisodeNo,
+                SiteType = novel.SiteType,
+                SiteNovelId = novel.NovelId,
+                Priority = (highPriority || novel.IsFavorite == 1) ? 1 : 0,
+            });
+            enqueued++;
+        }
+        LogHelper.Info(nameof(PrefetchService), $"Enqueued {enqueued} episodes for novel {novelDbId}");
+        return enqueued;
+    }
+
+    /// <summary>
+    /// 全登録小説の未読＆未キャッシュ話をキューイング。起動時に呼ぶ想定。
+    /// </summary>
+    public async Task EnqueueAllUnreadAsync()
+    {
+        var novels = await _novelRepo.GetAllAsync().ConfigureAwait(false);
+        // お気に入りを先頭へ
+        var ordered = novels.OrderByDescending(n => n.IsFavorite).ToList();
+        foreach (var novel in ordered)
+        {
+            var episodes = await _episodeRepo.GetByNovelIdAsync(novel.Id).ConfigureAwait(false);
+            var cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(novel.Id).ConfigureAwait(false);
+
+            foreach (var ep in episodes.Where(e => e.IsRead == 0))
+            {
+                if (cachedIds.Contains(ep.Id)) continue;
+                _queue.Enqueue(new PrefetchEpisodeJob
+                {
+                    NovelDbId = novel.Id,
+                    EpisodeDbId = ep.Id,
+                    EpisodeNo = ep.EpisodeNo,
+                    SiteType = novel.SiteType,
+                    SiteNovelId = novel.NovelId,
+                    Priority = novel.IsFavorite == 1 ? 1 : 0,
+                });
+            }
+        }
+    }
+}

--- a/_Apps/Services/Database/AppSettingsRepository.cs
+++ b/_Apps/Services/Database/AppSettingsRepository.cs
@@ -6,14 +6,17 @@ namespace LanobeReader.Services.Database;
 public class AppSettingsRepository
 {
     private readonly SQLiteAsyncConnection _db;
+    private readonly DatabaseService _dbService;
 
     public AppSettingsRepository(DatabaseService dbService)
     {
+        _dbService = dbService;
         _db = dbService.Connection;
     }
 
     public async Task<string> GetValueAsync(string key, string defaultValue = "")
     {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
         var setting = await _db.FindAsync<AppSetting>(key).ConfigureAwait(false);
         return setting?.Value ?? defaultValue;
     }
@@ -26,6 +29,7 @@ public class AppSettingsRepository
 
     public async Task SetValueAsync(string key, string value)
     {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
         var setting = await _db.FindAsync<AppSetting>(key).ConfigureAwait(false);
         if (setting is not null)
         {

--- a/_Apps/Services/Database/DatabaseService.cs
+++ b/_Apps/Services/Database/DatabaseService.cs
@@ -1,3 +1,4 @@
+using LanobeReader.Helpers;
 using LanobeReader.Models;
 using SQLite;
 
@@ -6,6 +7,8 @@ namespace LanobeReader.Services.Database;
 public class DatabaseService
 {
     private readonly SQLiteAsyncConnection _connection;
+    private Task? _initTask;
+    private readonly object _initLock = new();
 
     public DatabaseService()
     {
@@ -15,12 +18,31 @@ public class DatabaseService
 
     public SQLiteAsyncConnection Connection => _connection;
 
-    public async Task InitializeAsync()
+    /// <summary>
+    /// 初回のみ実際の初期化を行う。複数箇所から呼ばれても1回しか走らない。
+    /// </summary>
+    public Task EnsureInitializedAsync()
+    {
+        lock (_initLock)
+        {
+            return _initTask ??= InitializeInternalAsync();
+        }
+    }
+
+    public Task InitializeAsync() => EnsureInitializedAsync();
+
+    private async Task InitializeInternalAsync()
     {
         await _connection.CreateTableAsync<Novel>().ConfigureAwait(false);
         await _connection.CreateTableAsync<Episode>().ConfigureAwait(false);
         await _connection.CreateTableAsync<EpisodeCache>().ConfigureAwait(false);
         await _connection.CreateTableAsync<AppSetting>().ConfigureAwait(false);
+
+        // Simple migration: ensure new columns exist on pre-existing tables
+        await EnsureColumnAsync("novels", "is_favorite", "INTEGER NOT NULL DEFAULT 0").ConfigureAwait(false);
+        await EnsureColumnAsync("novels", "favorited_at", "TEXT NULL").ConfigureAwait(false);
+        await EnsureColumnAsync("episodes", "is_favorite", "INTEGER NOT NULL DEFAULT 0").ConfigureAwait(false);
+        await EnsureColumnAsync("episodes", "favorited_at", "TEXT NULL").ConfigureAwait(false);
 
         // composite index for episodes (novel_id, episode_no)
         await _connection.ExecuteAsync(
@@ -35,6 +57,31 @@ public class DatabaseService
         await SeedSettingsAsync().ConfigureAwait(false);
     }
 
+    private async Task EnsureColumnAsync(string table, string column, string ddlSuffix)
+    {
+        try
+        {
+            var cols = await _connection.QueryAsync<PragmaColumnInfo>($"PRAGMA table_info({table})").ConfigureAwait(false);
+            if (cols.Any(c => string.Equals(c.name, column, StringComparison.OrdinalIgnoreCase))) return;
+            await _connection.ExecuteAsync($"ALTER TABLE {table} ADD COLUMN {column} {ddlSuffix}").ConfigureAwait(false);
+            LogHelper.Info(nameof(DatabaseService), $"Added column {table}.{column}");
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn(nameof(DatabaseService), $"EnsureColumnAsync {table}.{column} failed: {ex.Message}");
+        }
+    }
+
+    private class PragmaColumnInfo
+    {
+        public int cid { get; set; }
+        public string name { get; set; } = string.Empty;
+        public string type { get; set; } = string.Empty;
+        public int notnull { get; set; }
+        public string? dflt_value { get; set; }
+        public int pk { get; set; }
+    }
+
     private async Task SeedSettingsAsync()
     {
         var defaults = new Dictionary<string, string>
@@ -45,6 +92,10 @@ public class DatabaseService
             ["background_theme"] = "0",
             ["line_spacing"] = "1",
             ["episodes_per_page"] = "50",
+            ["prefetch_enabled"] = "1",
+            ["request_delay_ms"] = "800",
+            ["vertical_writing"] = "0",
+            ["novel_sort_key"] = "updated_desc",
         };
 
         foreach (var (key, value) in defaults)

--- a/_Apps/Services/Database/EpisodeCacheRepository.cs
+++ b/_Apps/Services/Database/EpisodeCacheRepository.cs
@@ -6,38 +6,62 @@ namespace LanobeReader.Services.Database;
 public class EpisodeCacheRepository
 {
     private readonly SQLiteAsyncConnection _db;
+    private readonly DatabaseService _dbService;
 
     public EpisodeCacheRepository(DatabaseService dbService)
     {
+        _dbService = dbService;
         _db = dbService.Connection;
     }
 
-    public Task<EpisodeCache?> GetByEpisodeIdAsync(int episodeId)
+    private Task EnsureAsync() => _dbService.EnsureInitializedAsync();
+
+    public async Task<EpisodeCache?> GetByEpisodeIdAsync(int episodeId)
     {
-        return _db.Table<EpisodeCache>()
-            .FirstOrDefaultAsync(c => c.EpisodeId == episodeId)!;
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<EpisodeCache>()
+            .FirstOrDefaultAsync(c => c.EpisodeId == episodeId).ConfigureAwait(false);
     }
 
-    public Task<int> InsertAsync(EpisodeCache cache)
+    public async Task<int> InsertAsync(EpisodeCache cache)
     {
-        return _db.InsertAsync(cache);
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.InsertAsync(cache).ConfigureAwait(false);
     }
 
     public async Task DeleteByNovelIdAsync(int novelId)
     {
+        await EnsureAsync().ConfigureAwait(false);
         await _db.ExecuteAsync(
             "DELETE FROM episode_cache WHERE episode_id IN (SELECT id FROM episodes WHERE novel_id = ?)",
             novelId
         ).ConfigureAwait(false);
     }
 
-    public Task DeleteAllAsync()
+    public async Task DeleteAllAsync()
     {
-        return _db.DeleteAllAsync<EpisodeCache>();
+        await EnsureAsync().ConfigureAwait(false);
+        await _db.DeleteAllAsync<EpisodeCache>().ConfigureAwait(false);
+    }
+
+    public async Task<HashSet<int>> GetCachedEpisodeIdsAsync(int novelId)
+    {
+        await EnsureAsync().ConfigureAwait(false);
+        var rows = await _db.QueryAsync<CachedIdRow>(
+            "SELECT c.episode_id AS EpisodeId FROM episode_cache c " +
+            "INNER JOIN episodes e ON e.id = c.episode_id WHERE e.novel_id = ?",
+            novelId).ConfigureAwait(false);
+        return rows.Select(r => r.EpisodeId).ToHashSet();
+    }
+
+    private class CachedIdRow
+    {
+        public int EpisodeId { get; set; }
     }
 
     public async Task DeleteExpiredAsync(int cacheMonths)
     {
+        await EnsureAsync().ConfigureAwait(false);
         var cutoff = DateTime.UtcNow.AddMonths(-cacheMonths).ToString("o");
         await _db.ExecuteAsync(
             "DELETE FROM episode_cache WHERE cached_at < ?", cutoff

--- a/_Apps/Services/Database/EpisodeRepository.cs
+++ b/_Apps/Services/Database/EpisodeRepository.cs
@@ -6,94 +6,129 @@ namespace LanobeReader.Services.Database;
 public class EpisodeRepository
 {
     private readonly SQLiteAsyncConnection _db;
+    private readonly DatabaseService _dbService;
 
     public EpisodeRepository(DatabaseService dbService)
     {
+        _dbService = dbService;
         _db = dbService.Connection;
     }
 
-    public Task<List<Episode>> GetByNovelIdAsync(int novelId)
+    private Task EnsureAsync() => _dbService.EnsureInitializedAsync();
+
+    public async Task<List<Episode>> GetByNovelIdAsync(int novelId)
     {
-        return _db.Table<Episode>()
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>()
             .Where(e => e.NovelId == novelId)
             .OrderBy(e => e.EpisodeNo)
-            .ToListAsync();
+            .ToListAsync().ConfigureAwait(false);
     }
 
-    public Task<List<Episode>> GetPagedByNovelIdAsync(int novelId, int page, int pageSize)
+    public async Task<List<Episode>> GetPagedByNovelIdAsync(int novelId, int page, int pageSize)
     {
+        await EnsureAsync().ConfigureAwait(false);
         int offset = (page - 1) * pageSize;
-        return _db.QueryAsync<Episode>(
+        return await _db.QueryAsync<Episode>(
             "SELECT * FROM episodes WHERE novel_id = ? ORDER BY episode_no LIMIT ? OFFSET ?",
-            novelId, pageSize, offset);
+            novelId, pageSize, offset).ConfigureAwait(false);
     }
 
-    public Task<int> CountByNovelIdAsync(int novelId)
+    public async Task<int> CountByNovelIdAsync(int novelId)
     {
-        return _db.Table<Episode>().Where(e => e.NovelId == novelId).CountAsync();
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>().Where(e => e.NovelId == novelId).CountAsync().ConfigureAwait(false);
     }
 
-    public Task<int> CountUnreadByNovelIdAsync(int novelId)
+    public async Task<int> CountUnreadByNovelIdAsync(int novelId)
     {
-        return _db.Table<Episode>().Where(e => e.NovelId == novelId && e.IsRead == 0).CountAsync();
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>().Where(e => e.NovelId == novelId && e.IsRead == 0).CountAsync().ConfigureAwait(false);
     }
 
-    public Task<Episode?> GetByNovelAndEpisodeNoAsync(int novelId, int episodeNo)
+    public async Task<Episode?> GetByNovelAndEpisodeNoAsync(int novelId, int episodeNo)
     {
-        return _db.Table<Episode>()
-            .FirstOrDefaultAsync(e => e.NovelId == novelId && e.EpisodeNo == episodeNo)!;
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>()
+            .FirstOrDefaultAsync(e => e.NovelId == novelId && e.EpisodeNo == episodeNo).ConfigureAwait(false);
     }
 
-    public Task<Episode?> GetByIdAsync(int id)
+    public async Task<Episode?> GetByIdAsync(int id)
     {
-        return _db.Table<Episode>().FirstOrDefaultAsync(e => e.Id == id)!;
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>().FirstOrDefaultAsync(e => e.Id == id).ConfigureAwait(false);
     }
 
-    public Task<int> GetMaxEpisodeNoAsync(int novelId)
+    public async Task<int> GetMaxEpisodeNoAsync(int novelId)
     {
-        return _db.ExecuteScalarAsync<int>(
-            "SELECT COALESCE(MAX(episode_no), 0) FROM episodes WHERE novel_id = ?", novelId);
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.ExecuteScalarAsync<int>(
+            "SELECT COALESCE(MAX(episode_no), 0) FROM episodes WHERE novel_id = ?", novelId).ConfigureAwait(false);
     }
 
-    public Task<Episode?> GetLastReadEpisodeAsync(int novelId)
+    public async Task<Episode?> GetLastReadEpisodeAsync(int novelId)
     {
-        return _db.Table<Episode>()
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>()
             .Where(e => e.NovelId == novelId && e.IsRead == 1)
             .OrderByDescending(e => e.EpisodeNo)
-            .FirstOrDefaultAsync()!;
+            .FirstOrDefaultAsync().ConfigureAwait(false);
     }
 
-    public Task<Episode?> GetFirstUnreadEpisodeAsync(int novelId)
+    public async Task<Episode?> GetFirstUnreadEpisodeAsync(int novelId)
     {
-        return _db.Table<Episode>()
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>()
             .Where(e => e.NovelId == novelId && e.IsRead == 0)
             .OrderBy(e => e.EpisodeNo)
-            .FirstOrDefaultAsync()!;
+            .FirstOrDefaultAsync().ConfigureAwait(false);
     }
 
     public async Task InsertAllAsync(IEnumerable<Episode> episodes)
     {
+        await EnsureAsync().ConfigureAwait(false);
         await _db.InsertAllAsync(episodes).ConfigureAwait(false);
     }
 
-    public Task<int> UpdateAsync(Episode episode)
+    public async Task<int> UpdateAsync(Episode episode)
     {
-        return _db.UpdateAsync(episode);
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.UpdateAsync(episode).ConfigureAwait(false);
     }
 
     public async Task MarkAsReadAsync(int episodeId)
     {
+        await EnsureAsync().ConfigureAwait(false);
         var now = DateTime.UtcNow.ToString("o");
         await _db.ExecuteAsync(
             "UPDATE episodes SET is_read = 1, read_at = ? WHERE id = ?", now, episodeId
         ).ConfigureAwait(false);
     }
 
-    public Task<bool> AreAllReadAsync(int novelId)
+    public async Task<bool> AreAllReadAsync(int novelId)
     {
-        return _db.Table<Episode>()
+        await EnsureAsync().ConfigureAwait(false);
+        var count = await _db.Table<Episode>()
             .Where(e => e.NovelId == novelId && e.IsRead == 0)
-            .CountAsync()
-            .ContinueWith(t => t.Result == 0);
+            .CountAsync().ConfigureAwait(false);
+        return count == 0;
+    }
+
+    public async Task SetFavoriteAsync(int episodeId, bool favorite)
+    {
+        await EnsureAsync().ConfigureAwait(false);
+        var now = favorite ? DateTime.UtcNow.ToString("o") : null;
+        await _db.ExecuteAsync(
+            "UPDATE episodes SET is_favorite = ?, favorited_at = ? WHERE id = ?",
+            favorite ? 1 : 0, now, episodeId).ConfigureAwait(false);
+    }
+
+    public async Task<List<Episode>> GetFavoritesByNovelIdAsync(int novelId)
+    {
+        await EnsureAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>()
+            .Where(e => e.NovelId == novelId && e.IsFavorite == 1)
+            .OrderBy(e => e.EpisodeNo)
+            .ToListAsync().ConfigureAwait(false);
     }
 }

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -6,40 +6,77 @@ namespace LanobeReader.Services.Database;
 public class NovelRepository
 {
     private readonly SQLiteAsyncConnection _db;
+    private readonly DatabaseService _dbService;
 
     public NovelRepository(DatabaseService dbService)
     {
+        _dbService = dbService;
         _db = dbService.Connection;
     }
 
     public Task<List<Novel>> GetAllAsync()
     {
-        return _db.Table<Novel>().OrderByDescending(n => n.LastUpdatedAt).ToListAsync();
+        return GetAllAsync("updated_desc");
     }
 
-    public Task<Novel?> GetByIdAsync(int id)
+    public async Task<List<Novel>> GetAllAsync(string sortKey)
     {
-        return _db.Table<Novel>().FirstOrDefaultAsync(n => n.Id == id)!;
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return sortKey switch
+        {
+            "updated_asc" => await _db.Table<Novel>().OrderBy(n => n.LastUpdatedAt).ToListAsync().ConfigureAwait(false),
+            "title_asc" => await _db.Table<Novel>().OrderBy(n => n.Title).ToListAsync().ConfigureAwait(false),
+            "title_desc" => await _db.Table<Novel>().OrderByDescending(n => n.Title).ToListAsync().ConfigureAwait(false),
+            "author_asc" => await _db.Table<Novel>().OrderBy(n => n.Author).ToListAsync().ConfigureAwait(false),
+            "registered_desc" => await _db.Table<Novel>().OrderByDescending(n => n.RegisteredAt).ToListAsync().ConfigureAwait(false),
+            "unread_desc" => await _db.QueryAsync<Novel>(
+                "SELECT n.* FROM novels n " +
+                "ORDER BY (SELECT COUNT(*) FROM episodes e WHERE e.novel_id = n.id AND e.is_read = 0) DESC, n.last_updated_at DESC"
+            ).ConfigureAwait(false),
+            "favorite_first" => await _db.QueryAsync<Novel>(
+                "SELECT * FROM novels ORDER BY is_favorite DESC, last_updated_at DESC"
+            ).ConfigureAwait(false),
+            _ => await _db.Table<Novel>().OrderByDescending(n => n.LastUpdatedAt).ToListAsync().ConfigureAwait(false),
+        };
     }
 
-    public Task<Novel?> GetBySiteAndNovelIdAsync(int siteType, string novelId)
+    public async Task<Novel?> GetByIdAsync(int id)
     {
-        return _db.Table<Novel>()
-            .FirstOrDefaultAsync(n => n.SiteType == siteType && n.NovelId == novelId)!;
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.Table<Novel>().FirstOrDefaultAsync(n => n.Id == id).ConfigureAwait(false);
     }
 
-    public Task<int> InsertAsync(Novel novel)
+    public async Task<Novel?> GetBySiteAndNovelIdAsync(int siteType, string novelId)
     {
-        return _db.InsertAsync(novel);
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.Table<Novel>()
+            .FirstOrDefaultAsync(n => n.SiteType == siteType && n.NovelId == novelId).ConfigureAwait(false);
     }
 
-    public Task<int> UpdateAsync(Novel novel)
+    public async Task<int> InsertAsync(Novel novel)
     {
-        return _db.UpdateAsync(novel);
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.InsertAsync(novel).ConfigureAwait(false);
+    }
+
+    public async Task<int> UpdateAsync(Novel novel)
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.UpdateAsync(novel).ConfigureAwait(false);
+    }
+
+    public async Task SetFavoriteAsync(int novelId, bool favorite)
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        var now = favorite ? DateTime.UtcNow.ToString("o") : null;
+        await _db.ExecuteAsync(
+            "UPDATE novels SET is_favorite = ?, favorited_at = ? WHERE id = ?",
+            favorite ? 1 : 0, now, novelId).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(int novelId)
     {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
         // CASCADE: episode_cache → episodes → novels
         var episodes = await _db.Table<Episode>().Where(e => e.NovelId == novelId).ToListAsync().ConfigureAwait(false);
         foreach (var ep in episodes)
@@ -50,8 +87,9 @@ public class NovelRepository
         await _db.DeleteAsync<Novel>(novelId).ConfigureAwait(false);
     }
 
-    public Task<int> CountAsync()
+    public async Task<int> CountAsync()
     {
-        return _db.Table<Novel>().CountAsync();
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.Table<Novel>().CountAsync().ConfigureAwait(false);
     }
 }

--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using AngleSharp;
 using AngleSharp.Dom;
-using LanobeReader.Helpers;
 using LanobeReader.Models;
+using LanobeReader.Services.Network;
 
 namespace LanobeReader.Services.Kakuyomu;
 
@@ -12,11 +12,16 @@ public class KakuyomuApiService : INovelService
     private const string USER_AGENT = "Mozilla/5.0 (compatible; LanobeReader/1.0)";
 
     private readonly HttpClient _httpClient;
+    private readonly NetworkPolicyService _network;
 
-    public KakuyomuApiService(HttpClient httpClient)
+    public KakuyomuApiService(HttpClient httpClient, NetworkPolicyService network)
     {
         _httpClient = httpClient;
-        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(USER_AGENT);
+        _network = network;
+        if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(USER_AGENT);
+        }
     }
 
     public SiteType SiteType => SiteType.Kakuyomu;
@@ -24,12 +29,11 @@ public class KakuyomuApiService : INovelService
     public async Task<List<SearchResult>> SearchAsync(string keyword, string searchTarget, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(5));
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
 
-        // Kakuyomu search via HTML scraping (public API is undocumented)
         var encoded = Uri.EscapeDataString(keyword);
         var url = $"{BASE_URL}/search?q={encoded}";
-        var html = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
+        var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
 
         var config = Configuration.Default;
         var context = BrowsingContext.New(config);
@@ -38,7 +42,6 @@ public class KakuyomuApiService : INovelService
         var results = new List<SearchResult>();
         var seen = new HashSet<string>();
 
-        // New structure: <a title="タイトル" href="https://kakuyomu.jp/works/ID" class="...">タイトル</a>
         var titleLinks = document.QuerySelectorAll("a[title][href*='/works/']");
         foreach (var link in titleLinks)
         {
@@ -56,7 +59,7 @@ public class KakuyomuApiService : INovelService
                 NovelId = workId,
                 Title = title,
                 Author = "",
-                TotalEpisodes = 0,  // Will be fetched on registration
+                TotalEpisodes = 0,
                 IsCompleted = false,
             });
 
@@ -69,10 +72,10 @@ public class KakuyomuApiService : INovelService
     public async Task<List<Episode>> FetchEpisodeListAsync(string novelId, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        cts.CancelAfter(TimeSpan.FromSeconds(15));
 
         var url = $"{BASE_URL}/works/{novelId}";
-        var html = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
+        var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
 
         return ParseEpisodesFromApolloState(html);
     }
@@ -103,7 +106,6 @@ public class KakuyomuApiService : INovelService
                 if (!union.TryGetProperty("__ref", out var refProp)) continue;
                 var refKey = refProp.GetString();
                 if (string.IsNullOrEmpty(refKey)) continue;
-                // refKey looks like "Episode:16816927862837791426"
                 var colonIdx = refKey.IndexOf(':');
                 if (colonIdx < 0) continue;
                 ids.Add(refKey.Substring(colonIdx + 1));
@@ -127,7 +129,6 @@ public class KakuyomuApiService : INovelService
         if (!doc.RootElement.TryGetProperty("props", out var props)) return null;
         if (!props.TryGetProperty("pageProps", out var pageProps)) return null;
         if (!pageProps.TryGetProperty("__APOLLO_STATE__", out var apolloState)) return null;
-        // Clone so the JsonDocument can be disposed safely
         return apolloState.Clone();
     }
 
@@ -190,11 +191,11 @@ public class KakuyomuApiService : INovelService
     public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        cts.CancelAfter(TimeSpan.FromSeconds(20));
 
         // Fetch TOC and extract episode IDs from Apollo State
         var tocUrl = $"{BASE_URL}/works/{novelId}";
-        var tocHtml = await _httpClient.GetStringAsync(tocUrl, cts.Token).ConfigureAwait(false);
+        var tocHtml = await _network.GetStringAsync(SiteType.Kakuyomu, tocUrl, cts.Token).ConfigureAwait(false);
         var episodeIds = ParseEpisodeIdsFromApolloState(tocHtml);
 
         if (episodeNo < 1 || episodeNo > episodeIds.Count)
@@ -205,7 +206,7 @@ public class KakuyomuApiService : INovelService
         var episodeId = episodeIds[episodeNo - 1];
         var episodeHref = $"{BASE_URL}/works/{novelId}/episodes/{episodeId}";
 
-        var episodeHtml = await _httpClient.GetStringAsync(episodeHref, cts.Token).ConfigureAwait(false);
+        var episodeHtml = await _network.GetStringAsync(SiteType.Kakuyomu, episodeHref, cts.Token).ConfigureAwait(false);
 
         var config = Configuration.Default;
         var context = BrowsingContext.New(config);
@@ -233,7 +234,7 @@ public class KakuyomuApiService : INovelService
         cts.CancelAfter(TimeSpan.FromSeconds(30));
 
         var url = $"{BASE_URL}/works/{novelId}";
-        var html = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
+        var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
 
         var totalEpisodes = ParseEpisodeIdsFromApolloState(html).Count;
 
@@ -253,9 +254,68 @@ public class KakuyomuApiService : INovelService
         return (totalEpisodes, DateTime.UtcNow.ToString("o"), isCompleted);
     }
 
+    /// <summary>
+    /// ランキングページをスクレイピングして作品一覧を返す。
+    /// </summary>
+    public async Task<List<SearchResult>> FetchRankingAsync(string genreSlug, string periodSlug, CancellationToken ct = default)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(TimeSpan.FromSeconds(20));
+
+        var url = $"{BASE_URL}/rankings/{genreSlug}/{periodSlug}";
+        var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
+
+        var config = Configuration.Default;
+        var context = BrowsingContext.New(config);
+        var document = await context.OpenAsync(req => req.Content(html), cts.Token).ConfigureAwait(false);
+
+        var results = new List<SearchResult>();
+        var seen = new HashSet<string>();
+
+        var links = document.QuerySelectorAll("a[href^='/works/']");
+        foreach (var link in links)
+        {
+            var href = link.GetAttribute("href") ?? "";
+            if (href.Contains("/reviews") || href.Contains("/episodes/")) continue;
+
+            var workId = ExtractWorkId(href);
+            if (string.IsNullOrEmpty(workId) || !seen.Add(workId)) continue;
+
+            var title = (link.GetAttribute("title") ?? link.TextContent).Trim();
+            if (string.IsNullOrEmpty(title)) continue;
+
+            // 作者名抽出: 親要素から /users/ アンカーを探す
+            var author = "";
+            var parent = link.ParentElement;
+            for (int i = 0; i < 4 && parent is not null; i++)
+            {
+                var userLink = parent.QuerySelector("a[href^='/users/']");
+                if (userLink is not null)
+                {
+                    author = userLink.TextContent.Trim();
+                    break;
+                }
+                parent = parent.ParentElement;
+            }
+
+            results.Add(new SearchResult
+            {
+                SiteType = SiteType.Kakuyomu,
+                NovelId = workId,
+                Title = title,
+                Author = author,
+                TotalEpisodes = 0,
+                IsCompleted = false,
+            });
+
+            if (results.Count >= 30) break;
+        }
+
+        return results;
+    }
+
     private static string ExtractWorkId(string href)
     {
-        // Extract work ID from href like "/works/1234567890"
         var parts = href.Split('/');
         for (int i = 0; i < parts.Length - 1; i++)
         {

--- a/_Apps/Services/Narou/NarouApiService.cs
+++ b/_Apps/Services/Narou/NarouApiService.cs
@@ -1,23 +1,31 @@
+using System.IO.Compression;
 using System.Text.Json;
 using AngleSharp;
 using AngleSharp.Dom;
 using LanobeReader.Helpers;
 using LanobeReader.Models;
+using LanobeReader.Services.Network;
 
 namespace LanobeReader.Services.Narou;
 
 public class NarouApiService : INovelService
 {
     private const string API_BASE = "https://api.syosetu.com/novelapi/api/";
+    private const string RANK_BASE = "https://api.syosetu.com/rank/rankget/";
     private const string NCODE_BASE = "https://ncode.syosetu.com/";
     private const string USER_AGENT = "Mozilla/5.0 (compatible; LanobeReader/1.0)";
 
     private readonly HttpClient _httpClient;
+    private readonly NetworkPolicyService _network;
 
-    public NarouApiService(HttpClient httpClient)
+    public NarouApiService(HttpClient httpClient, NetworkPolicyService network)
     {
         _httpClient = httpClient;
-        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(USER_AGENT);
+        _network = network;
+        if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(USER_AGENT);
+        }
     }
 
     public SiteType SiteType => SiteType.Narou;
@@ -35,11 +43,15 @@ public class NarouApiService : INovelService
         var url = $"{API_BASE}?out=json&lim=20&{wordParam}={encoded}";
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(5));
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
 
-        var response = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
-        var jsonArray = JsonSerializer.Deserialize<JsonElement[]>(response);
+        var response = await _network.GetStringAsync(SiteType.Narou, url, cts.Token).ConfigureAwait(false);
+        return ParseNovelApiJson(response);
+    }
 
+    private static List<SearchResult> ParseNovelApiJson(string json)
+    {
+        var jsonArray = JsonSerializer.Deserialize<JsonElement[]>(json);
         var results = new List<SearchResult>();
         if (jsonArray is null || jsonArray.Length <= 1) return results;
 
@@ -52,13 +64,12 @@ public class NarouApiService : INovelService
                 SiteType = SiteType.Narou,
                 NovelId = item.GetProperty("ncode").GetString()?.ToLower() ?? "",
                 Title = item.GetProperty("title").GetString() ?? "",
-                Author = item.GetProperty("writer").GetString() ?? "",
-                TotalEpisodes = item.GetProperty("general_all_no").GetInt32(),
+                Author = item.TryGetProperty("writer", out var w) ? w.GetString() ?? "" : "",
+                TotalEpisodes = item.TryGetProperty("general_all_no", out var ga) ? ga.GetInt32() : 0,
                 IsCompleted = item.TryGetProperty("end", out var end) && end.GetInt32() == 0,
                 LastUpdatedAt = item.TryGetProperty("general_lastup", out var lastup) ? lastup.GetString() : null,
             });
         }
-
         return results;
     }
 
@@ -74,12 +85,12 @@ public class NarouApiService : INovelService
         while (true)
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(TimeSpan.FromSeconds(10));
+            cts.CancelAfter(TimeSpan.FromSeconds(15));
 
             var url = page == 1
                 ? $"{NCODE_BASE}{novelId}/"
                 : $"{NCODE_BASE}{novelId}/?p={page}";
-            var html = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
+            var html = await _network.GetStringAsync(SiteType.Narou, url, cts.Token).ConfigureAwait(false);
 
             var context = BrowsingContext.New(config);
             var document = await context.OpenAsync(req => req.Content(html), cts.Token).ConfigureAwait(false);
@@ -135,10 +146,10 @@ public class NarouApiService : INovelService
     public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(TimeSpan.FromSeconds(5));
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
 
         var url = $"{NCODE_BASE}{novelId}/{episodeNo}/";
-        var html = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
+        var html = await _network.GetStringAsync(SiteType.Narou, url, cts.Token).ConfigureAwait(false);
 
         var config = Configuration.Default;
         var context = BrowsingContext.New(config);
@@ -161,7 +172,7 @@ public class NarouApiService : INovelService
         cts.CancelAfter(TimeSpan.FromSeconds(30));
 
         var url = $"{API_BASE}?out=json&ncode={novelId}&of=ga-gl-e";
-        var response = await _httpClient.GetStringAsync(url, cts.Token).ConfigureAwait(false);
+        var response = await _network.GetStringAsync(SiteType.Narou, url, cts.Token).ConfigureAwait(false);
         var jsonArray = JsonSerializer.Deserialize<JsonElement[]>(response);
 
         if (jsonArray is null || jsonArray.Length <= 1)
@@ -175,5 +186,83 @@ public class NarouApiService : INovelService
         var isCompleted = item.TryGetProperty("end", out var end) && end.GetInt32() == 0;
 
         return (totalEpisodes, lastUpdatedAt, isCompleted);
+    }
+
+    /// <summary>
+    /// ランキング取得。期間と任意の大ジャンルで絞り込み、詳細メタを novelapi で一括取得する。
+    /// </summary>
+    public async Task<List<SearchResult>> FetchRankingAsync(RankingPeriod period, int? biggenre, int limit, CancellationToken ct = default)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
+
+        var rtype = BuildRtype(period);
+        var rankUrl = $"{RANK_BASE}?out=json&rtype={rtype}";
+
+        var rankJson = await _network.GetStringAsync(SiteType.Narou, rankUrl, cts.Token).ConfigureAwait(false);
+        var rankItems = JsonSerializer.Deserialize<JsonElement[]>(rankJson);
+        if (rankItems is null || rankItems.Length == 0) return new List<SearchResult>();
+
+        var ncodes = new List<string>();
+        foreach (var item in rankItems)
+        {
+            if (!item.TryGetProperty("ncode", out var nc)) continue;
+            var ncode = nc.GetString();
+            if (!string.IsNullOrEmpty(ncode)) ncodes.Add(ncode.ToLowerInvariant());
+            if (ncodes.Count >= Math.Min(limit, 100)) break;
+        }
+        if (ncodes.Count == 0) return new List<SearchResult>();
+
+        // novelapi へハイフン結合で一括問い合わせ（最大500件、API制限）
+        var ncodeParam = string.Join('-', ncodes);
+        var detailUrl = $"{API_BASE}?out=json&lim={ncodes.Count}&ncode={ncodeParam}";
+        if (biggenre.HasValue) detailUrl += $"&biggenre={biggenre.Value}";
+
+        var detailJson = await _network.GetStringAsync(SiteType.Narou, detailUrl, cts.Token).ConfigureAwait(false);
+        var results = ParseNovelApiJson(detailJson);
+
+        // ランキング順に並べる
+        var order = ncodes.Select((n, i) => (n, i)).ToDictionary(x => x.n, x => x.i);
+        return results
+            .Where(r => order.ContainsKey(r.NovelId))
+            .OrderBy(r => order[r.NovelId])
+            .ToList();
+    }
+
+    /// <summary>
+    /// ジャンル別の新着・人気作品取得（novelapi）。
+    /// </summary>
+    public async Task<List<SearchResult>> FetchByGenreAsync(int genre, string order, int limit, CancellationToken ct = default)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(TimeSpan.FromSeconds(20));
+
+        var lim = Math.Clamp(limit, 1, 100);
+        var url = $"{API_BASE}?out=json&lim={lim}&genre={genre}&order={Uri.EscapeDataString(order)}";
+
+        var json = await _network.GetStringAsync(SiteType.Narou, url, cts.Token).ConfigureAwait(false);
+        return ParseNovelApiJson(json);
+    }
+
+    private static string BuildRtype(RankingPeriod period)
+    {
+        var today = DateTime.Today;
+        // 4:00-7:00頃集計のため、当日朝8時以前は2日前、それ以外は前日を採用
+        var dailyTarget = DateTime.Now.Hour < 8 ? today.AddDays(-2) : today.AddDays(-1);
+
+        return period switch
+        {
+            RankingPeriod.Daily => $"{dailyTarget:yyyyMMdd}-d",
+            RankingPeriod.Weekly => $"{NearestTuesday(today):yyyyMMdd}-w",
+            RankingPeriod.Monthly => $"{new DateTime(today.Year, today.Month, 1):yyyyMMdd}-m",
+            RankingPeriod.Quarterly => $"{new DateTime(today.Year, today.Month, 1):yyyyMMdd}-q",
+            _ => $"{dailyTarget:yyyyMMdd}-d",
+        };
+    }
+
+    private static DateTime NearestTuesday(DateTime today)
+    {
+        int diff = ((int)today.DayOfWeek - (int)DayOfWeek.Tuesday + 7) % 7;
+        return today.AddDays(-diff);
     }
 }

--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -1,0 +1,142 @@
+using LanobeReader.Helpers;
+using LanobeReader.Models;
+using LanobeReader.Services.Database;
+using Microsoft.Maui.Networking;
+
+namespace LanobeReader.Services.Network;
+
+/// <summary>
+/// サイト別の HTTP リクエスト発行を直列化＋ディレイ＋Wi-Fi検出でゲートする共通サービス。
+/// - 同一サイトへのリクエストは SemaphoreSlim(1,1) で直列化
+/// - リクエスト間は request_delay_ms（既定800ms）のディレイを挿入
+/// - Wi-Fi接続状態の取得と変化通知も提供（Prefetch用途）
+/// </summary>
+public class NetworkPolicyService
+{
+    private readonly HttpClient _httpClient;
+    private readonly AppSettingsRepository _settingsRepo;
+
+    private readonly Dictionary<SiteType, SemaphoreSlim> _siteGates = new()
+    {
+        [SiteType.Narou] = new SemaphoreSlim(1, 1),
+        [SiteType.Kakuyomu] = new SemaphoreSlim(1, 1),
+    };
+
+    private readonly Dictionary<SiteType, DateTime> _lastRequestAt = new()
+    {
+        [SiteType.Narou] = DateTime.MinValue,
+        [SiteType.Kakuyomu] = DateTime.MinValue,
+    };
+
+    public NetworkPolicyService(HttpClient httpClient, AppSettingsRepository settingsRepo)
+    {
+        _httpClient = httpClient;
+        _settingsRepo = settingsRepo;
+
+        try
+        {
+            Connectivity.ConnectivityChanged += OnConnectivityChanged;
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn(nameof(NetworkPolicyService), $"Failed to hook ConnectivityChanged: {ex.Message}");
+        }
+    }
+
+    public event EventHandler? WifiConnected;
+    public event EventHandler? WifiDisconnected;
+
+    public bool IsOnline
+    {
+        get
+        {
+            try { return Connectivity.Current.NetworkAccess == NetworkAccess.Internet; }
+            catch { return true; }
+        }
+    }
+
+    public bool IsWifiConnected
+    {
+        get
+        {
+            try
+            {
+                return Connectivity.Current.NetworkAccess == NetworkAccess.Internet
+                    && Connectivity.Current.ConnectionProfiles.Contains(ConnectionProfile.WiFi);
+            }
+            catch { return false; }
+        }
+    }
+
+    private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
+    {
+        var isWifi = e.NetworkAccess == NetworkAccess.Internet
+            && e.ConnectionProfiles.Contains(ConnectionProfile.WiFi);
+        if (isWifi) WifiConnected?.Invoke(this, EventArgs.Empty);
+        else WifiDisconnected?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// 指定サイトに対して HTTP GET（文字列）を発行。直列化＋ディレイが自動で適用される。
+    /// </summary>
+    public async Task<string> GetStringAsync(SiteType site, string url, CancellationToken ct = default)
+    {
+        var gate = _siteGates[site];
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await EnforceDelayAsync(site, ct).ConfigureAwait(false);
+            var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+            _lastRequestAt[site] = DateTime.UtcNow;
+            return result;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// 指定サイトに対して HTTP GET（ストリーム）を発行（gzip 等の解凍用）。
+    /// </summary>
+    public async Task<Stream> GetStreamAsync(SiteType site, string url, CancellationToken ct = default)
+    {
+        var gate = _siteGates[site];
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await EnforceDelayAsync(site, ct).ConfigureAwait(false);
+            var result = await _httpClient.GetStreamAsync(url, ct).ConfigureAwait(false);
+            _lastRequestAt[site] = DateTime.UtcNow;
+            return result;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task EnforceDelayAsync(SiteType site, CancellationToken ct)
+    {
+        var delayMs = await GetDelayMsAsync().ConfigureAwait(false);
+        var last = _lastRequestAt[site];
+        if (last == DateTime.MinValue) return;
+
+        var elapsed = (DateTime.UtcNow - last).TotalMilliseconds;
+        var remaining = delayMs - elapsed;
+        if (remaining > 0)
+        {
+            await Task.Delay((int)remaining, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<int> GetDelayMsAsync()
+    {
+        try
+        {
+            var v = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, 800).ConfigureAwait(false);
+            return Math.Clamp(v, 100, 5000);
+        }
+        catch { return 800; }
+    }
+}

--- a/_Apps/Services/UpdateCheckService.cs
+++ b/_Apps/Services/UpdateCheckService.cs
@@ -1,5 +1,6 @@
 using LanobeReader.Helpers;
 using LanobeReader.Models;
+using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
 
 namespace LanobeReader.Services;
@@ -11,15 +12,18 @@ public class UpdateCheckService
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeRepository _episodeRepo;
     private readonly INovelServiceFactory _serviceFactory;
+    private readonly BackgroundJobQueue? _jobQueue;
 
     public UpdateCheckService(
         NovelRepository novelRepo,
         EpisodeRepository episodeRepo,
-        INovelServiceFactory serviceFactory)
+        INovelServiceFactory serviceFactory,
+        BackgroundJobQueue? jobQueue = null)
     {
         _novelRepo = novelRepo;
         _episodeRepo = episodeRepo;
         _serviceFactory = serviceFactory;
+        _jobQueue = jobQueue;
     }
 
     public async Task<List<(Novel novel, int newEpisodeCount)>> CheckAllAsync(CancellationToken ct = default)
@@ -69,6 +73,24 @@ public class UpdateCheckService
                             await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
 
                             updates.Add((novel, newEpisodes.Count));
+
+                            // Enqueue newly-added episodes for background prefetch (Wi-Fi gated)
+                            if (_jobQueue is not null)
+                            {
+                                var inserted = await _episodeRepo.GetByNovelIdAsync(novel.Id).ConfigureAwait(false);
+                                foreach (var ep in inserted.Where(e => e.EpisodeNo > currentMaxEpisode))
+                                {
+                                    _jobQueue.Enqueue(new PrefetchEpisodeJob
+                                    {
+                                        NovelDbId = novel.Id,
+                                        EpisodeDbId = ep.Id,
+                                        EpisodeNo = ep.EpisodeNo,
+                                        SiteType = novel.SiteType,
+                                        SiteNovelId = novel.NovelId,
+                                        Priority = novel.IsFavorite == 1 ? 1 : 0,
+                                    });
+                                }
+                            }
                         }
                     }
                 }

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LanobeReader.Helpers;
 using LanobeReader.Models;
+using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
 
 namespace LanobeReader.ViewModels;
@@ -11,18 +12,26 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
 {
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeRepository _episodeRepo;
+    private readonly EpisodeCacheRepository _cacheRepo;
     private readonly AppSettingsRepository _settingsRepo;
+    private readonly PrefetchService _prefetch;
 
     private int _novelDbId;
+    private List<Episode> _allEpisodes = new();
+    private HashSet<int> _cachedIds = new();
 
     public EpisodeListViewModel(
         NovelRepository novelRepo,
         EpisodeRepository episodeRepo,
-        AppSettingsRepository settingsRepo)
+        EpisodeCacheRepository cacheRepo,
+        AppSettingsRepository settingsRepo,
+        PrefetchService prefetch)
     {
         _novelRepo = novelRepo;
         _episodeRepo = episodeRepo;
+        _cacheRepo = cacheRepo;
         _settingsRepo = settingsRepo;
+        _prefetch = prefetch;
     }
 
     [ObservableProperty]
@@ -50,6 +59,15 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
     [ObservableProperty]
     private bool _isLoading;
 
+    [ObservableProperty]
+    private bool _isNovelFavorite;
+
+    [ObservableProperty]
+    private bool _showUnreadOnly;
+
+    [ObservableProperty]
+    private bool _showFavoritesOnly;
+
     private int _episodesPerPage = 50;
     private Novel? _novel;
 
@@ -72,28 +90,25 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
 
             _episodesPerPage = await _settingsRepo.GetIntValueAsync(SettingsKeys.EPISODES_PER_PAGE, 50);
 
-            // Check if episodes have chapters
-            var allEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
-            var hasChapters = allEpisodes.Any(e => e.ChapterName is not null);
+            _allEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
+            _cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(_novelDbId);
 
-            // Check last read
+            var hasChapters = _allEpisodes.Any(e => e.ChapterName is not null);
             var lastRead = await _episodeRepo.GetLastReadEpisodeAsync(_novelDbId);
 
             NovelTitle = _novel.Title;
             HasChapters = hasChapters;
             HasLastRead = lastRead is not null;
+            IsNovelFavorite = _novel.IsFavorite == 1;
 
             if (hasChapters)
             {
-                // Show all episodes grouped by chapter (no paging)
-                Episodes = new ObservableCollection<EpisodeViewModel>(
-                    allEpisodes.Select(EpisodeViewModel.FromModel));
+                ApplyFilterAndShow();
                 MaxPage = 1;
             }
             else
             {
-                var totalCount = allEpisodes.Count;
-                MaxPage = Math.Max(1, (int)Math.Ceiling((double)totalCount / _episodesPerPage));
+                RecalcPaging();
                 await LoadPageAsync();
             }
         }
@@ -107,11 +122,53 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         }
     }
 
-    private async Task LoadPageAsync()
+    private IEnumerable<Episode> FilteredEpisodes()
     {
-        var episodes = await _episodeRepo.GetPagedByNovelIdAsync(_novelDbId, CurrentPage, _episodesPerPage);
+        IEnumerable<Episode> src = _allEpisodes;
+        if (ShowUnreadOnly) src = src.Where(e => e.IsRead == 0);
+        if (ShowFavoritesOnly) src = src.Where(e => e.IsFavorite == 1);
+        return src;
+    }
+
+    private void ApplyFilterAndShow()
+    {
         Episodes = new ObservableCollection<EpisodeViewModel>(
-            episodes.Select(EpisodeViewModel.FromModel));
+            FilteredEpisodes().Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id))));
+    }
+
+    private void RecalcPaging()
+    {
+        var totalCount = FilteredEpisodes().Count();
+        MaxPage = Math.Max(1, (int)Math.Ceiling((double)totalCount / _episodesPerPage));
+        if (CurrentPage > MaxPage) CurrentPage = MaxPage;
+    }
+
+    private Task LoadPageAsync()
+    {
+        var list = FilteredEpisodes()
+            .Skip((CurrentPage - 1) * _episodesPerPage)
+            .Take(_episodesPerPage)
+            .Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)))
+            .ToList();
+        Episodes = new ObservableCollection<EpisodeViewModel>(list);
+        return Task.CompletedTask;
+    }
+
+    partial void OnShowUnreadOnlyChanged(bool value) => _ = ReloadListAsync();
+    partial void OnShowFavoritesOnlyChanged(bool value) => _ = ReloadListAsync();
+
+    private async Task ReloadListAsync()
+    {
+        if (HasChapters)
+        {
+            ApplyFilterAndShow();
+        }
+        else
+        {
+            CurrentPage = 1;
+            RecalcPaging();
+            await LoadPageAsync();
+        }
     }
 
     [RelayCommand]
@@ -134,6 +191,39 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         if (_novel is null) return;
         await Shell.Current.GoToAsync(
             $"reader?novelId={_novelDbId}&episodeId={episode.Id}&siteType={_novel.SiteType}&siteNovelId={_novel.NovelId}");
+    }
+
+    [RelayCommand]
+    private async Task ToggleEpisodeFavoriteAsync(EpisodeViewModel ep)
+    {
+        var newValue = !ep.IsFavorite;
+        await _episodeRepo.SetFavoriteAsync(ep.Id, newValue);
+        ep.IsFavorite = newValue;
+
+        var source = _allEpisodes.FirstOrDefault(e => e.Id == ep.Id);
+        if (source is not null) source.IsFavorite = newValue ? 1 : 0;
+    }
+
+    [RelayCommand]
+    private async Task ToggleNovelFavoriteAsync()
+    {
+        if (_novel is null) return;
+        var newValue = !IsNovelFavorite;
+        await _novelRepo.SetFavoriteAsync(_novel.Id, newValue);
+        IsNovelFavorite = newValue;
+        _novel.IsFavorite = newValue ? 1 : 0;
+    }
+
+    [RelayCommand]
+    private async Task DownloadAllAsync()
+    {
+        if (_novel is null) return;
+        var enqueued = await _prefetch.EnqueueNovelAsync(_novelDbId, highPriority: true);
+        await Shell.Current.DisplayAlert("一括ダウンロード",
+            enqueued > 0
+                ? $"{enqueued}話をバックグラウンドで取得します（Wi-Fi接続時のみ）"
+                : "新規取得する話はありません",
+            "OK");
     }
 
     [RelayCommand(CanExecute = nameof(CanGoPrev))]

--- a/_Apps/ViewModels/EpisodeViewModel.cs
+++ b/_Apps/ViewModels/EpisodeViewModel.cs
@@ -20,7 +20,13 @@ public partial class EpisodeViewModel : ObservableObject
     [ObservableProperty]
     private bool _isRead;
 
-    public static EpisodeViewModel FromModel(Episode episode)
+    [ObservableProperty]
+    private bool _isFavorite;
+
+    [ObservableProperty]
+    private bool _isCached;
+
+    public static EpisodeViewModel FromModel(Episode episode, bool isCached = false)
     {
         return new EpisodeViewModel
         {
@@ -29,6 +35,8 @@ public partial class EpisodeViewModel : ObservableObject
             Title = episode.Title,
             ChapterName = episode.ChapterName,
             IsRead = episode.IsRead == 1,
+            IsFavorite = episode.IsFavorite == 1,
+            IsCached = isCached,
         };
     }
 }

--- a/_Apps/ViewModels/NovelCardViewModel.cs
+++ b/_Apps/ViewModels/NovelCardViewModel.cs
@@ -35,6 +35,9 @@ public partial class NovelCardViewModel : ObservableObject
     [ObservableProperty]
     private string _novelId = string.Empty;
 
+    [ObservableProperty]
+    private bool _isFavorite;
+
     public static NovelCardViewModel FromModel(Novel novel, int unreadCount)
     {
         return new NovelCardViewModel
@@ -49,6 +52,7 @@ public partial class NovelCardViewModel : ObservableObject
             LastUpdatedAt = novel.LastUpdatedAt ?? "",
             IsCompleted = novel.IsCompleted == 1,
             HasUnconfirmedUpdate = novel.HasUnconfirmedUpdate == 1,
+            IsFavorite = novel.IsFavorite == 1,
         };
     }
 }

--- a/_Apps/ViewModels/NovelListViewModel.cs
+++ b/_Apps/ViewModels/NovelListViewModel.cs
@@ -12,17 +12,20 @@ public partial class NovelListViewModel : ObservableObject
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeRepository _episodeRepo;
     private readonly EpisodeCacheRepository _cacheRepo;
+    private readonly AppSettingsRepository _settingsRepo;
     private readonly UpdateCheckService _updateCheckService;
 
     public NovelListViewModel(
         NovelRepository novelRepo,
         EpisodeRepository episodeRepo,
         EpisodeCacheRepository cacheRepo,
+        AppSettingsRepository settingsRepo,
         UpdateCheckService updateCheckService)
     {
         _novelRepo = novelRepo;
         _episodeRepo = episodeRepo;
         _cacheRepo = cacheRepo;
+        _settingsRepo = settingsRepo;
         _updateCheckService = updateCheckService;
     }
 
@@ -36,8 +39,12 @@ public partial class NovelListViewModel : ObservableObject
     [ObservableProperty]
     private bool _hasCheckError;
 
+    [ObservableProperty]
+    private string _sortKey = "updated_desc";
+
     public async Task InitializeAsync()
     {
+        SortKey = await _settingsRepo.GetValueAsync(SettingsKeys.NOVEL_SORT_KEY, "updated_desc");
         await LoadNovelsAsync();
     }
 
@@ -45,7 +52,7 @@ public partial class NovelListViewModel : ObservableObject
     {
         try
         {
-            var novels = await _novelRepo.GetAllAsync();
+            var novels = await _novelRepo.GetAllAsync(SortKey);
             var cards = new List<NovelCardViewModel>();
 
             foreach (var novel in novels)
@@ -61,6 +68,43 @@ public partial class NovelListViewModel : ObservableObject
         {
             LogHelper.Error(nameof(NovelListViewModel), $"LoadNovelsAsync failed: {ex.Message}");
         }
+    }
+
+    partial void OnSortKeyChanged(string value)
+    {
+        _ = _settingsRepo.SetValueAsync(SettingsKeys.NOVEL_SORT_KEY, value);
+        _ = LoadNovelsAsync();
+    }
+
+    [RelayCommand]
+    private async Task ChangeSortAsync()
+    {
+        var options = new[]
+        {
+            "更新日時（新しい順）",
+            "更新日時（古い順）",
+            "タイトル昇順",
+            "タイトル降順",
+            "作者昇順",
+            "登録日時（新しい順）",
+            "未読話数（多い順）",
+            "お気に入り優先",
+        };
+        var selected = await Shell.Current.DisplayActionSheet("並び順", "キャンセル", null, options);
+        if (string.IsNullOrEmpty(selected) || selected == "キャンセル") return;
+
+        SortKey = selected switch
+        {
+            "更新日時（新しい順）" => "updated_desc",
+            "更新日時（古い順）" => "updated_asc",
+            "タイトル昇順" => "title_asc",
+            "タイトル降順" => "title_desc",
+            "作者昇順" => "author_asc",
+            "登録日時（新しい順）" => "registered_desc",
+            "未読話数（多い順）" => "unread_desc",
+            "お気に入り優先" => "favorite_first",
+            _ => SortKey,
+        };
     }
 
     [RelayCommand(CanExecute = nameof(CanRefresh))]
@@ -88,7 +132,6 @@ public partial class NovelListViewModel : ObservableObject
     [RelayCommand]
     private async Task NavigateToDetail(NovelCardViewModel card)
     {
-        // Confirm unconfirmed update
         var novel = await _novelRepo.GetByIdAsync(card.Id);
         if (novel is not null && novel.HasUnconfirmedUpdate == 1)
         {
@@ -98,6 +141,18 @@ public partial class NovelListViewModel : ObservableObject
         }
 
         await Shell.Current.GoToAsync($"episodes?novelId={card.Id}");
+    }
+
+    [RelayCommand]
+    private async Task ToggleFavoriteAsync(NovelCardViewModel card)
+    {
+        var newValue = !card.IsFavorite;
+        await _novelRepo.SetFavoriteAsync(card.Id, newValue);
+        card.IsFavorite = newValue;
+        if (SortKey == "favorite_first")
+        {
+            await LoadNovelsAsync();
+        }
     }
 
     [RelayCommand]

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -19,6 +19,7 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private int _currentEpisodeId;
     private int _siteType;
     private string _siteNovelId = string.Empty;
+    private int _backgroundThemeIndex;
 
     public ReaderViewModel(
         EpisodeRepository episodeRepo,
@@ -39,6 +40,9 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
 
     [ObservableProperty]
     private string _episodeContent = string.Empty;
+
+    [ObservableProperty]
+    private string _episodeHtml = string.Empty;
 
     [ObservableProperty]
     private bool _isLoading = true;
@@ -62,6 +66,15 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private Color _textColor = Color.FromArgb("#212121");
 
     [ObservableProperty]
+    private bool _isVerticalWriting;
+
+    [ObservableProperty]
+    private bool _isHorizontal = true;
+
+    [ObservableProperty]
+    private bool _isCurrentEpisodeFavorite;
+
+    [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(PrevEpisodeCommand))]
     private bool _hasPrevEpisode;
 
@@ -70,6 +83,15 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private bool _hasNextEpisode;
 
     private Episode? _episode;
+
+    partial void OnIsVerticalWritingChanged(bool value)
+    {
+        IsHorizontal = !value;
+        if (value && !string.IsNullOrEmpty(EpisodeContent))
+        {
+            RefreshHtml();
+        }
+    }
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
@@ -90,16 +112,24 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private async Task LoadSettingsAsync()
     {
         var fontSizeSp = await _settingsRepo.GetIntValueAsync(SettingsKeys.FONT_SIZE_SP, 16);
-        var backgroundTheme = await _settingsRepo.GetIntValueAsync(SettingsKeys.BACKGROUND_THEME, 0);
+        _backgroundThemeIndex = await _settingsRepo.GetIntValueAsync(SettingsKeys.BACKGROUND_THEME, 0);
         var lineSpacing = await _settingsRepo.GetIntValueAsync(SettingsKeys.LINE_SPACING, 1);
+        var vertical = await _settingsRepo.GetIntValueAsync(SettingsKeys.VERTICAL_WRITING, 0);
 
-        var (bg, text) = ThemeHelper.GetThemeColors(backgroundTheme);
+        var (bg, text) = ThemeHelper.GetThemeColors(_backgroundThemeIndex);
         var lh = ThemeHelper.GetLineHeight(lineSpacing);
 
         FontSize = fontSizeSp;
         BackgroundColor = bg;
         TextColor = text;
         LineHeight = lh;
+        IsVerticalWriting = vertical == 1;
+        IsHorizontal = !IsVerticalWriting;
+    }
+
+    private void RefreshHtml()
+    {
+        EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, FontSize, LineHeight, _backgroundThemeIndex);
     }
 
     private async Task LoadEpisodeAsync(int episodeId)
@@ -110,11 +140,9 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
             _episode = await _episodeRepo.GetByIdAsync(episodeId);
             if (_episode is null) return;
 
-            // Check for prev/next
             var prev = await _episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo - 1);
             var next = await _episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo + 1);
 
-            // Get content (cache first)
             string content;
             var cache = await _cacheRepo.GetByEpisodeIdAsync(episodeId);
             if (cache is not null)
@@ -123,7 +151,6 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
             }
             else
             {
-                // Check connectivity
                 var connectivity = Connectivity.Current.NetworkAccess;
                 if (connectivity != NetworkAccess.Internet)
                 {
@@ -134,7 +161,6 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
                 var service = _serviceFactory.GetService((SiteType)_siteType);
                 content = await service.FetchEpisodeContentAsync(_siteNovelId, _episode.EpisodeNo);
 
-                // Save to cache
                 await _cacheRepo.InsertAsync(new EpisodeCache
                 {
                     EpisodeId = episodeId,
@@ -145,10 +171,13 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
 
             EpisodeTitle = _episode.Title;
             EpisodeContent = content;
+            IsCurrentEpisodeFavorite = _episode.IsFavorite == 1;
             HasPrevEpisode = prev is not null;
             HasNextEpisode = next is not null;
             IsHeaderVisible = true;
             IsFooterVisible = true;
+
+            if (IsVerticalWriting) RefreshHtml();
         }
         catch (TaskCanceledException)
         {
@@ -210,6 +239,16 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     }
 
     [RelayCommand]
+    private async Task ToggleFavoriteAsync()
+    {
+        if (_episode is null) return;
+        var newValue = !IsCurrentEpisodeFavorite;
+        await _episodeRepo.SetFavoriteAsync(_episode.Id, newValue);
+        _episode.IsFavorite = newValue ? 1 : 0;
+        IsCurrentEpisodeFavorite = newValue;
+    }
+
+    [RelayCommand]
     private async Task MarkAsReadAsync()
     {
         if (_episode is null || _episode.IsRead == 1) return;
@@ -217,7 +256,6 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         await _episodeRepo.MarkAsReadAsync(_episode.Id);
         _episode.IsRead = 1;
 
-        // Check if all episodes are read
         var allRead = await _episodeRepo.AreAllReadAsync(_novelDbId);
         if (allRead)
         {

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -4,7 +4,10 @@ using CommunityToolkit.Mvvm.Input;
 using LanobeReader.Helpers;
 using LanobeReader.Models;
 using LanobeReader.Services;
+using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
+using LanobeReader.Services.Kakuyomu;
+using LanobeReader.Services.Narou;
 
 namespace LanobeReader.ViewModels;
 
@@ -13,15 +16,47 @@ public partial class SearchViewModel : ObservableObject
     private readonly INovelServiceFactory _serviceFactory;
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeRepository _episodeRepo;
+    private readonly NarouApiService _narou;
+    private readonly KakuyomuApiService _kakuyomu;
+    private readonly PrefetchService _prefetch;
 
     public SearchViewModel(
         INovelServiceFactory serviceFactory,
         NovelRepository novelRepo,
-        EpisodeRepository episodeRepo)
+        EpisodeRepository episodeRepo,
+        NarouApiService narou,
+        KakuyomuApiService kakuyomu,
+        PrefetchService prefetch)
     {
         _serviceFactory = serviceFactory;
         _novelRepo = novelRepo;
         _episodeRepo = episodeRepo;
+        _narou = narou;
+        _kakuyomu = kakuyomu;
+        _prefetch = prefetch;
+
+        NarouBigGenres = new ObservableCollection<GenreInfo>(NarouGenres.BigGenres);
+        KakuyomuGenreList = new ObservableCollection<GenreInfo>(KakuyomuGenres.Genres);
+        KakuyomuPeriodList = new ObservableCollection<GenreInfo>(KakuyomuGenres.Periods);
+
+        SelectedNarouBigGenre = NarouBigGenres.First();
+        SelectedKakuyomuGenre = KakuyomuGenreList.First();
+        SelectedKakuyomuPeriod = KakuyomuPeriodList.First();
+    }
+
+    // Mode: 0=Keyword, 1=Ranking, 2=Genre browse
+    [ObservableProperty]
+    private int _mode;
+
+    public bool IsKeywordMode => Mode == 0;
+    public bool IsRankingMode => Mode == 1;
+    public bool IsGenreMode => Mode == 2;
+
+    partial void OnModeChanged(int value)
+    {
+        OnPropertyChanged(nameof(IsKeywordMode));
+        OnPropertyChanged(nameof(IsRankingMode));
+        OnPropertyChanged(nameof(IsGenreMode));
     }
 
     [ObservableProperty]
@@ -50,6 +85,32 @@ public partial class SearchViewModel : ObservableObject
     [ObservableProperty]
     private string _errorMessage = string.Empty;
 
+    // Ranking/Genre browse
+    public ObservableCollection<GenreInfo> NarouBigGenres { get; }
+    public ObservableCollection<GenreInfo> KakuyomuGenreList { get; }
+    public ObservableCollection<GenreInfo> KakuyomuPeriodList { get; }
+
+    [ObservableProperty]
+    private GenreInfo? _selectedNarouBigGenre;
+
+    [ObservableProperty]
+    private GenreInfo? _selectedKakuyomuGenre;
+
+    [ObservableProperty]
+    private GenreInfo? _selectedKakuyomuPeriod;
+
+    [ObservableProperty]
+    private int _rankingPeriodIndex; // 0=Daily 1=Weekly 2=Monthly 3=Quarterly
+
+    [RelayCommand]
+    private void SetModeKeyword() => Mode = 0;
+
+    [RelayCommand]
+    private void SetModeRanking() => Mode = 1;
+
+    [RelayCommand]
+    private void SetModeGenre() => Mode = 2;
+
     [RelayCommand(CanExecute = nameof(CanSearch))]
     private async Task SearchAsync()
     {
@@ -66,8 +127,7 @@ public partial class SearchViewModel : ObservableObject
             {
                 try
                 {
-                    var narouService = _serviceFactory.GetService(SiteType.Narou);
-                    var narouResults = await narouService.SearchAsync(SearchKeyword, searchTarget);
+                    var narouResults = await _narou.SearchAsync(SearchKeyword, searchTarget);
                     results.AddRange(narouResults);
                 }
                 catch (TaskCanceledException)
@@ -86,8 +146,7 @@ public partial class SearchViewModel : ObservableObject
             {
                 try
                 {
-                    var kakuyomuService = _serviceFactory.GetService(SiteType.Kakuyomu);
-                    var kakuyomuResults = await kakuyomuService.SearchAsync(SearchKeyword, searchTarget);
+                    var kakuyomuResults = await _kakuyomu.SearchAsync(SearchKeyword, searchTarget);
                     results.AddRange(kakuyomuResults);
                 }
                 catch (TaskCanceledException)
@@ -100,16 +159,7 @@ public partial class SearchViewModel : ObservableObject
                 }
             }
 
-            // Check registration status
-            var viewModels = new List<SearchResultViewModel>();
-            foreach (var result in results)
-            {
-                var existing = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
-                viewModels.Add(SearchResultViewModel.FromModel(result, existing is not null));
-            }
-
-            SearchResults = new ObservableCollection<SearchResultViewModel>(viewModels);
-            HasSearched = true;
+            await ShowResultsAsync(results);
         }
         catch (Exception ex)
         {
@@ -124,6 +174,111 @@ public partial class SearchViewModel : ObservableObject
     }
 
     private bool CanSearch() => !string.IsNullOrWhiteSpace(SearchKeyword) && !IsLoading;
+
+    [RelayCommand]
+    private async Task FetchRankingAsync()
+    {
+        IsLoading = true;
+        HasError = false;
+        ErrorMessage = string.Empty;
+        try
+        {
+            var results = new List<SearchResult>();
+            var period = (RankingPeriod)Math.Clamp(RankingPeriodIndex, 0, 3);
+
+            if (SearchNarou)
+            {
+                try
+                {
+                    int? bg = null;
+                    if (SelectedNarouBigGenre is not null && int.TryParse(SelectedNarouBigGenre.Id, out var bgv)) bg = bgv;
+                    var narouList = await _narou.FetchRankingAsync(period, bg, 30);
+                    results.AddRange(narouList);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Warn(nameof(SearchViewModel), $"Narou ranking failed: {ex.Message}");
+                }
+            }
+
+            if (SearchKakuyomu)
+            {
+                try
+                {
+                    var periodSlug = period switch
+                    {
+                        RankingPeriod.Daily => "daily",
+                        RankingPeriod.Weekly => "weekly",
+                        RankingPeriod.Monthly => "monthly",
+                        _ => "weekly",
+                    };
+                    var kakuyomuList = await _kakuyomu.FetchRankingAsync(
+                        SelectedKakuyomuGenre?.Id ?? "all", periodSlug);
+                    results.AddRange(kakuyomuList);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Warn(nameof(SearchViewModel), $"Kakuyomu ranking failed: {ex.Message}");
+                }
+            }
+
+            await ShowResultsAsync(results);
+        }
+        finally { IsLoading = false; }
+    }
+
+    [RelayCommand]
+    private async Task FetchGenreAsync()
+    {
+        IsLoading = true;
+        HasError = false;
+        ErrorMessage = string.Empty;
+        try
+        {
+            var results = new List<SearchResult>();
+
+            if (SearchNarou && SelectedNarouBigGenre is not null && int.TryParse(SelectedNarouBigGenre.Id, out var bg))
+            {
+                try
+                {
+                    var narouList = await _narou.FetchByGenreAsync(bg, "weeklypoint", 30);
+                    results.AddRange(narouList);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Warn(nameof(SearchViewModel), $"Narou genre failed: {ex.Message}");
+                }
+            }
+
+            if (SearchKakuyomu && SelectedKakuyomuGenre is not null)
+            {
+                try
+                {
+                    var kakuyomuList = await _kakuyomu.FetchRankingAsync(SelectedKakuyomuGenre.Id, "weekly");
+                    results.AddRange(kakuyomuList);
+                }
+                catch (Exception ex)
+                {
+                    LogHelper.Warn(nameof(SearchViewModel), $"Kakuyomu genre failed: {ex.Message}");
+                }
+            }
+
+            await ShowResultsAsync(results);
+        }
+        finally { IsLoading = false; }
+    }
+
+    private async Task ShowResultsAsync(List<SearchResult> results)
+    {
+        var viewModels = new List<SearchResultViewModel>();
+        foreach (var result in results)
+        {
+            var existing = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
+            viewModels.Add(SearchResultViewModel.FromModel(result, existing is not null));
+        }
+        SearchResults = new ObservableCollection<SearchResultViewModel>(viewModels);
+        HasSearched = true;
+    }
 
     [RelayCommand]
     private async Task RegisterAsync(SearchResultViewModel result)
@@ -147,11 +302,9 @@ public partial class SearchViewModel : ObservableObject
 
             await _novelRepo.InsertAsync(novel);
 
-            // Fetch episode list
             var service = _serviceFactory.GetService(result.SiteType);
             var episodes = await service.FetchEpisodeListAsync(result.NovelId);
 
-            // Set novel_id for each episode
             var dbNovel = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
             if (dbNovel is not null)
             {
@@ -161,9 +314,11 @@ public partial class SearchViewModel : ObservableObject
                 }
                 await _episodeRepo.InsertAllAsync(episodes);
 
-                // Update total episodes
                 dbNovel.TotalEpisodes = episodes.Count;
                 await _novelRepo.UpdateAsync(dbNovel);
+
+                // Auto-enqueue prefetch for newly registered novel (Wi-Fi only)
+                _ = Task.Run(() => _prefetch.EnqueueNovelAsync(dbNovel.Id));
             }
 
             result.IsRegistered = true;

--- a/_Apps/ViewModels/SettingsViewModel.cs
+++ b/_Apps/ViewModels/SettingsViewModel.cs
@@ -37,6 +37,15 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private string _previewText = "サンプルテキストです。フォントサイズと行間のプレビューを表示しています。";
 
+    [ObservableProperty]
+    private bool _verticalWriting;
+
+    [ObservableProperty]
+    private bool _prefetchEnabled = true;
+
+    [ObservableProperty]
+    private int _requestDelayMs = 800;
+
     public async Task InitializeAsync()
     {
         CacheMonths = await _settingsRepo.GetIntValueAsync(SettingsKeys.CACHE_MONTHS, 3);
@@ -45,6 +54,9 @@ public partial class SettingsViewModel : ObservableObject
         BackgroundTheme = await _settingsRepo.GetIntValueAsync(SettingsKeys.BACKGROUND_THEME, 0);
         LineSpacing = await _settingsRepo.GetIntValueAsync(SettingsKeys.LINE_SPACING, 1);
         EpisodesPerPage = await _settingsRepo.GetIntValueAsync(SettingsKeys.EPISODES_PER_PAGE, 50);
+        VerticalWriting = await _settingsRepo.GetIntValueAsync(SettingsKeys.VERTICAL_WRITING, 0) == 1;
+        PrefetchEnabled = await _settingsRepo.GetIntValueAsync(SettingsKeys.PREFETCH_ENABLED, 1) == 1;
+        RequestDelayMs = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, 800);
     }
 
     partial void OnCacheMonthsChanged(int value) =>
@@ -64,6 +76,15 @@ public partial class SettingsViewModel : ObservableObject
 
     partial void OnEpisodesPerPageChanged(int value) =>
         _ = _settingsRepo.SetValueAsync(SettingsKeys.EPISODES_PER_PAGE, value.ToString());
+
+    partial void OnVerticalWritingChanged(bool value) =>
+        _ = _settingsRepo.SetValueAsync(SettingsKeys.VERTICAL_WRITING, value ? "1" : "0");
+
+    partial void OnPrefetchEnabledChanged(bool value) =>
+        _ = _settingsRepo.SetValueAsync(SettingsKeys.PREFETCH_ENABLED, value ? "1" : "0");
+
+    partial void OnRequestDelayMsChanged(int value) =>
+        _ = _settingsRepo.SetValueAsync(SettingsKeys.REQUEST_DELAY_MS, Math.Clamp(value, 500, 2000).ToString());
 
     [RelayCommand]
     private async Task ClearCacheAsync()

--- a/_Apps/Views/EpisodeListPage.xaml
+++ b/_Apps/Views/EpisodeListPage.xaml
@@ -12,23 +12,40 @@
 		<converters:BoolToVisibilityConverter x:Key="BoolToVis" />
 		<converters:InverseBoolConverter x:Key="InverseBool" />
 		<converters:BoolToGrayConverter x:Key="BoolToGrayConverter" />
+		<converters:BoolToGoldConverter x:Key="BoolToGoldConverter" />
 	</ContentPage.Resources>
 
 	<ContentPage.ToolbarItems>
 		<ToolbarItem Text="続きから読む" Command="{Binding ReadContinueCommand}" />
+		<ToolbarItem Text="★作品" Command="{Binding ToggleNovelFavoriteCommand}" />
+		<ToolbarItem Text="一括DL" Command="{Binding DownloadAllCommand}" />
 	</ContentPage.ToolbarItems>
 
-	<Grid RowDefinitions="*,Auto">
+	<Grid RowDefinitions="Auto,*,Auto">
+		<!-- Filter row -->
+		<HorizontalStackLayout Grid.Row="0" Padding="8,4" Spacing="16">
+			<HorizontalStackLayout Spacing="4">
+				<CheckBox IsChecked="{Binding ShowUnreadOnly}" />
+				<Label Text="未読のみ" VerticalOptions="Center" />
+			</HorizontalStackLayout>
+			<HorizontalStackLayout Spacing="4">
+				<CheckBox IsChecked="{Binding ShowFavoritesOnly}" />
+				<Label Text="★のみ" VerticalOptions="Center" />
+			</HorizontalStackLayout>
+			<Label Text="★" FontSize="16" VerticalOptions="Center"
+                   TextColor="{Binding IsNovelFavorite, Converter={StaticResource BoolToGoldConverter}}" />
+		</HorizontalStackLayout>
+
 		<!-- Loading -->
-		<ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
+		<ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
 		<!-- Episode list -->
-		<CollectionView Grid.Row="0" ItemsSource="{Binding Episodes}" SelectionMode="None"
+		<CollectionView Grid.Row="1" ItemsSource="{Binding Episodes}" SelectionMode="None"
                          IsGrouped="False">
 			<CollectionView.ItemTemplate>
 				<DataTemplate x:DataType="vm:EpisodeViewModel">
-					<Grid Padding="16,10" ColumnDefinitions="Auto,*">
+					<Grid Padding="16,10" ColumnDefinitions="Auto,*,Auto,Auto">
 						<Grid.GestureRecognizers>
 							<TapGestureRecognizer
 									Command="{Binding Source={RelativeSource AncestorType={x:Type vm:EpisodeListViewModel}}, Path=NavigateToEpisodeCommand, x:DataType=vm:EpisodeListViewModel}"
@@ -47,13 +64,28 @@
 							<Label Text="{Binding Title}" FontSize="14"
                                    TextColor="{Binding IsRead, Converter={StaticResource BoolToGrayConverter}}" />
 						</VerticalStackLayout>
+
+						<!-- Cached indicator -->
+						<Label Grid.Column="2" Text="●" FontSize="10" TextColor="#4CAF50"
+                               VerticalOptions="Center" Margin="0,0,8,0"
+                               IsVisible="{Binding IsCached}" />
+
+						<!-- Favorite star (tap to toggle) -->
+						<Label Grid.Column="3" Text="★" FontSize="18" VerticalOptions="Center"
+                               TextColor="{Binding IsFavorite, Converter={StaticResource BoolToGoldConverter}}">
+							<Label.GestureRecognizers>
+								<TapGestureRecognizer
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:EpisodeListViewModel}}, Path=ToggleEpisodeFavoriteCommand, x:DataType=vm:EpisodeListViewModel}"
+                                    CommandParameter="{Binding}" />
+							</Label.GestureRecognizers>
+						</Label>
 					</Grid>
 				</DataTemplate>
 			</CollectionView.ItemTemplate>
 		</CollectionView>
 
 		<!-- Paging buttons (hidden when has chapters) -->
-		<Grid Grid.Row="1" ColumnDefinitions="*,Auto,*" Padding="8"
+		<Grid Grid.Row="2" ColumnDefinitions="*,Auto,*" Padding="8"
               IsVisible="{Binding HasChapters, Converter={StaticResource InverseBool}}">
 			<Button Grid.Column="0" Text="◀ 前へ" Command="{Binding PrevPageCommand}"
                     HorizontalOptions="Start" />

--- a/_Apps/Views/NovelListPage.xaml
+++ b/_Apps/Views/NovelListPage.xaml
@@ -11,9 +11,11 @@
 		<converters:BoolToVisibilityConverter x:Key="BoolToVis" />
 		<converters:InverseBoolConverter x:Key="InverseBool" />
 		<converters:IntToBoolConverter x:Key="IntToBool" />
+		<converters:BoolToGoldConverter x:Key="BoolToGoldConverter" />
 	</ContentPage.Resources>
 
 	<ContentPage.ToolbarItems>
+		<ToolbarItem Text="並び替え" Command="{Binding ChangeSortCommand}" />
 		<ToolbarItem Text="更新" Command="{Binding RefreshCommand}"
                      IsEnabled="{Binding HasCheckError}" />
 	</ContentPage.ToolbarItems>
@@ -37,6 +39,9 @@
 					<SwipeView Margin="8,4">
 						<SwipeView.RightItems>
 							<SwipeItems Mode="Reveal">
+								<SwipeItem Text="★お気に入り" BackgroundColor="#FFC107"
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:NovelListViewModel}}, Path=ToggleFavoriteCommand, x:DataType=vm:NovelListViewModel}"
+                                    CommandParameter="{Binding}" />
 								<SwipeItem Text="キャッシュ削除" BackgroundColor="Orange"
                                     Command="{Binding Source={RelativeSource AncestorType={x:Type vm:NovelListViewModel}}, Path=DeleteCacheCommand, x:DataType=vm:NovelListViewModel}"
                                     CommandParameter="{Binding}" />
@@ -59,13 +64,17 @@
                                     CommandParameter="{Binding}" />
 							</Border.GestureRecognizers>
 
-							<Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto">
+							<Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto">
+								<!-- Favorite star -->
+								<Label Grid.Row="0" Grid.Column="0" Grid.RowSpan="3"
+                                       Text="★" FontSize="20" VerticalOptions="Center" Margin="0,0,6,0"
+                                       TextColor="{Binding IsFavorite, Converter={StaticResource BoolToGoldConverter}}" />
 								<!-- Title -->
-								<Label Grid.Row="0" Grid.Column="0" Text="{Binding Title}"
+								<Label Grid.Row="0" Grid.Column="1" Text="{Binding Title}"
                                        FontSize="16" FontAttributes="Bold" LineBreakMode="TailTruncation" />
 
 								<!-- Site badge -->
-								<Border Grid.Row="0" Grid.Column="1" Padding="4,2"
+								<Border Grid.Row="0" Grid.Column="2" Padding="4,2"
                                         BackgroundColor="#6200EE">
 									<Border.StrokeShape>
 										<RoundRectangle CornerRadius="8" />
@@ -74,7 +83,7 @@
 								</Border>
 
 								<!-- Author + Status -->
-								<HorizontalStackLayout Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Spacing="8">
+								<HorizontalStackLayout Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Spacing="8">
 									<Label Text="{Binding Author}" FontSize="12" TextColor="Gray" />
 									<Label Text="完結" FontSize="11" TextColor="Green"
                                            IsVisible="{Binding IsCompleted}" />
@@ -83,7 +92,7 @@
 								</HorizontalStackLayout>
 
 								<!-- Unread + Updated -->
-								<HorizontalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Spacing="12">
+								<HorizontalStackLayout Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Spacing="12">
 									<Border Padding="6,2" BackgroundColor="#FF5722"
                                            IsVisible="{Binding UnreadCount, Converter={StaticResource IntToBool}}">
 										<Border.StrokeShape>

--- a/_Apps/Views/ReaderPage.xaml
+++ b/_Apps/Views/ReaderPage.xaml
@@ -2,49 +2,63 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:LanobeReader.ViewModels"
+             xmlns:converters="clr-namespace:LanobeReader.Converters"
              x:Class="LanobeReader.Views.ReaderPage"
              x:DataType="vm:ReaderViewModel"
              Shell.TabBarIsVisible="False"
              Shell.NavBarIsVisible="False"
              BackgroundColor="{Binding BackgroundColor}">
 
-    <Grid RowDefinitions="Auto,*,Auto">
+	<ContentPage.Resources>
+		<converters:BoolToGoldConverter x:Key="BoolToGoldConverter" />
+	</ContentPage.Resources>
 
-        <!-- Header -->
-        <Grid Grid.Row="0" Padding="8" BackgroundColor="#80000000"
-              ColumnDefinitions="Auto,*,Auto"
+	<Grid RowDefinitions="Auto,*,Auto">
+
+		<!-- Header -->
+		<Grid Grid.Row="0" Padding="8" BackgroundColor="#80000000"
+              ColumnDefinitions="Auto,*,Auto,Auto"
               IsVisible="{Binding IsHeaderVisible}">
-            <Button Grid.Column="0" Text="◀" Command="{Binding PrevEpisodeCommand}"
+			<Button Grid.Column="0" Text="◀" Command="{Binding PrevEpisodeCommand}"
                     BackgroundColor="Transparent" TextColor="White" />
-            <Label Grid.Column="1" Text="{Binding EpisodeTitle}" TextColor="White"
+			<Label Grid.Column="1" Text="{Binding EpisodeTitle}" TextColor="White"
                    FontSize="14" VerticalOptions="Center" HorizontalTextAlignment="Center"
                    LineBreakMode="TailTruncation" />
-            <Button Grid.Column="2" Text="目次" Command="{Binding NavigateToTocCommand}"
+			<Button Grid.Column="2" Text="★" Command="{Binding ToggleFavoriteCommand}"
+                    BackgroundColor="Transparent"
+                    TextColor="{Binding IsCurrentEpisodeFavorite, Converter={StaticResource BoolToGoldConverter}}" />
+			<Button Grid.Column="3" Text="目次" Command="{Binding NavigateToTocCommand}"
                     BackgroundColor="Transparent" TextColor="White" />
-        </Grid>
+		</Grid>
 
-        <!-- Loading -->
-        <ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
+		<!-- Loading -->
+		<ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
-        <!-- Content -->
-        <ScrollView Grid.Row="1" x:Name="ContentScrollView" Scrolled="OnScrolled">
-            <Label Text="{Binding EpisodeContent}" Padding="16"
+		<!-- Content (horizontal - Label) -->
+		<ScrollView Grid.Row="1" x:Name="ContentScrollView" Scrolled="OnScrolled"
+                    IsVisible="{Binding IsHorizontal}">
+			<Label Text="{Binding EpisodeContent}" Padding="16"
                    FontSize="{Binding FontSize}"
                    LineHeight="{Binding LineHeight}"
                    TextColor="{Binding TextColor}" />
-        </ScrollView>
+		</ScrollView>
 
-        <!-- Footer -->
-        <Grid Grid.Row="2" Padding="8" BackgroundColor="#80000000"
+		<!-- Content (vertical writing - WebView) -->
+		<WebView Grid.Row="1" x:Name="VerticalWebView"
+                 IsVisible="{Binding IsVerticalWriting}"
+                 Navigating="OnWebViewNavigating" />
+
+		<!-- Footer -->
+		<Grid Grid.Row="2" Padding="8" BackgroundColor="#80000000"
               ColumnDefinitions="*,*,*"
               IsVisible="{Binding IsFooterVisible}">
-            <Button Grid.Column="0" Text="目次" Command="{Binding NavigateToTocCommand}"
+			<Button Grid.Column="0" Text="目次" Command="{Binding NavigateToTocCommand}"
                     BackgroundColor="Transparent" TextColor="White" />
-            <Button Grid.Column="1" Text="◀ 前へ" Command="{Binding PrevEpisodeCommand}"
+			<Button Grid.Column="1" Text="◀ 前へ" Command="{Binding PrevEpisodeCommand}"
                     BackgroundColor="Transparent" TextColor="White" />
-            <Button Grid.Column="2" Text="次へ ▶" Command="{Binding NextEpisodeCommand}"
+			<Button Grid.Column="2" Text="次へ ▶" Command="{Binding NextEpisodeCommand}"
                     BackgroundColor="Transparent" TextColor="White" />
-        </Grid>
-    </Grid>
+		</Grid>
+	</Grid>
 </ContentPage>

--- a/_Apps/Views/ReaderPage.xaml.cs
+++ b/_Apps/Views/ReaderPage.xaml.cs
@@ -10,15 +10,35 @@ public partial class ReaderPage : ContentPage
     {
         InitializeComponent();
         BindingContext = _viewModel = viewModel;
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ReaderViewModel.EpisodeHtml) or nameof(ReaderViewModel.IsVerticalWriting))
+        {
+            if (_viewModel.IsVerticalWriting && !string.IsNullOrEmpty(_viewModel.EpisodeHtml))
+            {
+                VerticalWebView.Source = new HtmlWebViewSource { Html = _viewModel.EpisodeHtml };
+            }
+        }
     }
 
     private async void OnScrolled(object? sender, ScrolledEventArgs e)
     {
         if (sender is not ScrollView scrollView) return;
 
-        // Check if scrolled to bottom (within 10px tolerance)
         if (scrollView.ScrollY + scrollView.Height >= scrollView.ContentSize.Height - 10)
         {
+            await _viewModel.MarkAsReadCommand.ExecuteAsync(null);
+        }
+    }
+
+    private async void OnWebViewNavigating(object? sender, WebNavigatingEventArgs e)
+    {
+        if (e.Url?.StartsWith("lanobe://read-end", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            e.Cancel = true;
             await _viewModel.MarkAsReadCommand.ExecuteAsync(null);
         }
     }

--- a/_Apps/Views/SearchPage.xaml
+++ b/_Apps/Views/SearchPage.xaml
@@ -12,16 +12,67 @@
 		<converters:InverseBoolConverter x:Key="InverseBool" />
 	</ContentPage.Resources>
 
-	<Grid RowDefinitions="Auto,Auto,*">
-		<!-- Search bar -->
-		<Grid Grid.Row="0" Padding="8" ColumnDefinitions="*,Auto">
-			<Entry Grid.Column="0" Placeholder="タイトル・作者名で検索"
-                   Text="{Binding SearchKeyword}" ReturnCommand="{Binding SearchCommand}" />
-			<Button Grid.Column="1" Text="検索" Command="{Binding SearchCommand}" Margin="4,0,0,0" />
+	<Grid RowDefinitions="Auto,Auto,Auto,*">
+		<!-- Mode tabs -->
+		<HorizontalStackLayout Grid.Row="0" Padding="8,4" Spacing="6">
+			<Button Text="検索" Command="{Binding SetModeKeywordCommand}" FontSize="12" HeightRequest="36" />
+			<Button Text="ランキング" Command="{Binding SetModeRankingCommand}" FontSize="12" HeightRequest="36" />
+			<Button Text="ジャンル" Command="{Binding SetModeGenreCommand}" FontSize="12" HeightRequest="36" />
+		</HorizontalStackLayout>
+
+		<!-- Mode-specific inputs -->
+		<Grid Grid.Row="1" Padding="8,0">
+			<!-- Keyword mode -->
+			<Grid IsVisible="{Binding IsKeywordMode}" ColumnDefinitions="*,Auto">
+				<Entry Grid.Column="0" Placeholder="タイトル・作者名で検索"
+                       Text="{Binding SearchKeyword}" ReturnCommand="{Binding SearchCommand}" />
+				<Button Grid.Column="1" Text="検索" Command="{Binding SearchCommand}" Margin="4,0,0,0" />
+			</Grid>
+
+			<!-- Ranking mode -->
+			<VerticalStackLayout IsVisible="{Binding IsRankingMode}" Spacing="6">
+				<HorizontalStackLayout Spacing="8">
+					<Label Text="期間:" VerticalOptions="Center" />
+					<Picker SelectedIndex="{Binding RankingPeriodIndex}">
+						<Picker.Items>
+							<x:String>日間</x:String>
+							<x:String>週間</x:String>
+							<x:String>月間</x:String>
+							<x:String>四半期</x:String>
+						</Picker.Items>
+					</Picker>
+				</HorizontalStackLayout>
+				<HorizontalStackLayout Spacing="8">
+					<Label Text="なろう大ジャンル:" VerticalOptions="Center" />
+					<Picker ItemsSource="{Binding NarouBigGenres, x:DataType=vm:SearchViewModel}" ItemDisplayBinding="{Binding Name}"
+                            SelectedItem="{Binding SelectedNarouBigGenre}" />
+				</HorizontalStackLayout>
+				<HorizontalStackLayout Spacing="8">
+					<Label Text="カクヨムジャンル:" VerticalOptions="Center" />
+					<Picker ItemsSource="{Binding KakuyomuGenreList}" ItemDisplayBinding="{Binding Name}"
+                            SelectedItem="{Binding SelectedKakuyomuGenre}" />
+				</HorizontalStackLayout>
+				<Button Text="ランキング取得" Command="{Binding FetchRankingCommand}" />
+			</VerticalStackLayout>
+
+			<!-- Genre mode -->
+			<VerticalStackLayout IsVisible="{Binding IsGenreMode}" Spacing="6">
+				<HorizontalStackLayout Spacing="8">
+					<Label Text="なろう大ジャンル:" VerticalOptions="Center" />
+					<Picker ItemsSource="{Binding NarouBigGenres}" ItemDisplayBinding="{Binding Name}"
+                            SelectedItem="{Binding SelectedNarouBigGenre}" />
+				</HorizontalStackLayout>
+				<HorizontalStackLayout Spacing="8">
+					<Label Text="カクヨムジャンル:" VerticalOptions="Center" />
+					<Picker ItemsSource="{Binding KakuyomuGenreList}" ItemDisplayBinding="{Binding Name}"
+                            SelectedItem="{Binding SelectedKakuyomuGenre}" />
+				</HorizontalStackLayout>
+				<Button Text="ジャンル別取得" Command="{Binding FetchGenreCommand}" />
+			</VerticalStackLayout>
 		</Grid>
 
 		<!-- Site filters -->
-		<HorizontalStackLayout Grid.Row="1" Padding="8,0" Spacing="16">
+		<HorizontalStackLayout Grid.Row="2" Padding="8,0" Spacing="16">
 			<HorizontalStackLayout Spacing="4">
 				<CheckBox IsChecked="{Binding SearchNarou}" />
 				<Label Text="なろう" VerticalOptions="Center" />
@@ -32,21 +83,13 @@
 			</HorizontalStackLayout>
 		</HorizontalStackLayout>
 
-		<Grid Grid.Row="2">
-			<!-- Loading indicator -->
+		<Grid Grid.Row="3">
 			<ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                                HorizontalOptions="Center" VerticalOptions="Center" />
 
-			<!-- Error message -->
 			<Label Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
                    TextColor="Red" Padding="16" FontSize="14" />
 
-			<!-- Empty state -->
-			<Label Text="見つかりませんでした" FontSize="16"
-                   HorizontalOptions="Center" VerticalOptions="Center"
-                   IsVisible="False" x:Name="EmptyLabel" />
-
-			<!-- Search results -->
 			<CollectionView ItemsSource="{Binding SearchResults}" SelectionMode="None">
 				<CollectionView.ItemTemplate>
 					<DataTemplate x:DataType="vm:SearchResultViewModel">
@@ -58,19 +101,12 @@
 								<RoundRectangle CornerRadius="10" />
 							</Border.StrokeShape>
 							<Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto">
-								<!-- Title -->
 								<Label Grid.Row="0" Grid.Column="0" Text="{Binding Title}"
                                        FontSize="15" FontAttributes="Bold" LineBreakMode="TailTruncation" />
-
-								<!-- Site badge -->
 								<Label Grid.Row="0" Grid.Column="1" Text="{Binding SiteTypeLabel}"
                                        FontSize="11" TextColor="Gray" VerticalOptions="Center" />
-
-								<!-- Author -->
 								<Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
                                        Text="{Binding Author}" FontSize="12" TextColor="Gray" />
-
-								<!-- Info row -->
 								<HorizontalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Spacing="12">
 									<Label Text="{Binding TotalEpisodes, StringFormat='{0}話'}" FontSize="12" />
 									<Label Text="完結" FontSize="11" TextColor="Green"
@@ -78,8 +114,6 @@
 									<Label Text="連載中" FontSize="11" TextColor="Orange"
                                            IsVisible="{Binding IsCompleted, Converter={StaticResource InverseBool}}" />
 								</HorizontalStackLayout>
-
-								<!-- Register button -->
 								<Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,8,0,0">
 									<Button Text="登録"
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SearchViewModel}}, Path=RegisterCommand, x:DataType=vm:SearchViewModel}"

--- a/_Apps/Views/SettingsPage.xaml
+++ b/_Apps/Views/SettingsPage.xaml
@@ -81,6 +81,34 @@
                     <RadioButton Content="広" GroupName="Spacing"
                                  CheckedChanged="OnSpacingChanged" x:Name="SpacingWide" />
                 </HorizontalStackLayout>
+
+                <!-- Vertical writing -->
+                <HorizontalStackLayout Spacing="8" Margin="0,8,0,0">
+                    <Switch IsToggled="{Binding VerticalWriting}" />
+                    <Label Text="縦書き表示" FontSize="14" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
+
+            <BoxView HeightRequest="1" Color="LightGray" />
+
+            <!-- Network / Prefetch settings -->
+            <VerticalStackLayout Spacing="8">
+                <Label Text="通信設定" FontSize="18" FontAttributes="Bold" />
+
+                <HorizontalStackLayout Spacing="8">
+                    <Switch IsToggled="{Binding PrefetchEnabled}" />
+                    <Label Text="Wi-Fi接続時にバックグラウンド先読みする" FontSize="13" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+                <Label FontSize="11" TextColor="Gray"
+                       Text="モバイル通信時は常に先読みしません" />
+
+                <Label FontSize="14" Margin="0,8,0,0">
+                    <Label.Text>
+                        <Binding Path="RequestDelayMs" StringFormat="リクエスト間ディレイ: {0}ms" />
+                    </Label.Text>
+                </Label>
+                <Slider Minimum="500" Maximum="2000" Value="{Binding RequestDelayMs}"
+                        ThumbColor="{AppThemeBinding Light=#6200EE, Dark=#BB86FC}" />
             </VerticalStackLayout>
 
             <BoxView HeightRequest="1" Color="LightGray" />


### PR DESCRIPTION
## Summary
[_Apps/Features/plan_2026-04-07_feature-expansion.md](_Apps/Features/plan_2026-04-07_feature-expansion.md) の S1〜S7 を実装。

- **S1 NetworkPolicyService**: Narou/Kakuyomu の HTTP をサイト別 SemaphoreSlim で直列化＋800msディレイ (設定で500–2000ms可変)
- **S2 BackgroundJobQueue + PrefetchService**: Wi-Fi接続時のみ稼働、モバイル通信時は完全停止 (固定)、切断時自動pause/再接続レジューム、連続5失敗で中断
- **S3 お気に入り (作品+話)**: novels/episodes に列追加、PRAGMA+ALTER 簡易マイグレーション。NovelList/EpisodeList/Reader の各画面に★UI
- **S4 小説一覧ソート**: 8種類 (更新日時新旧/タイトル昇降/作者/登録日/未読数/お気に入り優先)
- **S5 一括ダウンロード**: 手動ボタン + 登録直後/更新検出時/起動時スキャンで自動キューイング
- **S6 縦書き表示**: 横書き=Label / 縦書き=WebView のハイブリッド。writing-mode: vertical-rl + JS Bridge で既読検知 (lanobe://read-end)
- **S7 ランキング/ジャンルブラウズ**: なろう (公式API、ハイフン結合で詳細一括取得) ＋カクヨム (HTMLスクレイピング) 両対応。SearchPage に3モードタブ追加

## 副次修正
- DB初期化を idempotent な Task キャッシュ化 (DatabaseService.EnsureInitializedAsync)。各 Repository が自動で初期化を待機するため、ページ描画と DB 初期化の競合 (no such table: app_settings) を解消

## Test plan
- [ ] 既存DBから起動 → ALTER TABLE で is_favorite/favorited_at 列が追加されること
- [ ] NovelList: 並び替え ActionSheet で各ソートが効くこと
- [ ] NovelList: SwipeView の★切替で永続化されること
- [ ] EpisodeList: 一括DL ボタンで全話キューイングされること、●インジケータ表示
- [ ] EpisodeList: ★/未読のみフィルタが効くこと、各話の★トグルが永続化されること
- [ ] Reader: 縦書きSwitch ON で WebView に切り替わり、左端まで読むと既読化
- [ ] Reader: ヘッダの★ボタンで現在話のお気に入りトグル
- [ ] Search: ランキングタブで なろう+カクヨム の結果が並ぶこと
- [ ] Search: ジャンルタブで 大ジャンル選択結果が出ること
- [ ] モバイル通信時は Prefetch ジョブが走らないこと
- [ ] 設定: ディレイ・先読みON/OFF・縦書き が永続化されること