### PR TITLE
perf: データ層パフォーマンス改善 (H1 + H5)

### DIFF
--- a/_Apps/Features/audit_2026-04-08_apps-refactor.md
+++ b/_Apps/Features/audit_2026-04-08_apps-refactor.md
@@ -1,0 +1,123 @@
+# _Apps 改善課題一覧（2026-04-08 監査）
+
+作成日: 2026-04-08
+対象: `_Apps`（LanobeReader, .NET MAUI Android, app-novelviewer ブランチ）
+位置づけ: 個別 PR プラン（`plan_2026-04-08_*.md` 等）から参照される**マスター課題リスト**。各項目は ID で参照する。
+
+構成: ViewModels 7 / Views 5 / Services 12（DB4・API4・Background3・Network1）/ Models 8 / Converters 5 / Helpers 4、総行数 約 3,946 行 / 55 ファイル。
+
+---
+
+## High（優先度・高）
+
+### H1. NovelListViewModel の N+1 クエリ
+- **箇所**: [NovelListViewModel.cs:51-71](../ViewModels/NovelListViewModel.cs#L51-L71), [EpisodeRepository.cs:43-47](../Services/Database/EpisodeRepository.cs#L43-L47)
+- **現状**: `GetAllAsync(SortKey)` 後に novel ごとに `CountUnreadByNovelIdAsync` を await ループで呼び出し、SQL が `1 + N` 回発行される。
+- **改善案**: Repository に `GetAllWithUnreadCountAsync` を追加し、LEFT JOIN + GROUP BY で 1 クエリ化。
+- **担当 PR**: PR2（plan_2026-04-08_pr2-data-performance.md）
+
+### H2. ReaderPage コードビハインドの MVVM 違反
+- **箇所**: [ReaderPage.xaml.cs:16-24](../Views/ReaderPage.xaml.cs#L16-L24)
+- **現状**: ViewModel の PropertyChanged を直接購読し WebView.Source を命令的に差し替え。テスト困難。
+- **改善案**: WebView 用の `HtmlSource` AttachedBehavior を作り XAML バインドで完結。
+- **担当 PR**: PR3 予定
+
+### H3. SettingsPage のラジオボタン初期化の命令的処理
+- **箇所**: [SettingsPage.xaml.cs:22-46](../Views/SettingsPage.xaml.cs#L22-L46)
+- **現状**: `_initialized` フラグ + switch で状態復元、ラジオ変更イベントをコードビハインドで処理。
+- **改善案**: VM に `SelectedThemeIndex` を追加、`IntToBoolConverter` + ConverterParameter で XAML バインドに統一、コードビハインド全削除。
+- **担当 PR**: PR4 予定
+
+### H4. ReaderViewModel / ReaderHtmlBuilder の全文 HTML 再生成
+- **箇所**: [ReaderHtmlBuilder.cs:10-50](../Helpers/ReaderHtmlBuilder.cs#L10-L50), [ReaderViewModel.cs:130-132](../ViewModels/ReaderViewModel.cs#L130-L132)
+- **現状**: フォントサイズ・行間・テーマ変更のたびに本文全文を再ビルドし WebView 再ロード。長編で UI ブロック。
+- **改善案**: 本文 HTML は 1 回のみ生成、`:root{--font-size:…}` 等の CSS 変数で保持、設定変更時は `webview.Eval` で CSS 変数だけ差し替え。
+- **担当 PR**: PR3 予定
+
+### H5. EpisodeListViewModel のフィルタ＆ページング重複計算
+- **箇所**: [EpisodeListViewModel.cs:125-155](../ViewModels/EpisodeListViewModel.cs#L125-L155)
+- **現状**: `FilteredEpisodes()` が遅延列挙で `RecalcPaging` と `LoadPageAsync` の両方から毎回呼ばれ、同じ LINQ が 2 回実行される。
+- **改善案**: `_filteredCache: List<Episode>` を導入、フィルタ条件変化時のみ再構築、ページ送りはキャッシュ参照のみ。
+- **担当 PR**: PR2（plan_2026-04-08_pr2-data-performance.md）
+
+### H6. SearchViewModel の逐次実行＆エラー状態書き換え
+- **箇所**: [SearchViewModel.cs:115-174](../ViewModels/SearchViewModel.cs#L115-L174)
+- **現状**: Narou → Kakuyomu を順次 await。`HasError` が後段で上書きされる可能性。
+- **改善案**: `Task.WhenAll` で並列化、結果を `(hits, errors)` の構造体に集約、エラーは改行連結。
+- **担当 PR**: PR4 予定
+
+### H7. BackgroundJobQueue の重複抑止の競合余地
+- **箇所**: [BackgroundJobQueue.cs:51-62](../Services/Background/BackgroundJobQueue.cs#L51-L62)
+- **現状**: HashSet + lock。処理中例外で `_enqueuedEpisodeIds` から Remove されない経路の懸念。
+- **改善案**: `finally` での Remove 確実化、`ConcurrentDictionary<long,byte>` 化。
+- **担当 PR**: 未定（後続）
+
+---
+
+## Medium（優先度・中）
+
+### M1. Converter 乱立
+- **箇所**: `_Apps/Converters/` 配下 5 ファイル（BoolToGold / BoolToGray / HasValue / InverseBool / IntToBool）
+- **改善案**: `GenericBoolConverter`（`TrueValue` / `FalseValue` プロパティ）に統合。
+
+### M2. マジックナンバー散在
+- **箇所**: `ReaderHtmlBuilder`（色コード）、`NarouApiService`（件数・タイムアウト）、`BackgroundJobQueue`（バッチ間隔）
+- **改善案**: `AppConstants.cs` または `SettingsKeys.cs` に集約。配色は `Resources/Styles/Colors.xaml`。
+
+### M3. App.xaml.cs 初期化の `_ = Task.Run(...)` 散発
+- **箇所**: [App.xaml.cs:60-102](../App.xaml.cs#L60-L102)
+- **改善案**: `IAppInitializer` サービスに集約、必須/非必須で段階分け、失敗時 UI 通知。
+
+### M4. NovelCardViewModel と検索結果カードの重複
+- **箇所**: `ViewModels/NovelCardViewModel.cs`, 検索結果カード VM
+- **改善案**: `ItemCardViewModelBase` を抽出、差分プロパティのみ派生側で保持。
+
+### M5. Repository の EnsureAsync ボイラープレート
+- **箇所**: `_Apps/Services/Database/*Repository.cs` 各メソッド冒頭の `await EnsureAsync()`
+- **改善案**: `RepositoryBase` に初期化ゲートを実装、派生側は本体処理のみに。
+- **関連**: この整理に合わせて `EpisodeRepository.CountUnreadByNovelIdAsync`（H1 対応後に dead code 化）の削除を検討。
+
+### M6. IQueryAttributable の型安全性
+- **箇所**: [ReaderViewModel.cs:96-104](../ViewModels/ReaderViewModel.cs#L96-L104), [EpisodeListViewModel.cs:74-81](../ViewModels/EpisodeListViewModel.cs#L74-L81)
+- **改善案**: `record ReaderRouteArgs(...)` 等のラッパー + 拡張メソッドで吸収。
+
+---
+
+## Low（優先度・低）
+
+### L1. Styles.xaml の被覆不足
+- **箇所**: [Styles.xaml](../Resources/Styles/Styles.xaml)
+- **現状**: Card / Status ラベルはあるが Entry / Picker / CheckBox 未整備。
+
+### L2. XAML の GestureRecognizer 重複
+- **箇所**: Views/*.xaml
+- **改善案**: ControlTemplate / Attached Behavior で再利用化。
+
+### L3. NovelRepository.GetAllAsync のオーバーロード
+- **箇所**: [NovelRepository.cs:17-41](../Services/Database/NovelRepository.cs#L17-L41)
+- **改善案**: デフォルト引数で 1 本化。
+
+### L5. 生 SQL での `SELECT *` / `SELECT n.*` 使用
+- **箇所**:
+  - [NovelRepository.cs:33](../Services/Database/NovelRepository.cs#L33) — `unread_desc` ソートの `SELECT n.* FROM novels n ...`
+  - [NovelRepository.cs:37](../Services/Database/NovelRepository.cs#L37) — `favorite_first` ソートの `SELECT * FROM novels ...`
+  - [EpisodeRepository.cs:33](../Services/Database/EpisodeRepository.cs#L33) — `GetPagedByNovelIdAsync` の `SELECT * FROM episodes ...`
+- **現状**: 列順序依存・将来の列追加時に sqlite-net のマッピングが暗黙的に壊れる恐れがある（エラーにならず値が欠落するため検知が遅れる）。
+- **改善案**: PR2 で新設する `GetAllWithUnreadCountAsync` と同じく、`Models/Novel.cs` / `Models/Episode.cs` の `[Column]` 宣言に対応する列を明示列挙する。SQL は長くなるが、スキーマ変更時にコンパイラは助けてくれないので明示の方が安全。
+- **担当 PR**: 未定（PR2 のスコープ外 — 既存 `GetAllAsync` 温存方針と矛盾するため混ぜない。`EpisodeRepository.GetPagedByNovelIdAsync` も現時点で呼び出し元は限定的なので後続の Repository 整理 PR でまとめて対応）。
+
+### L4. TBirdObject 継承規則準拠チェック
+- **箇所**: `_Apps/Services/` 配下の Dispose が必要なサービス
+- **改善案**: `DisposeManagedResource` / `DisposeUnmanagedResource` override 準拠を再確認（CLAUDE.md 共通ルール）。
+
+---
+
+## PR 分割状況
+
+| PR | 対応項目 | プランファイル |
+|---|---|---|
+| PR1 | Converter 土台整理（完了） | - |
+| PR2 | H1, H5 | plan_2026-04-08_pr2-data-performance.md |
+| PR3（予定） | H2, H4 | 未作成 |
+| PR4（予定） | H3, H6 | 未作成 |
+| 未定 | H7, M*, L* | 上記 PR 後に必要性を再評価 |

--- a/_Apps/Features/plan_2026-04-08_pr2-data-performance.md
+++ b/_Apps/Features/plan_2026-04-08_pr2-data-performance.md
@@ -1,0 +1,668 @@
+# PR2: データ層パフォーマンス改善（H1 + H5）
+
+作成日: 2026-04-08
+対象ブランチ: `app-novelviewer` から派生する作業ブランチ（例: `feature/pr2-data-perf-20260408`）
+前提: PR1（未コミット変更の確定 / Converter 整理の土台）はマージ済み
+
+このドキュメントは **追加調査なしで別セッションが実装可能** なレベルを目標に書かれている。必要な型情報・スキーマ・呼び出し元・DI 構成・完成形コードをすべて含む。
+
+---
+
+関連: 全課題マスター一覧は [audit_2026-04-08_apps-refactor.md](audit_2026-04-08_apps-refactor.md) を参照。本 PR は H1 / H5 に対応する。
+
+## 0. 目的
+
+`_Apps`（LanobeReader, .NET MAUI Android）のデータ取得処理における 2 点のパフォーマンス問題を解消する。
+
+- **H1**: `NovelListViewModel.LoadNovelsAsync` の N+1 クエリ解消
+- **H5**: `EpisodeListViewModel` のフィルタ＆ページング重複 LINQ の解消
+
+UI/XAML・ナビゲーション・Search/Reader/Settings には一切手を入れない。変更は Repository 1 本 + ViewModel 2 本のみに閉じる。
+
+---
+
+## 1. 事前に把握しておくべき事実（調査済み）
+
+### 1.1 DB スキーマ（確認済み）
+
+#### `novels` テーブル — `Models/Novel.cs`
+| 列名 | C# プロパティ | 型 | 備考 |
+|---|---|---|---|
+| `id` | `Id` | int | PK, AutoIncrement |
+| `site_type` | `SiteType` | int | |
+| `novel_id` | `NovelId` | string | サイト側 ID |
+| `title` | `Title` | string | |
+| `author` | `Author` | string | |
+| `total_episodes` | `TotalEpisodes` | int | |
+| `is_completed` | `IsCompleted` | int | 0/1 |
+| `last_updated_at` | `LastUpdatedAt` | string? | ISO 8601 |
+| `registered_at` | `RegisteredAt` | string | ISO 8601 |
+| `has_unconfirmed_update` | `HasUnconfirmedUpdate` | int | 0/1 |
+| `has_check_error` | `HasCheckError` | int | 0/1 |
+| `is_favorite` | `IsFavorite` | int | 0/1 |
+| `favorited_at` | `FavoritedAt` | string? | |
+
+`SiteTypeEnum` は `[Ignore]` プロパティなので DB マッピング対象外。
+
+#### `episodes` テーブル — `Models/Episode.cs`
+主要列のみ: `id`, `novel_id`, `episode_no`, `chapter_name`, `title`, `is_read` (0/1), `read_at`, `published_at`, `is_favorite` (0/1), `favorited_at`。`novel_id` に `idx_episodes_novel_id` インデックスあり。
+
+### 1.2 sqlite-net のカラムマッピング仕様
+
+`sqlite-net-pcl` の `QueryAsync<T>` は、SELECT 結果の**列名**と `T` の `[Column("xxx")]` 属性を照合してマッピングする。既定では大文字小文字を区別しない。`T` に存在しない列は無視される。したがって:
+
+- `Novel` 派生クラスに `[Column("unread_count")] int UnreadCount` を追加した型を用意し、`SELECT n.*, ... AS unread_count` で一括マッピングできる。
+- 派生クラスを別テーブルとして扱わせないため、クラスに `[Table]` 属性は付けない。`QueryAsync<T>` は `[Table]` 不要で動作する（`Table<T>()` LINQ API とは異なる）。
+
+### 1.3 既存の `NovelRepository.GetAllAsync` 呼び出し元（Grep 済み）
+
+| ファイル | 呼び方 | 用途 | 本 PR で影響 |
+|---|---|---|---|
+| `ViewModels/NovelListViewModel.cs:55` | `GetAllAsync(SortKey)` | 一覧表示 | **差し替え対象** |
+| `Services/UpdateCheckService.cs:39` | `GetAllAsync()`（引数なし） | 更新チェック巡回 | **温存** |
+| `Services/Background/PrefetchService.cs:64` | `GetAllAsync()`（引数なし） | バックグラウンド取得 | **温存** |
+
+→ 既存の `GetAllAsync()` / `GetAllAsync(string)` は**削除せず温存**する。新メソッドを追加するのみ。
+
+### 1.4 `EpisodeRepository.CountUnreadByNovelIdAsync` の参照（Grep 済み）
+
+`NovelListViewModel.cs:60` 以外で使われていない。本 PR で唯一の呼び出し元が消えるが、**メソッド自体は残す**（スコープ最小化）。
+
+### 1.5 `NovelListViewModel` 内での `_episodeRepo` 使用箇所（Grep 済み）
+
+- `:13` フィールド宣言
+- `:26` コンストラクタ代入
+- `:60` `CountUnreadByNovelIdAsync` 呼び出し
+
+→ `:60` を消すと `_episodeRepo` は完全未使用になる。コンストラクタ引数ごと**削除**する。
+
+### 1.6 DI 構成（`MauiProgram.cs:52` 確認済み）
+
+```csharp
+builder.Services.AddTransient<NovelListViewModel>();
+```
+
+コンテナは MS.DI の自動コンストラクタ解決。コンストラクタから `EpisodeRepository` を外しても**他の登録変更は不要**。
+
+### 1.7 `NovelCardViewModel.FromModel` のシグネチャ（確認済み）
+
+```csharp
+public static NovelCardViewModel FromModel(Novel novel, int unreadCount)
+```
+
+引数に `Novel` インスタンスと未読数の `int` を受ける。既存のまま使える。
+
+### 1.8 既存 `GetAllAsync(sortKey)` の ORDER BY 対応表（`NovelRepository.cs:22-41` より）
+
+| sortKey | ORDER BY（移植先で再現すべき順序） |
+|---|---|
+| `updated_desc` （既定） | `n.last_updated_at DESC` |
+| `updated_asc` | `n.last_updated_at ASC` |
+| `title_asc` | `n.title ASC` |
+| `title_desc` | `n.title DESC` |
+| `author_asc` | `n.author ASC` |
+| `registered_desc` | `n.registered_at DESC` |
+| `unread_desc` | `unread_count DESC, n.last_updated_at DESC`（既存のサブクエリ版と同結果） |
+| `favorite_first` | `n.is_favorite DESC, n.last_updated_at DESC` |
+
+> 注: sqlite-net の `Table<T>().OrderBy(x => x.Title)` は SQL 化時に大小文字を気にしない `COLLATE NOCASE` を**付けない**。生 SQL 移植版も `COLLATE` 指定なしで揃え、順序の差異をなくす。
+
+---
+
+## 2. 変更対象ファイル（全 3 ファイル）
+
+1. `_Apps/Services/Database/NovelRepository.cs`  — メソッド 1 個追加、内部 row 型 1 個追加、`record` 1 個追加
+2. `_Apps/ViewModels/NovelListViewModel.cs`  — `LoadNovelsAsync` 書き換え、`EpisodeRepository` 依存削除
+3. `_Apps/ViewModels/EpisodeListViewModel.cs`  — フィルタキャッシュ導入、`FilteredEpisodes()` 削除
+
+**触らないファイル**: View/XAML、Converters、Styles、Search/Reader/Settings 系、Services/Background、Models、MauiProgram.cs、EpisodeRepository.cs。
+
+---
+
+## 3. 実装詳細
+
+### 3.1 `NovelRepository.cs` の変更
+
+#### 3.1.1 追加する型（ファイル末尾、`NovelRepository` クラスの**外**、同一名前空間内）
+
+```csharp
+// using LanobeReader.Models; は既に using 済み
+
+/// <summary>
+/// 小説と未読話数をひとまとめにした DTO。
+/// H1 対応で N+1 を解消するための集約クエリ戻り値。
+/// </summary>
+public sealed record NovelWithUnread(Novel Novel, int UnreadCount);
+```
+
+#### 3.1.2 追加する内部クラス（`NovelRepository` クラス**内**、private）
+
+```csharp
+// sqlite-net は [Column] 属性で列マッピングするため、Novel を継承して
+// 未読数列だけ拡張する。[Table] は付けない（QueryAsync<T> では不要）。
+private sealed class NovelWithUnreadRow : Novel
+{
+    [SQLite.Column("unread_count")]
+    public int UnreadCount { get; set; }
+}
+```
+
+#### 3.1.3 追加するメソッド（`GetAllAsync(string sortKey)` の直後に配置）
+
+```csharp
+public async Task<List<NovelWithUnread>> GetAllWithUnreadCountAsync(string sortKey)
+{
+    await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+
+    // novels の全列を明示列挙 + 未読数を 1 クエリで取得。
+    // LEFT JOIN により episodes が 0 件の小説も unread_count = 0 で返る。
+    // `n.*` は使わない（カラム順序依存やスキーマ変更時の破損を避けるため）。
+    // 列は Models/Novel.cs の [Column] 宣言と 1 対 1 対応させる。
+    const string baseSql =
+        "SELECT " +
+        "  n.id, " +
+        "  n.site_type, " +
+        "  n.novel_id, " +
+        "  n.title, " +
+        "  n.author, " +
+        "  n.total_episodes, " +
+        "  n.is_completed, " +
+        "  n.last_updated_at, " +
+        "  n.registered_at, " +
+        "  n.has_unconfirmed_update, " +
+        "  n.has_check_error, " +
+        "  n.is_favorite, " +
+        "  n.favorited_at, " +
+        "  COALESCE(u.cnt, 0) AS unread_count " +
+        "FROM novels n " +
+        "LEFT JOIN (" +
+        "    SELECT novel_id, COUNT(*) AS cnt " +
+        "    FROM episodes " +
+        "    WHERE is_read = 0 " +
+        "    GROUP BY novel_id" +
+        ") u ON u.novel_id = n.id ";
+
+    string orderBy = sortKey switch
+    {
+        "updated_asc"     => "ORDER BY n.last_updated_at ASC",
+        "title_asc"       => "ORDER BY n.title ASC",
+        "title_desc"      => "ORDER BY n.title DESC",
+        "author_asc"      => "ORDER BY n.author ASC",
+        "registered_desc" => "ORDER BY n.registered_at DESC",
+        "unread_desc"     => "ORDER BY unread_count DESC, n.last_updated_at DESC",
+        "favorite_first"  => "ORDER BY n.is_favorite DESC, n.last_updated_at DESC",
+        _                 => "ORDER BY n.last_updated_at DESC", // updated_desc / 未知キー
+    };
+
+    var rows = await _db.QueryAsync<NovelWithUnreadRow>(baseSql + orderBy)
+        .ConfigureAwait(false);
+
+    var result = new List<NovelWithUnread>(rows.Count);
+    foreach (var r in rows)
+    {
+        // Novel 部分のコピー（派生クラスインスタンスをそのまま外に出さない）
+        var novel = new Novel
+        {
+            Id = r.Id,
+            SiteType = r.SiteType,
+            NovelId = r.NovelId,
+            Title = r.Title,
+            Author = r.Author,
+            TotalEpisodes = r.TotalEpisodes,
+            IsCompleted = r.IsCompleted,
+            LastUpdatedAt = r.LastUpdatedAt,
+            RegisteredAt = r.RegisteredAt,
+            HasUnconfirmedUpdate = r.HasUnconfirmedUpdate,
+            HasCheckError = r.HasCheckError,
+            IsFavorite = r.IsFavorite,
+            FavoritedAt = r.FavoritedAt,
+        };
+        result.Add(new NovelWithUnread(novel, r.UnreadCount));
+    }
+    return result;
+}
+```
+
+> **実装メモ**: `NovelWithUnreadRow` はそのまま `Novel` としてキャストして返すのではなく、値をコピーした新 `Novel` を作って返す。理由は (a) 派生クラスが外部に漏れるのを防ぐ (b) `NovelWithUnread.Novel` の型契約を厳格にする。件数規模（最大数百件想定）からコピーコストは無視できる。
+
+#### 3.1.4 既存メソッドの扱い
+
+- `GetAllAsync()` / `GetAllAsync(string sortKey)`: **温存**（UpdateCheckService, PrefetchService が使用中）
+- 他メソッド: 変更なし
+
+---
+
+### 3.2 `NovelListViewModel.cs` の変更
+
+#### 3.2.1 コンストラクタから `EpisodeRepository` を削除
+
+**Before**:
+```csharp
+private readonly NovelRepository _novelRepo;
+private readonly EpisodeRepository _episodeRepo;
+private readonly EpisodeCacheRepository _cacheRepo;
+private readonly AppSettingsRepository _settingsRepo;
+private readonly UpdateCheckService _updateCheckService;
+
+public NovelListViewModel(
+    NovelRepository novelRepo,
+    EpisodeRepository episodeRepo,
+    EpisodeCacheRepository cacheRepo,
+    AppSettingsRepository settingsRepo,
+    UpdateCheckService updateCheckService)
+{
+    _novelRepo = novelRepo;
+    _episodeRepo = episodeRepo;
+    _cacheRepo = cacheRepo;
+    _settingsRepo = settingsRepo;
+    _updateCheckService = updateCheckService;
+}
+```
+
+**After**:
+```csharp
+private readonly NovelRepository _novelRepo;
+private readonly EpisodeCacheRepository _cacheRepo;
+private readonly AppSettingsRepository _settingsRepo;
+private readonly UpdateCheckService _updateCheckService;
+
+public NovelListViewModel(
+    NovelRepository novelRepo,
+    EpisodeCacheRepository cacheRepo,
+    AppSettingsRepository settingsRepo,
+    UpdateCheckService updateCheckService)
+{
+    _novelRepo = novelRepo;
+    _cacheRepo = cacheRepo;
+    _settingsRepo = settingsRepo;
+    _updateCheckService = updateCheckService;
+}
+```
+
+> DI は `MauiProgram.cs:52` で `AddTransient<NovelListViewModel>()` として自動解決されるため、登録側の変更は不要。
+
+#### 3.2.2 `LoadNovelsAsync` の書き換え
+
+**Before** (`:51-71`):
+```csharp
+private async Task LoadNovelsAsync()
+{
+    try
+    {
+        var novels = await _novelRepo.GetAllAsync(SortKey);
+        var cards = new List<NovelCardViewModel>();
+
+        foreach (var novel in novels)
+        {
+            var unread = await _episodeRepo.CountUnreadByNovelIdAsync(novel.Id);
+            cards.Add(NovelCardViewModel.FromModel(novel, unread));
+        }
+
+        Novels = new ObservableCollection<NovelCardViewModel>(cards);
+        HasCheckError = novels.Any(n => n.HasCheckError == 1);
+    }
+    catch (Exception ex)
+    {
+        LogHelper.Error(nameof(NovelListViewModel), $"LoadNovelsAsync failed: {ex.Message}");
+    }
+}
+```
+
+**After**:
+```csharp
+private async Task LoadNovelsAsync()
+{
+    try
+    {
+        var rows = await _novelRepo.GetAllWithUnreadCountAsync(SortKey);
+        Novels = new ObservableCollection<NovelCardViewModel>(
+            rows.Select(r => NovelCardViewModel.FromModel(r.Novel, r.UnreadCount)));
+        HasCheckError = rows.Any(r => r.Novel.HasCheckError == 1);
+    }
+    catch (Exception ex)
+    {
+        LogHelper.Error(nameof(NovelListViewModel), $"LoadNovelsAsync failed: {ex.Message}");
+    }
+}
+```
+
+#### 3.2.3 using 文の整理
+
+`LanobeReader.Services.Database` は引き続き必要（`NovelRepository` / `EpisodeCacheRepository` / `AppSettingsRepository`）。**削除する using はなし**。
+
+---
+
+### 3.3 `EpisodeListViewModel.cs` の変更
+
+#### 3.3.1 フィールド追加
+
+`:19-21` の既存フィールド群の直後に追加:
+
+```csharp
+private int _novelDbId;
+private List<Episode> _allEpisodes = new();
+private HashSet<int> _cachedIds = new();
+// ↓ 追加
+private List<Episode> _filteredCache = new(); // ShowUnreadOnly / ShowFavoritesOnly 適用済みキャッシュ
+```
+
+> `_allEpisodes` と `_filteredCache` は Episode への参照を共有するため追加メモリは参照分のみ。
+
+#### 3.3.2 `FilteredEpisodes()` を削除し、`RebuildFilterCache()` に置き換え
+
+**Before** (`:125-131`):
+```csharp
+private IEnumerable<Episode> FilteredEpisodes()
+{
+    IEnumerable<Episode> src = _allEpisodes;
+    if (ShowUnreadOnly) src = src.Where(e => e.IsRead == 0);
+    if (ShowFavoritesOnly) src = src.Where(e => e.IsFavorite == 1);
+    return src;
+}
+```
+
+**After**:
+```csharp
+private void RebuildFilterCache()
+{
+    IEnumerable<Episode> src = _allEpisodes;
+    if (ShowUnreadOnly) src = src.Where(e => e.IsRead == 0);
+    if (ShowFavoritesOnly) src = src.Where(e => e.IsFavorite == 1);
+    _filteredCache = src.ToList();
+}
+```
+
+#### 3.3.3 `ApplyFilterAndShow` の変更
+
+**Before** (`:133-137`):
+```csharp
+private void ApplyFilterAndShow()
+{
+    Episodes = new ObservableCollection<EpisodeViewModel>(
+        FilteredEpisodes().Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id))));
+}
+```
+
+**After**:
+```csharp
+private void ApplyFilterAndShow()
+{
+    Episodes = new ObservableCollection<EpisodeViewModel>(
+        _filteredCache.Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id))));
+}
+```
+
+#### 3.3.4 `RecalcPaging` の変更
+
+**Before** (`:139-144`):
+```csharp
+private void RecalcPaging()
+{
+    var totalCount = FilteredEpisodes().Count();
+    MaxPage = Math.Max(1, (int)Math.Ceiling((double)totalCount / _episodesPerPage));
+    if (CurrentPage > MaxPage) CurrentPage = MaxPage;
+}
+```
+
+**After**:
+```csharp
+private void RecalcPaging()
+{
+    var totalCount = _filteredCache.Count;
+    MaxPage = Math.Max(1, (int)Math.Ceiling((double)totalCount / _episodesPerPage));
+    if (CurrentPage > MaxPage) CurrentPage = MaxPage;
+}
+```
+
+#### 3.3.5 `LoadPageAsync` の変更
+
+**Before** (`:146-155`):
+```csharp
+private Task LoadPageAsync()
+{
+    var list = FilteredEpisodes()
+        .Skip((CurrentPage - 1) * _episodesPerPage)
+        .Take(_episodesPerPage)
+        .Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)))
+        .ToList();
+    Episodes = new ObservableCollection<EpisodeViewModel>(list);
+    return Task.CompletedTask;
+}
+```
+
+**After**:
+```csharp
+private Task LoadPageAsync()
+{
+    var list = _filteredCache
+        .Skip((CurrentPage - 1) * _episodesPerPage)
+        .Take(_episodesPerPage)
+        .Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)))
+        .ToList();
+    Episodes = new ObservableCollection<EpisodeViewModel>(list);
+    return Task.CompletedTask;
+}
+```
+
+#### 3.3.6 `InitializeAsync` への `RebuildFilterCache()` 差し込み
+
+**Before** (`:83-123` の該当部分抜粋):
+```csharp
+_allEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
+_cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(_novelDbId);
+
+var hasChapters = _allEpisodes.Any(e => e.ChapterName is not null);
+```
+
+**After**:
+```csharp
+_allEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
+_cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(_novelDbId);
+RebuildFilterCache(); // ← 追加（_allEpisodes 代入直後）
+
+var hasChapters = _allEpisodes.Any(e => e.ChapterName is not null);
+```
+
+#### 3.3.7 `ReloadListAsync` への `RebuildFilterCache()` 差し込み
+
+**Before** (`:160-172`):
+```csharp
+private async Task ReloadListAsync()
+{
+    if (HasChapters)
+    {
+        ApplyFilterAndShow();
+    }
+    else
+    {
+        CurrentPage = 1;
+        RecalcPaging();
+        await LoadPageAsync();
+    }
+}
+```
+
+**After**:
+```csharp
+private async Task ReloadListAsync()
+{
+    RebuildFilterCache(); // ← ShowUnreadOnly / ShowFavoritesOnly 変更時の再計算はここだけ
+    if (HasChapters)
+    {
+        ApplyFilterAndShow();
+    }
+    else
+    {
+        CurrentPage = 1;
+        RecalcPaging();
+        await LoadPageAsync();
+    }
+}
+```
+
+#### 3.3.8 `ToggleEpisodeFavoriteAsync` の同期
+
+お気に入りを外した際、`ShowFavoritesOnly == true` だとキャッシュから該当要素を除く必要がある。
+
+**Before** (`:196-205`):
+```csharp
+[RelayCommand]
+private async Task ToggleEpisodeFavoriteAsync(EpisodeViewModel ep)
+{
+    var newValue = !ep.IsFavorite;
+    await _episodeRepo.SetFavoriteAsync(ep.Id, newValue);
+    ep.IsFavorite = newValue;
+
+    var source = _allEpisodes.FirstOrDefault(e => e.Id == ep.Id);
+    if (source is not null) source.IsFavorite = newValue ? 1 : 0;
+}
+```
+
+**After**:
+```csharp
+[RelayCommand]
+private async Task ToggleEpisodeFavoriteAsync(EpisodeViewModel ep)
+{
+    var newValue = !ep.IsFavorite;
+    await _episodeRepo.SetFavoriteAsync(ep.Id, newValue);
+    ep.IsFavorite = newValue;
+
+    var source = _allEpisodes.FirstOrDefault(e => e.Id == ep.Id);
+    if (source is not null) source.IsFavorite = newValue ? 1 : 0;
+
+    // ShowFavoritesOnly 時は外した要素を表示から除く必要があるため再構築。
+    // それ以外のフィルタ状態ではキャッシュ内容は不変なので何もしない。
+    if (ShowFavoritesOnly)
+    {
+        RebuildFilterCache();
+        if (HasChapters)
+        {
+            ApplyFilterAndShow();
+        }
+        else
+        {
+            RecalcPaging();
+            await LoadPageAsync();
+        }
+    }
+}
+```
+
+> **注**: 既読トグル系のコマンドは現状存在しない（Reader 側で `is_read` を更新）。`ShowUnreadOnly` のキャッシュ同期は画面遷移後の `InitializeAsync` 再実行で担保される（`EpisodeListPage` が `AddTransient` で都度生成される MAUI の挙動に依存）。別セッションで既読トグル機能を追加する場合は同様のキャッシュ同期を組み込むこと。
+
+---
+
+## 4. 完成形コードの配置マップ
+
+| 項目 | 配置場所 |
+|---|---|
+| `NovelWithUnread` record | `NovelRepository.cs`、名前空間直下、クラス外 |
+| `NovelWithUnreadRow` 内部クラス | `NovelRepository.cs`、クラス内 private |
+| `GetAllWithUnreadCountAsync` | `NovelRepository.cs`、`GetAllAsync(string)` の直後 |
+| `RebuildFilterCache` | `EpisodeListViewModel.cs`、旧 `FilteredEpisodes()` と同じ位置 |
+| `_filteredCache` フィールド | `EpisodeListViewModel.cs`、`_cachedIds` の直後 |
+
+---
+
+## 5. ビルド・動作確認手順
+
+### 5.1 ビルド
+```bash
+dotnet build /c/Work/Github/TBird.Library/_Apps/App.sln --no-restore
+```
+- 警告ゼロであること
+- `EpisodeRepository` を削除した影響で `CS0246` 等が出ないこと（`using` は残したまま OK）
+
+### 5.2 手動チェックリスト
+
+#### 小説一覧（H1 検証）
+- [ ] 8 種のソートキーすべてで一覧が表示される
+- [ ] 既存の `GetAllAsync(sortKey)` と**同一の並び順**になる（切替前のブランチでスクリーンショット取得 → 比較）
+- [ ] 未読話数バッジが従来と一致（3〜5 件の小説で目視比較）
+- [ ] `unread_desc` でも一致（既存はサブクエリ版 `(SELECT COUNT(*) FROM episodes ...)` だったが LEFT JOIN + GROUP BY でも結果は同じ）
+- [ ] 登録 0 話の小説（新規追加直後など）が `unread_count = 0` で表示される（LEFT JOIN + COALESCE の確認）
+- [ ] リフレッシュ（更新チェック）→ リスト再読込が正常
+- [ ] お気に入りトグル後、`favorite_first` ソート時にリストが更新される
+
+#### エピソード一覧（H5 検証）
+- [ ] 章ありタイトルで全話表示
+- [ ] 章なしタイトルで前/次ページボタンが正常に動作
+- [ ] ページ送りで `MaxPage` が変わらないこと（フィルタ未変更時にキャッシュが維持されることの裏付け）
+- [ ] 「未読のみ」ON/OFF で表示が切り替わる
+- [ ] 「お気に入りのみ」ON/OFF で表示が切り替わる
+- [ ] 「お気に入りのみ」ON のときに表示中エピソードのお気に入りを外す → 即座にリストから消える
+- [ ] 長編（500 話以上）でページ送りの体感が改善している
+
+### 5.3 パフォーマンス実測（任意）
+
+Android 実機で Stopwatch ログを仕込んで before/after を比較すると効果が定量化できる（ログは PR に含めない）。
+
+---
+
+## 6. リスク一覧と対策
+
+| # | リスク | 発生箇所 | 対策 |
+|---|---|---|---|
+| R1 | sqlite-net のカラムマッピングずれで `UnreadCount` が常に 0 / 列追加時にクエリが壊れる | `GetAllWithUnreadCountAsync` | SELECT で `n.*` を**使わず**全列を明示列挙する（§3.1.3 参照）。`[Column("unread_count")]` と SQL の `AS unread_count` を一致させる。将来 `novels` に列が追加されたらこの SQL にも追記する |
+| R2 | `unread_desc` の順序が既存と微妙にズレる | 同 | 既存はサブクエリ版で `ORDER BY (SELECT COUNT(*) ...) DESC, n.last_updated_at DESC`。新版も `unread_count DESC, n.last_updated_at DESC` で揃える。Null タイブレークは `last_updated_at` が `NULL` の行がある場合 SQLite 既定で NULL 最小扱い、既存と同じ挙動 |
+| R3 | タイトル/著者ソートで大小文字順序が変わる | 同 | 既存の LINQ 版も `COLLATE` 指定なし → 新版も付けない |
+| R4 | `_filteredCache` が古い状態のまま UI に反映 | `EpisodeListViewModel` | 再構築呼び出しを `InitializeAsync` / `ReloadListAsync` / `ToggleEpisodeFavoriteAsync (ShowFavoritesOnly時)` の 3 箇所に限定し列挙済み |
+| R5 | `NovelListViewModel` のコンストラクタ引数削除で他所の手動 new がコンパイルエラー | - | Grep で `new NovelListViewModel(` を検索し、ヒットがないことを確認（DI 経由のみ想定） |
+| R6 | `EpisodeRepository` の `CountUnreadByNovelIdAsync` が dead code になる | - | 今回は温存。削除は Repository 基底クラス整理（[audit_2026-04-08_apps-refactor.md](audit_2026-04-08_apps-refactor.md) の M5）に合わせて後続 PR で検討 |
+
+### 事前に走らせる Grep（実装セッション開始時の最終確認）
+
+```text
+pattern: new NovelListViewModel\(
+path:    c:\Work\Github\TBird.Library\_Apps
+期待:    ヒットなし（DI 解決のみ）
+
+pattern: CountUnreadByNovelIdAsync
+path:    c:\Work\Github\TBird.Library\_Apps
+期待:    EpisodeRepository.cs:43 の宣言のみ（呼び出し元消滅）
+```
+
+---
+
+## 7. コミット分割方針
+
+レビュー容易性のため 3 コミットに分割する。
+
+1. **`refactor(NovelRepository): add GetAllWithUnreadCountAsync for H1`**
+   - `NovelRepository.cs` のみ変更
+   - この時点でビルドは通る（新メソッド追加のみ、既存メソッドは未削除）
+
+2. **`perf(NovelListViewModel): use aggregated query to remove N+1 (H1)`**
+   - `NovelListViewModel.cs` の `LoadNovelsAsync` 差し替え
+   - `EpisodeRepository` 依存削除（コンストラクタ、フィールド）
+   - 手動チェック: 一覧表示・ソート
+
+3. **`perf(EpisodeListViewModel): cache filtered episodes (H5)`**
+   - `EpisodeListViewModel.cs` のフィルタキャッシュ導入
+   - 手動チェック: ページング・フィルタトグル
+
+---
+
+## 8. スコープ外（やらないこと）
+
+- H2 ReaderPage コードビハインド除去
+- H3 SettingsPage 状態管理
+- H4 Reader の CSS 変数化
+- H6 SearchViewModel 並列化
+- H7 BackgroundJobQueue 競合安全化
+- Medium / Low 以下のすべて
+- `EpisodeRepository.CountUnreadByNovelIdAsync` の削除
+- `NovelRepository.GetAllAsync` の既存オーバーロード削除
+- `MauiProgram.cs` の DI 設定変更
+- テストコードの追加（プロジェクトにテスト基盤なし）
+
+---
+
+## 9. 完了条件（Definition of Done）
+
+1. 変更は 3 ファイルのみ（`git diff --stat` で確認）
+2. `dotnet build` が警告ゼロ
+3. §5.2 手動チェックリスト全通過
+4. 3 コミット構成
+5. PR 本文に本ファイル（`_Apps/Features/plan_2026-04-08_pr2-data-performance.md`）へのリンクと「H1/H5 対応」の明記
+6. PR 対象ブランチは `app-novelviewer`（`_Apps` 配下のファイルは `app-novelviewer` にしか存在しないため、CLAUDE.md のブランチ選定ルールに従い base = `app-novelviewer`）

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -3,8 +3,16 @@ using SQLite;
 
 namespace LanobeReader.Services.Database;
 
+public sealed record NovelWithUnread(Novel Novel, int UnreadCount);
+
 public class NovelRepository
 {
+    private sealed class NovelWithUnreadRow : Novel
+    {
+        [SQLite.Column("unread_count")]
+        public int UnreadCount { get; set; }
+    }
+
     private readonly SQLiteAsyncConnection _db;
     private readonly DatabaseService _dbService;
 
@@ -38,6 +46,73 @@ public class NovelRepository
             ).ConfigureAwait(false),
             _ => await _db.Table<Novel>().OrderByDescending(n => n.LastUpdatedAt).ToListAsync().ConfigureAwait(false),
         };
+    }
+
+    public async Task<List<NovelWithUnread>> GetAllWithUnreadCountAsync(string sortKey)
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+
+        const string baseSql =
+            "SELECT " +
+            "  n.id, " +
+            "  n.site_type, " +
+            "  n.novel_id, " +
+            "  n.title, " +
+            "  n.author, " +
+            "  n.total_episodes, " +
+            "  n.is_completed, " +
+            "  n.last_updated_at, " +
+            "  n.registered_at, " +
+            "  n.has_unconfirmed_update, " +
+            "  n.has_check_error, " +
+            "  n.is_favorite, " +
+            "  n.favorited_at, " +
+            "  COALESCE(u.cnt, 0) AS unread_count " +
+            "FROM novels n " +
+            "LEFT JOIN (" +
+            "    SELECT novel_id, COUNT(*) AS cnt " +
+            "    FROM episodes " +
+            "    WHERE is_read = 0 " +
+            "    GROUP BY novel_id" +
+            ") u ON u.novel_id = n.id ";
+
+        string orderBy = sortKey switch
+        {
+            "updated_asc"     => "ORDER BY n.last_updated_at ASC",
+            "title_asc"       => "ORDER BY n.title ASC",
+            "title_desc"      => "ORDER BY n.title DESC",
+            "author_asc"      => "ORDER BY n.author ASC",
+            "registered_desc" => "ORDER BY n.registered_at DESC",
+            "unread_desc"     => "ORDER BY unread_count DESC, n.last_updated_at DESC",
+            "favorite_first"  => "ORDER BY n.is_favorite DESC, n.last_updated_at DESC",
+            _                 => "ORDER BY n.last_updated_at DESC",
+        };
+
+        var rows = await _db.QueryAsync<NovelWithUnreadRow>(baseSql + orderBy)
+            .ConfigureAwait(false);
+
+        var result = new List<NovelWithUnread>(rows.Count);
+        foreach (var r in rows)
+        {
+            var novel = new Novel
+            {
+                Id = r.Id,
+                SiteType = r.SiteType,
+                NovelId = r.NovelId,
+                Title = r.Title,
+                Author = r.Author,
+                TotalEpisodes = r.TotalEpisodes,
+                IsCompleted = r.IsCompleted,
+                LastUpdatedAt = r.LastUpdatedAt,
+                RegisteredAt = r.RegisteredAt,
+                HasUnconfirmedUpdate = r.HasUnconfirmedUpdate,
+                HasCheckError = r.HasCheckError,
+                IsFavorite = r.IsFavorite,
+                FavoritedAt = r.FavoritedAt,
+            };
+            result.Add(new NovelWithUnread(novel, r.UnreadCount));
+        }
+        return result;
     }
 
     public async Task<Novel?> GetByIdAsync(int id)

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -19,6 +19,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
     private int _novelDbId;
     private List<Episode> _allEpisodes = new();
     private HashSet<int> _cachedIds = new();
+    private List<Episode> _filteredCache = new();
 
     public EpisodeListViewModel(
         NovelRepository novelRepo,
@@ -92,6 +93,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
 
             _allEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
             _cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(_novelDbId);
+            RebuildFilterCache();
 
             var hasChapters = _allEpisodes.Any(e => e.ChapterName is not null);
             var lastRead = await _episodeRepo.GetLastReadEpisodeAsync(_novelDbId);
@@ -122,30 +124,30 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         }
     }
 
-    private IEnumerable<Episode> FilteredEpisodes()
+    private void RebuildFilterCache()
     {
         IEnumerable<Episode> src = _allEpisodes;
         if (ShowUnreadOnly) src = src.Where(e => e.IsRead == 0);
         if (ShowFavoritesOnly) src = src.Where(e => e.IsFavorite == 1);
-        return src;
+        _filteredCache = src.ToList();
     }
 
     private void ApplyFilterAndShow()
     {
         Episodes = new ObservableCollection<EpisodeViewModel>(
-            FilteredEpisodes().Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id))));
+            _filteredCache.Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id))));
     }
 
     private void RecalcPaging()
     {
-        var totalCount = FilteredEpisodes().Count();
+        var totalCount = _filteredCache.Count;
         MaxPage = Math.Max(1, (int)Math.Ceiling((double)totalCount / _episodesPerPage));
         if (CurrentPage > MaxPage) CurrentPage = MaxPage;
     }
 
     private Task LoadPageAsync()
     {
-        var list = FilteredEpisodes()
+        var list = _filteredCache
             .Skip((CurrentPage - 1) * _episodesPerPage)
             .Take(_episodesPerPage)
             .Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)))
@@ -159,6 +161,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
 
     private async Task ReloadListAsync()
     {
+        RebuildFilterCache();
         if (HasChapters)
         {
             ApplyFilterAndShow();
@@ -202,6 +205,20 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
 
         var source = _allEpisodes.FirstOrDefault(e => e.Id == ep.Id);
         if (source is not null) source.IsFavorite = newValue ? 1 : 0;
+
+        if (ShowFavoritesOnly)
+        {
+            RebuildFilterCache();
+            if (HasChapters)
+            {
+                ApplyFilterAndShow();
+            }
+            else
+            {
+                RecalcPaging();
+                await LoadPageAsync();
+            }
+        }
     }
 
     [RelayCommand]

--- a/_Apps/ViewModels/NovelListViewModel.cs
+++ b/_Apps/ViewModels/NovelListViewModel.cs
@@ -10,20 +10,17 @@ namespace LanobeReader.ViewModels;
 public partial class NovelListViewModel : ObservableObject
 {
     private readonly NovelRepository _novelRepo;
-    private readonly EpisodeRepository _episodeRepo;
     private readonly EpisodeCacheRepository _cacheRepo;
     private readonly AppSettingsRepository _settingsRepo;
     private readonly UpdateCheckService _updateCheckService;
 
     public NovelListViewModel(
         NovelRepository novelRepo,
-        EpisodeRepository episodeRepo,
         EpisodeCacheRepository cacheRepo,
         AppSettingsRepository settingsRepo,
         UpdateCheckService updateCheckService)
     {
         _novelRepo = novelRepo;
-        _episodeRepo = episodeRepo;
         _cacheRepo = cacheRepo;
         _settingsRepo = settingsRepo;
         _updateCheckService = updateCheckService;
@@ -52,17 +49,10 @@ public partial class NovelListViewModel : ObservableObject
     {
         try
         {
-            var novels = await _novelRepo.GetAllAsync(SortKey);
-            var cards = new List<NovelCardViewModel>();
-
-            foreach (var novel in novels)
-            {
-                var unread = await _episodeRepo.CountUnreadByNovelIdAsync(novel.Id);
-                cards.Add(NovelCardViewModel.FromModel(novel, unread));
-            }
-
-            Novels = new ObservableCollection<NovelCardViewModel>(cards);
-            HasCheckError = novels.Any(n => n.HasCheckError == 1);
+            var rows = await _novelRepo.GetAllWithUnreadCountAsync(SortKey);
+            Novels = new ObservableCollection<NovelCardViewModel>(
+                rows.Select(r => NovelCardViewModel.FromModel(r.Novel, r.UnreadCount)));
+            HasCheckError = rows.Any(r => r.Novel.HasCheckError == 1);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
計画書: [_Apps/Features/plan_2026-04-08_pr2-data-performance.md](_Apps/Features/plan_2026-04-08_pr2-data-performance.md)

- **H1**: `NovelListViewModel.LoadNovelsAsync` の N+1 クエリを解消。`NovelRepository.GetAllWithUnreadCountAsync` を新設し、`LEFT JOIN` + `GROUP BY` で未読数を 1 クエリで集約取得。
- **H5**: `EpisodeListViewModel` のフィルタ＆ページング処理における重複 LINQ 列挙を解消。`_filteredCache` を導入し、フィルタ状態変更時にのみ再構築。

## 変更ファイル (3)
- `_Apps/Services/Database/NovelRepository.cs` — `NovelWithUnread` record / `GetAllWithUnreadCountAsync` 追加
- `_Apps/ViewModels/NovelListViewModel.cs` — 新メソッド利用に差替え、`EpisodeRepository` 依存削除
- `_Apps/ViewModels/EpisodeListViewModel.cs` — `_filteredCache` 導入、`FilteredEpisodes()` 削除

## 設計メモ
- `NovelRepository.GetAllAsync` の既存オーバーロードは温存（`UpdateCheckService` / `PrefetchService` が使用中）
- `EpisodeRepository.CountUnreadByNovelIdAsync` は dead code 化するが削除は後続 PR (audit の M5) に委ねる
- SELECT は `n.*` を使わず全列明示列挙（スキーマ変更時の破損回避）
- 既存ソートキー 8 種の順序を完全再現（`COLLATE` 指定なしで揃え）

## Test plan
- [x] `dotnet build _Apps/App.sln` — エラー 0（警告は既存 XAML のみ）
- [x] `new NovelListViewModel(` のヒットなし（DI 経由のみ）
- [x] `CountUnreadByNovelIdAsync` 呼び出し元消滅（宣言のみ残存）
- [ ] 小説一覧: 8 種ソートキーで表示確認
- [ ] 小説一覧: 未読バッジが従来と一致
- [ ] 小説一覧: 0 話小説が `unread_count=0` で表示
- [ ] 小説一覧: `favorite_first` でお気に入りトグル反映
- [ ] エピソード一覧: 章あり/章なしでの表示とページング
- [ ] エピソード一覧: 「未読のみ」「お気に入りのみ」ON/OFF
- [ ] エピソード一覧: お気に入り解除時の即時反映（`ShowFavoritesOnly` ON）
- [ ] エピソード一覧: 長編でのページ送り体感改善