### PR TITLE
refactor(Reader): CSS custom properties + ReaderWebView binding (H2/H4)

### DIFF
--- a/_Apps/Controls/ReaderWebView.cs
+++ b/_Apps/Controls/ReaderWebView.cs
@@ -1,0 +1,36 @@
+namespace LanobeReader.Controls;
+
+/// <summary>
+/// Reader 画面の縦書き表示用 WebView。
+/// HtmlSource (string) を bind すると HTML を再ロードする。
+/// プロパティ変更通知は UI スレッドからのみ発生する前提で実装している
+/// （MAUI の BindableProperty 既定動作）。
+/// 将来、CSS 変数のライブ差し替え用 CssVariables Bindable を追加する予定
+/// （plan_2026-04-09_pr3b-reader-live-css.md）。
+/// </summary>
+public sealed class ReaderWebView : WebView
+{
+    public static readonly BindableProperty HtmlSourceProperty = BindableProperty.Create(
+        nameof(HtmlSource),
+        typeof(string),
+        typeof(ReaderWebView),
+        default(string),
+        propertyChanged: OnHtmlSourceChanged);
+
+    public string? HtmlSource
+    {
+        get => (string?)GetValue(HtmlSourceProperty);
+        set => SetValue(HtmlSourceProperty, value);
+    }
+
+    private static void OnHtmlSourceChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var self = (ReaderWebView)bindable;
+        var html = newValue as string;
+        if (string.IsNullOrEmpty(html))
+        {
+            return;
+        }
+        self.Source = new HtmlWebViewSource { Html = html };
+    }
+}

--- a/_Apps/Helpers/ReaderCssState.cs
+++ b/_Apps/Helpers/ReaderCssState.cs
@@ -1,0 +1,12 @@
+namespace LanobeReader.Helpers;
+
+/// <summary>
+/// ReaderHtmlBuilder に渡す CSS カスタムプロパティ値のスナップショット。
+/// 将来、ReaderWebView から実行時差し替え用 Bindable としても使えるよう
+/// record の value equality を採用している。
+/// </summary>
+public sealed record ReaderCssState(
+    double FontSizePx,
+    double LineHeight,
+    string BackgroundHex,
+    string ForegroundHex);

--- a/_Apps/Helpers/ReaderHtmlBuilder.cs
+++ b/_Apps/Helpers/ReaderHtmlBuilder.cs
@@ -1,32 +1,39 @@
+using System.Globalization;
 using System.Text;
 
 namespace LanobeReader.Helpers;
 
 /// <summary>
-/// 縦書き WebView 用の HTML 文字列を生成するビルダー。
+/// 縦書き WebView 用の HTML を生成するビルダー。
+/// スタイル値は CSS カスタムプロパティ（--reader-fs 等）に切り出してあり、
+/// 将来 JS から :root の値を書き換えることでライブ反映が可能な構造。
 /// </summary>
 public static class ReaderHtmlBuilder
 {
-    public static string Build(string content, double fontSizePx, double lineHeight, int backgroundTheme)
+    public static string Build(string content, ReaderCssState state)
     {
-        var (bg, fg) = backgroundTheme switch
-        {
-            1 => ("#121212", "#E0E0E0"),
-            2 => ("#F5E6C8", "#3E2C1C"),
-            _ => ("#FFFFFF", "#212121"),
-        };
+        var inv = CultureInfo.InvariantCulture;
+        var sb = new StringBuilder(content.Length + 1024);
 
-        var sb = new StringBuilder();
         sb.Append("<!doctype html><html lang=\"ja\"><head><meta charset=\"utf-8\">");
         sb.Append("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
         sb.Append("<style>");
+        sb.Append(":root{");
+        sb.Append($"--reader-fs:{state.FontSizePx.ToString("0.##", inv)}px;");
+        sb.Append($"--reader-lh:{state.LineHeight.ToString("0.##", inv)};");
+        sb.Append($"--reader-bg:{state.BackgroundHex};");
+        sb.Append($"--reader-fg:{state.ForegroundHex};");
+        sb.Append("}");
         sb.Append("html,body{margin:0;padding:0;height:100%;}");
-        sb.Append($"body{{background:{bg};color:{fg};font-family:serif;");
-        sb.Append($"writing-mode:vertical-rl;-webkit-writing-mode:vertical-rl;");
-        sb.Append($"font-size:{fontSizePx.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)}px;");
-        sb.Append($"line-height:{lineHeight.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)};");
+        sb.Append("body{");
+        sb.Append("background:var(--reader-bg);color:var(--reader-fg);");
+        sb.Append("font-family:serif;");
+        sb.Append("writing-mode:vertical-rl;-webkit-writing-mode:vertical-rl;");
+        sb.Append("font-size:var(--reader-fs);");
+        sb.Append("line-height:var(--reader-lh);");
         sb.Append("padding:16px;box-sizing:border-box;overflow-x:auto;overflow-y:hidden;");
-        sb.Append("-webkit-tap-highlight-color:transparent;}");
+        sb.Append("-webkit-tap-highlight-color:transparent;");
+        sb.Append("}");
         sb.Append("p{margin:0 0 1em 0;text-indent:1em;}");
         sb.Append("</style></head><body>");
 
@@ -37,6 +44,8 @@ public static class ReaderHtmlBuilder
             sb.Append("</p>");
         }
 
+        // 既存の read-end 検知 JS（lanobe://read-end URI 発火）。
+        // OnWebViewNavigating 側と連動しているため変更禁止。
         sb.Append("<script>");
         sb.Append("(function(){var fired=false;function check(){if(fired)return;");
         sb.Append("var el=document.scrollingElement||document.documentElement;");

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -129,8 +129,16 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
 
     private void RefreshHtml()
     {
-        EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, FontSize, LineHeight, _backgroundThemeIndex);
+        var state = new ReaderCssState(
+            FontSizePx: FontSize,
+            LineHeight: LineHeight,
+            BackgroundHex: ColorToHex(BackgroundColor),
+            ForegroundHex: ColorToHex(TextColor));
+        EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, state);
     }
+
+    private static string ColorToHex(Color c) =>
+        $"#{(int)(c.Red * 255):X2}{(int)(c.Green * 255):X2}{(int)(c.Blue * 255):X2}";
 
     private async Task LoadEpisodeAsync(int episodeId)
     {

--- a/_Apps/Views/ReaderPage.xaml
+++ b/_Apps/Views/ReaderPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:LanobeReader.ViewModels"
+             xmlns:controls="clr-namespace:LanobeReader.Controls"
              x:Class="LanobeReader.Views.ReaderPage"
              x:DataType="vm:ReaderViewModel"
              Shell.TabBarIsVisible="False"
@@ -40,9 +41,10 @@
 		</ScrollView>
 
 		<!-- Content (vertical writing - WebView) -->
-		<WebView Grid.Row="1" x:Name="VerticalWebView"
-                 IsVisible="{Binding IsVerticalWriting}"
-                 Navigating="OnWebViewNavigating" />
+		<controls:ReaderWebView Grid.Row="1"
+                                IsVisible="{Binding IsVerticalWriting}"
+                                HtmlSource="{Binding EpisodeHtml}"
+                                Navigating="OnWebViewNavigating" />
 
 		<!-- Footer -->
 		<Grid Grid.Row="2" Padding="8" BackgroundColor="#80000000"

--- a/_Apps/Views/ReaderPage.xaml.cs
+++ b/_Apps/Views/ReaderPage.xaml.cs
@@ -4,24 +4,10 @@ namespace LanobeReader.Views;
 
 public partial class ReaderPage : ContentPage
 {
-    private readonly ReaderViewModel _viewModel;
-
     public ReaderPage(ReaderViewModel viewModel)
     {
         InitializeComponent();
-        BindingContext = _viewModel = viewModel;
-        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
-    }
-
-    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName is nameof(ReaderViewModel.EpisodeHtml) or nameof(ReaderViewModel.IsVerticalWriting))
-        {
-            if (_viewModel.IsVerticalWriting && !string.IsNullOrEmpty(_viewModel.EpisodeHtml))
-            {
-                VerticalWebView.Source = new HtmlWebViewSource { Html = _viewModel.EpisodeHtml };
-            }
-        }
+        BindingContext = viewModel;
     }
 
     private async void OnScrolled(object? sender, ScrolledEventArgs e)
@@ -30,7 +16,10 @@ public partial class ReaderPage : ContentPage
 
         if (scrollView.ScrollY + scrollView.Height >= scrollView.ContentSize.Height - 10)
         {
-            await _viewModel.MarkAsReadCommand.ExecuteAsync(null);
+            if (BindingContext is ReaderViewModel vm)
+            {
+                await vm.MarkAsReadCommand.ExecuteAsync(null);
+            }
         }
     }
 
@@ -39,7 +28,10 @@ public partial class ReaderPage : ContentPage
         if (e.Url?.StartsWith("lanobe://read-end", StringComparison.OrdinalIgnoreCase) == true)
         {
             e.Cancel = true;
-            await _viewModel.MarkAsReadCommand.ExecuteAsync(null);
+            if (BindingContext is ReaderViewModel vm)
+            {
+                await vm.MarkAsReadCommand.ExecuteAsync(null);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Reader（縦書き WebView）画面の H2 + H4（縮退版）リファクタ。

- **H4**: `ReaderHtmlBuilder` の CSS 値を CSS カスタムプロパティ（`--reader-fs`, `--reader-lh`, `--reader-bg`, `--reader-fg`）に切り出し。配色テーブル重複を削除し `ThemeHelper` に一本化。パラメータオブジェクト `ReaderCssState` を導入
- **H2**: `ReaderPage.xaml.cs` の `OnViewModelPropertyChanged` を削除し、カスタムコントロール `ReaderWebView`（`HtmlSource` BindableProperty）による XAML バインドに置き換え

### H4 は縮退版
CSS 変数化 + ThemeHelper 統合まで。ライブ反映経路（`CssVariables` Bindable / `EvaluateJavaScriptAsync` / `partial void OnFontSizeChanged` 等）は [PR3b](https://github.com/twinbird827/TBird.Library/blob/app-novelviewer/_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md) で実装する。

### 変更ファイル（6 ファイル）
| 種類 | パス |
|---|---|
| 新規 | `_Apps/Controls/ReaderWebView.cs` |
| 新規 | `_Apps/Helpers/ReaderCssState.cs` |
| 変更 | `_Apps/Helpers/ReaderHtmlBuilder.cs` |
| 変更 | `_Apps/ViewModels/ReaderViewModel.cs` |
| 変更 | `_Apps/Views/ReaderPage.xaml` |
| 変更 | `_Apps/Views/ReaderPage.xaml.cs` |

### 設計判断
- `Color.ToHex()` は MAUI バージョンにより `#RRGGBB` / `#RRGGBBAA` 形式が変わりうるため、`ColorToHex` で Alpha なし `#RRGGBB` を自前フォーマット
- `OnScrolled` / `OnWebViewNavigating` は Behavior 化せず code-behind に温存（スコープ外）
- code-behind の残ハンドラは `BindingContext is ReaderViewModel vm` パターンで VM 参照

### 関連ドキュメント
- 実装プラン: [`_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md`](https://github.com/twinbird827/TBird.Library/blob/app-novelviewer/_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md)
- 後続プラン: [`_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md`](https://github.com/twinbird827/TBird.Library/blob/app-novelviewer/_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md)

## Test plan
- [ ] 縦書き ON で小説を開く → 縦書き表示される
- [ ] 縦書き OFF で小説を開く → 横書き表示される
- [ ] 3 テーマ（白/ダーク/セピア）の配色が従来と同一
- [ ] フォントサイズ・行間が設定値どおり
- [ ] 縦書きで最後までスクロール → `lanobe://read-end` 発火 → 既読化
- [ ] 横書きで最後までスクロール → `OnScrolled` 発火 → 既読化
- [ ] 次/前エピソード遷移 → 正しく本文が更新される
- [ ] 縦書き ON → OFF → 別エピソード → 再度 ON で新エピソードが正しく表示（古い HTML が残らない）
- [ ] `dotnet build` 警告ゼロ ✅