### PR TITLE
feat(Reader): live CSS update via JS without WebView reload

### DIFF
--- a/_Apps/Controls/ReaderWebView.cs
+++ b/_Apps/Controls/ReaderWebView.cs
@@ -1,21 +1,31 @@
+using System.Diagnostics;
+using System.Globalization;
+using LanobeReader.Helpers;
+
 namespace LanobeReader.Controls;
 
 /// <summary>
 /// Reader 画面の縦書き表示用 WebView。
-/// HtmlSource (string) を bind すると HTML を再ロードする。
-/// プロパティ変更通知は UI スレッドからのみ発生する前提で実装している
-/// （MAUI の BindableProperty 既定動作）。
-/// 将来、CSS 変数のライブ差し替え用 CssVariables Bindable を追加する予定
-/// （plan_2026-04-09_pr3b-reader-live-css.md）。
+///
+/// 本コントロールのプロパティ変更通知は UI スレッドからのみ発生する前提で実装されている
+/// （MAUI の BindableProperty 既定動作）。別スレッドから HtmlSource / CssVariables を
+/// 書き換える場合は呼び出し側で Dispatcher 経由にすること。
 /// </summary>
 public sealed class ReaderWebView : WebView
 {
+    private bool _htmlLoaded;
+    private ReaderCssState? _pendingCss;
+
+    public ReaderWebView()
+    {
+        Navigated += OnNavigated;
+    }
+
+    // --- HtmlSource ---
+
     public static readonly BindableProperty HtmlSourceProperty = BindableProperty.Create(
-        nameof(HtmlSource),
-        typeof(string),
-        typeof(ReaderWebView),
-        default(string),
-        propertyChanged: OnHtmlSourceChanged);
+        nameof(HtmlSource), typeof(string), typeof(ReaderWebView),
+        default(string), propertyChanged: OnHtmlSourceChanged);
 
     public string? HtmlSource
     {
@@ -27,10 +37,70 @@ public sealed class ReaderWebView : WebView
     {
         var self = (ReaderWebView)bindable;
         var html = newValue as string;
-        if (string.IsNullOrEmpty(html))
-        {
-            return;
-        }
+        if (string.IsNullOrEmpty(html)) return;
+
+        // 新しい HTML をロードする直前に、古い document 向けの保留 CSS を破棄する。
+        self._htmlLoaded = false;
+        self._pendingCss = null;
         self.Source = new HtmlWebViewSource { Html = html };
+    }
+
+    // --- CssVariables ---
+
+    public static readonly BindableProperty CssVariablesProperty = BindableProperty.Create(
+        nameof(CssVariables), typeof(ReaderCssState), typeof(ReaderWebView),
+        default(ReaderCssState), propertyChanged: OnCssVariablesChanged);
+
+    public ReaderCssState? CssVariables
+    {
+        get => (ReaderCssState?)GetValue(CssVariablesProperty);
+        set => SetValue(CssVariablesProperty, value);
+    }
+
+    private static void OnCssVariablesChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var self = (ReaderWebView)bindable;
+        if (newValue is not ReaderCssState state) return;
+
+        if (self._htmlLoaded)
+        {
+            _ = self.ApplyCssAsync(state);
+        }
+        else
+        {
+            self._pendingCss = state;
+        }
+    }
+
+    private void OnNavigated(object? sender, WebNavigatedEventArgs e)
+    {
+        if (e.Result != WebNavigationResult.Success) return;
+        _htmlLoaded = true;
+        if (_pendingCss is not null)
+        {
+            var s = _pendingCss;
+            _pendingCss = null;
+            _ = ApplyCssAsync(s);
+        }
+    }
+
+    private async Task ApplyCssAsync(ReaderCssState state)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        var js =
+            "(function(){var s=document.documentElement.style;" +
+            $"s.setProperty('--reader-fs','{state.FontSizePx.ToString("0.##", inv)}px');" +
+            $"s.setProperty('--reader-lh','{state.LineHeight.ToString("0.##", inv)}');" +
+            $"s.setProperty('--reader-bg','{state.BackgroundHex}');" +
+            $"s.setProperty('--reader-fg','{state.ForegroundHex}');" +
+            "})();";
+        try
+        {
+            await EvaluateJavaScriptAsync(js);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[ReaderWebView] ApplyCssAsync failed: {ex}");
+        }
     }
 }

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -72,6 +72,9 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private bool _isHorizontal = true;
 
     [ObservableProperty]
+    private ReaderCssState? _readerCss;
+
+    [ObservableProperty]
     private bool _isCurrentEpisodeFavorite;
 
     [ObservableProperty]
@@ -90,6 +93,19 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         if (value && !string.IsNullOrEmpty(EpisodeContent))
         {
             RefreshHtml();
+        }
+    }
+
+    partial void OnFontSizeChanged(double value) => UpdateCssStateIfReady();
+    partial void OnLineHeightChanged(double value) => UpdateCssStateIfReady();
+    partial void OnBackgroundColorChanged(Color value) => UpdateCssStateIfReady();
+    partial void OnTextColorChanged(Color value) => UpdateCssStateIfReady();
+
+    private void UpdateCssStateIfReady()
+    {
+        if (ReaderCss is not null)
+        {
+            ReaderCss = BuildCssState();
         }
     }
 
@@ -125,17 +141,24 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         LineHeight = lh;
         IsVerticalWriting = vertical == 1;
         IsHorizontal = !IsVerticalWriting;
+        ReaderCss = BuildCssState();
     }
+
+    public Task ReloadSettingsAsync() => LoadSettingsAsync();
 
     private void RefreshHtml()
     {
-        var state = new ReaderCssState(
-            FontSizePx: FontSize,
-            LineHeight: LineHeight,
-            BackgroundHex: ColorToHex(BackgroundColor),
-            ForegroundHex: ColorToHex(TextColor));
+        var state = BuildCssState();
+        // EpisodeHtml 先・ReaderCss 後: 古い document への無駄な JS 適用を防ぐ
         EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, state);
+        ReaderCss = state;
     }
+
+    private ReaderCssState BuildCssState() => new(
+        FontSizePx: FontSize,
+        LineHeight: LineHeight,
+        BackgroundHex: ColorToHex(BackgroundColor),
+        ForegroundHex: ColorToHex(TextColor));
 
     private static string ColorToHex(Color c) =>
         $"#{(int)(c.Red * 255):X2}{(int)(c.Green * 255):X2}{(int)(c.Blue * 255):X2}";

--- a/_Apps/Views/ReaderPage.xaml
+++ b/_Apps/Views/ReaderPage.xaml
@@ -44,6 +44,7 @@
 		<controls:ReaderWebView Grid.Row="1"
                                 IsVisible="{Binding IsVerticalWriting}"
                                 HtmlSource="{Binding EpisodeHtml}"
+                                CssVariables="{Binding ReaderCss}"
                                 Navigating="OnWebViewNavigating" />
 
 		<!-- Footer -->

--- a/_Apps/Views/ReaderPage.xaml.cs
+++ b/_Apps/Views/ReaderPage.xaml.cs
@@ -10,6 +10,15 @@ public partial class ReaderPage : ContentPage
         BindingContext = viewModel;
     }
 
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is ReaderViewModel vm)
+        {
+            _ = vm.ReloadSettingsAsync();
+        }
+    }
+
     private async void OnScrolled(object? sender, ScrolledEventArgs e)
     {
         if (sender is not ScrollView scrollView) return;


### PR DESCRIPTION
## Summary

PR3a で整えた CSS カスタムプロパティ基盤の上に、設定変更時の **WebView リロードなし** ライブ反映経路を実装。

- **`ReaderWebView.CssVariables`** BindableProperty 追加。HTML ロード済みなら `EvaluateJavaScriptAsync` で `:root` の CSS 変数を即時更新、未ロードなら `Navigated` 時に保留適用（`_pendingCss`）
- **`ReaderViewModel.ReaderCss`** ObservableProperty + `partial void On{FontSize|LineHeight|BackgroundColor|TextColor}Changed` 4本で設定変更を検知し `ReaderCss` を自動更新
- **`ReaderPage.OnAppearing`** で `ReloadSettingsAsync` を呼び出し、設定画面から戻った際に変更を反映

### 設計判断
- **方針 B 採用**: `OnAppearing` での設定再読込。Messenger パターンより単純で、Shell 遷移のみの本アプリに適合
- **代入順序**: `RefreshHtml` 内は `EpisodeHtml` → `ReaderCss` の順（古い document への無駄 JS を防止）
- **`_pendingCss` 破棄**: `HtmlSource` 再代入時に `_pendingCss = null` で古い保留を確実にクリア
- **`ApplyCssAsync`** の catch では `Debug.WriteLine` で必ずログ出力（サイレント catch 禁止）
- **`UpdateCssStateIfReady`**: `ReaderCss == null`（初期化フェーズ）では発火しない設計で、`LoadSettingsAsync` 内の順次代入による無駄な中間更新を抑制

### 変更ファイル（4 ファイル）
| 種類 | パス |
|---|---|
| 変更 | `_Apps/Controls/ReaderWebView.cs` |
| 変更 | `_Apps/ViewModels/ReaderViewModel.cs` |
| 変更 | `_Apps/Views/ReaderPage.xaml` |
| 変更 | `_Apps/Views/ReaderPage.xaml.cs` |

### 関連ドキュメント
- 実装プラン: [`_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md`](https://github.com/twinbird827/TBird.Library/blob/app-novelviewer/_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md)
- 前提 PR: PR3a [`_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md`](https://github.com/twinbird827/TBird.Library/blob/app-novelviewer/_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md)

## Test plan
- [ ] 縦書き Reader 表示中 → 設定画面でフォントサイズ変更 → Reader に戻る → スクロール位置が維持されたままフォントサイズが変わっている（リロードなし確認）
- [ ] 同様に行間変更が反映される
- [ ] 同様にテーマ（背景色・文字色）変更が反映される
- [ ] 設定を連続で複数回変更しても正しく反映される
- [ ] 縦書きで別エピソードに遷移した直後にテーマ変更 → 新エピソードに正しく反映される
- [ ] `Debug.WriteLine` の `ApplyCssAsync failed` ログが出ていない
- [ ] PR3a 回帰: 3 テーマの配色・縦書きスクロール既読化・エピソード遷移が正常
- [ ] `dotnet build` 警告ゼロ ✅