### PR TITLE
docs: add PR3a/PR3b reader refactor plans

### DIFF
--- a/_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md
+++ b/_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md
@@ -1,0 +1,536 @@
+# PR3a: Reader 画面リファクタ（H2 + H4 縮退版）
+
+作成日: 2026-04-09
+更新日: 2026-04-09（レビュー反映 — H4 を縮退し JS 経路を PR3b に分離）
+対象ブランチ: `app-novelviewer` から派生する作業ブランチ（例: `feature/pr3a-reader-refactor-20260409`）
+前提: PR2（plan_2026-04-08_pr2-data-performance.md）マージ済み
+関連:
+- 全課題マスター一覧は [audit_2026-04-08_apps-refactor.md](audit_2026-04-08_apps-refactor.md) を参照
+- 本 PR から分離したライブ反映経路は [plan_2026-04-09_pr3b-reader-live-css.md](plan_2026-04-09_pr3b-reader-live-css.md) を参照
+
+このドキュメントは **追加調査なしで別セッションが実装可能** なレベルを目標に書かれている。
+
+---
+
+## 0. 目的とスコープ
+
+Reader（縦書き WebView）画面の以下 2 点を改善する。
+
+- **H2**: `ReaderPage.xaml.cs` のコードビハインドで ViewModel.PropertyChanged を購読し `WebView.Source` を命令的に差し替えている箇所を、カスタムコントロール（`ReaderWebView`）による XAML バインドに置き換える。
+- **H4（縮退版）**: `ReaderHtmlBuilder` が CSS 値（フォントサイズ・行間・配色）を文字列補間で焼き込んでいるのを **CSS カスタムプロパティ（CSS 変数）に切り出す**。同時に `ReaderHtmlBuilder` 内の配色テーブル重複を `ThemeHelper` に一本化する。
+
+### 本 PR では触らない（次 PR に分離）
+
+レビューで「本 PR では動作確認不能なデッドコード」と指摘された以下は **[plan_2026-04-09_pr3b-reader-live-css.md](plan_2026-04-09_pr3b-reader-live-css.md)** に切り出し、設定画面からのライブ反映 UI を実装する PR と同時に導入する:
+
+- `ReaderWebView.CssVariables` Bindable + `EvaluateJavaScriptAsync` による実行時差し替え
+- `_htmlLoaded` / `_pendingCss` 遅延適用フラグ
+- `ReaderViewModel.ReaderCss` ObservableProperty と `partial void OnFontSizeChanged` 等 4 本
+- `UpdateCssStateIfReady` ヘルパ
+
+理由: 現状の `ReaderViewModel` には `FontSize` / `BackgroundColor` 等を**再代入する経路が存在しない**（`LoadSettingsAsync` からの初期化のみ）。上記コードは本 PR では 1 度も発火せず、`ApplyCssAsync` が壊れていてもマージ通過してしまう。
+
+### 本 PR で残す H4 の価値
+- **スタイルとコンテンツの分離**: `ReaderHtmlBuilder` は CSS 変数初期値付きの HTML を生成するだけになり、純粋関数化してテスト容易化
+- **`ThemeHelper` 重複解消**: `ReaderHtmlBuilder` 内の `(bg, fg)` switch を削除
+- **次 PR の土台**: HTML 側に `:root{...}` 定義が入っていれば、後から JS で `--reader-fs` 等を書き換えられる構造が整う
+
+本 PR のスコープは Reader 画面周辺に閉じる。`OnScrolled` / `OnWebViewNavigating` 等の View イベントハンドラ（コードビハインド残存分）は**触らない**。
+
+---
+
+## 1. 事前に把握しておくべき事実（調査済み）
+
+### 1.1 現在の `ReaderPage.xaml.cs` の役割（[ReaderPage.xaml.cs](../Views/ReaderPage.xaml.cs)）
+
+コードビハインドは以下 3 つのハンドラを持つ:
+
+| 行 | ハンドラ | 役割 | 本 PR での扱い |
+|---|---|---|---|
+| `:13` `:16-25` | `OnViewModelPropertyChanged` | `EpisodeHtml` / `IsVerticalWriting` の変化を購読し `VerticalWebView.Source` に HTML を代入 | **削除** |
+| `:27-35` | `OnScrolled` | `ScrollView` のスクロール終端を検知して `MarkAsReadCommand` 実行（横書き時） | **温存** |
+| `:37-44` | `OnWebViewNavigating` | `lanobe://read-end` URI を傍受して `MarkAsReadCommand` 実行（縦書き時） | **温存** |
+
+`OnScrolled` と `OnWebViewNavigating` は Behavior 化することも可能だが別タスク。本 PR では触らない。
+
+### 1.2 現在の `ReaderPage.xaml` の WebView 定義（[ReaderPage.xaml:43-45](../Views/ReaderPage.xaml#L43-L45)）
+
+```xml
+<WebView Grid.Row="1" x:Name="VerticalWebView"
+         IsVisible="{Binding IsVerticalWriting}"
+         Navigating="OnWebViewNavigating" />
+```
+
+`x:Name="VerticalWebView"` は `OnViewModelPropertyChanged` から参照されている（H2 で削除）。`Navigating` イベントは温存するので `x:Name` は削除してよい（コードビハインドからの参照が消えるため）。
+
+### 1.3 現在の `ReaderHtmlBuilder.Build` シグネチャ（[ReaderHtmlBuilder.cs:10](../Helpers/ReaderHtmlBuilder.cs#L10)）
+
+```csharp
+public static string Build(string content, double fontSizePx, double lineHeight, int backgroundTheme)
+```
+
+- `backgroundTheme` から `(bg, fg)` を switch で引く（`ThemeHelper.GetThemeColors` と**重複**）
+- `fontSizePx` / `lineHeight` を `body` の `font-size` / `line-height` に焼き込み
+- `body` 末尾に `lanobe://read-end` 発火用 JS が入っている（**温存必須**、`OnWebViewNavigating` の相方）
+
+### 1.4 `ReaderViewModel` の現在の挙動
+
+- `RefreshHtml()` は `EpisodeHtml` プロパティ（`ObservableProperty`）を更新 → 現状はコードビハインドが拾って WebView.Source 更新
+- `FontSize`, `LineHeight`, `BackgroundColor`, `TextColor`, `IsVerticalWriting` は `[ObservableProperty]`
+- `_backgroundThemeIndex` は `int` フィールド（ObservableProperty ではない）。`LoadSettingsAsync` でのみ代入される
+
+### 1.5 `ThemeHelper.GetThemeColors` との重複（[ThemeHelper.cs:5-10](../Helpers/ThemeHelper.cs#L5-L10)）
+
+`ReaderHtmlBuilder` 内の配色テーブルは `ThemeHelper` と完全に同じ値を保持。マジックナンバー重複。H4 対応のついでに `ReaderHtmlBuilder` 側を `ThemeHelper` に寄せる（配色 switch を削除し、呼び出し元 ViewModel が既に保持している `BackgroundColor`/`TextColor` を Hex に変換して渡す）。
+
+### 1.6 DI 構成（[MauiProgram.cs:55](../MauiProgram.cs#L55)）
+
+`builder.Services.AddTransient<ReaderViewModel>();` — コンストラクタ引数の変更なしで進めるため DI 変更は不要。
+
+---
+
+## 2. 設計：カスタムコントロール `ReaderWebView`
+
+H2 をカバーするために `WebView` を継承したカスタムコントロールを 1 個導入する。Attached Property + Behavior の組み合わせより構造が単純で、責務が 1 クラスに閉じる。
+
+**本 PR 版の `ReaderWebView` は `HtmlSource` 1 つの Bindable しか持たない**。CSS ライブ差し替え用の `CssVariables` Bindable は次 PR で追加する。
+
+### 2.1 公開 BindableProperty
+
+| プロパティ | 型 | 役割 |
+|---|---|---|
+| `HtmlSource` | `string?` | 値が変化したら `this.Source = new HtmlWebViewSource { Html = value }` を実行 |
+
+### 2.2 内部動作
+
+1. `HtmlSource` が変化 → `Source` を再代入 → WebView 再ロード
+2. 空文字/null の場合は何もしない（初期化直後の空値を弾く）
+
+### 2.3 `ReaderCssState` の扱い
+
+CSS 値をまとめて `ReaderHtmlBuilder.Build` に渡すためのパラメータオブジェクトとして `ReaderCssState` record を導入する。**ViewModel 内部でビルダー呼び出し時に生成する局所的な DTO** であり、BindableProperty や ObservableProperty にはしない。
+
+```csharp
+namespace LanobeReader.Helpers;
+
+public sealed record ReaderCssState(
+    double FontSizePx,
+    double LineHeight,
+    string BackgroundHex, // "#RRGGBB"
+    string ForegroundHex);
+```
+
+配置先は `Helpers/`（`ReaderHtmlBuilder` と同じレイヤ）。`Controls/` 配下にすると ViewModel → View の参照が発生しレイヤ逆転するため避ける。
+
+---
+
+## 3. 変更対象ファイル一覧
+
+| 種類 | パス |
+|---|---|
+| 新規 | `_Apps/Controls/ReaderWebView.cs` |
+| 新規 | `_Apps/Helpers/ReaderCssState.cs` |
+| 変更 | `_Apps/Helpers/ReaderHtmlBuilder.cs` |
+| 変更 | `_Apps/ViewModels/ReaderViewModel.cs` |
+| 変更 | `_Apps/Views/ReaderPage.xaml` |
+| 変更 | `_Apps/Views/ReaderPage.xaml.cs` |
+
+**触らない**: MauiProgram.cs、Converters、Styles、他 VM、他 Service、Models、DB。
+
+---
+
+## 4. 実装詳細
+
+### 4.1 `_Apps/Helpers/ReaderCssState.cs`（新規）
+
+```csharp
+namespace LanobeReader.Helpers;
+
+/// <summary>
+/// ReaderHtmlBuilder に渡す CSS カスタムプロパティ値のスナップショット。
+/// 将来、ReaderWebView から実行時差し替え用 Bindable としても使えるよう
+/// record の value equality を採用している。
+/// </summary>
+public sealed record ReaderCssState(
+    double FontSizePx,
+    double LineHeight,
+    string BackgroundHex,
+    string ForegroundHex);
+```
+
+### 4.2 `_Apps/Controls/ReaderWebView.cs`（新規）
+
+```csharp
+namespace LanobeReader.Controls;
+
+/// <summary>
+/// Reader 画面の縦書き表示用 WebView。
+/// HtmlSource (string) を bind すると HTML を再ロードする。
+/// プロパティ変更通知は UI スレッドからのみ発生する前提で実装している
+/// （MAUI の BindableProperty 既定動作）。
+/// 将来、CSS 変数のライブ差し替え用 CssVariables Bindable を追加する予定
+/// （plan_2026-04-09_pr3b-reader-live-css.md）。
+/// </summary>
+public sealed class ReaderWebView : WebView
+{
+    public static readonly BindableProperty HtmlSourceProperty = BindableProperty.Create(
+        nameof(HtmlSource),
+        typeof(string),
+        typeof(ReaderWebView),
+        default(string),
+        propertyChanged: OnHtmlSourceChanged);
+
+    public string? HtmlSource
+    {
+        get => (string?)GetValue(HtmlSourceProperty);
+        set => SetValue(HtmlSourceProperty, value);
+    }
+
+    private static void OnHtmlSourceChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var self = (ReaderWebView)bindable;
+        var html = newValue as string;
+        if (string.IsNullOrEmpty(html))
+        {
+            return;
+        }
+        self.Source = new HtmlWebViewSource { Html = html };
+    }
+}
+```
+
+### 4.3 `_Apps/Helpers/ReaderHtmlBuilder.cs`（全面書き換え）
+
+```csharp
+using System.Globalization;
+using System.Text;
+
+namespace LanobeReader.Helpers;
+
+/// <summary>
+/// 縦書き WebView 用の HTML を生成するビルダー。
+/// スタイル値は CSS カスタムプロパティ（--reader-fs 等）に切り出してあり、
+/// 将来 JS から :root の値を書き換えることでライブ反映が可能な構造。
+/// </summary>
+public static class ReaderHtmlBuilder
+{
+    public static string Build(string content, ReaderCssState state)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        var sb = new StringBuilder(content.Length + 1024);
+
+        sb.Append("<!doctype html><html lang=\"ja\"><head><meta charset=\"utf-8\">");
+        sb.Append("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+        sb.Append("<style>");
+        sb.Append(":root{");
+        sb.Append($"--reader-fs:{state.FontSizePx.ToString("0.##", inv)}px;");
+        sb.Append($"--reader-lh:{state.LineHeight.ToString("0.##", inv)};");
+        sb.Append($"--reader-bg:{state.BackgroundHex};");
+        sb.Append($"--reader-fg:{state.ForegroundHex};");
+        sb.Append("}");
+        sb.Append("html,body{margin:0;padding:0;height:100%;}");
+        sb.Append("body{");
+        sb.Append("background:var(--reader-bg);color:var(--reader-fg);");
+        sb.Append("font-family:serif;");
+        sb.Append("writing-mode:vertical-rl;-webkit-writing-mode:vertical-rl;");
+        sb.Append("font-size:var(--reader-fs);");
+        sb.Append("line-height:var(--reader-lh);");
+        sb.Append("padding:16px;box-sizing:border-box;overflow-x:auto;overflow-y:hidden;");
+        sb.Append("-webkit-tap-highlight-color:transparent;");
+        sb.Append("}");
+        sb.Append("p{margin:0 0 1em 0;text-indent:1em;}");
+        sb.Append("</style></head><body>");
+
+        foreach (var line in content.Split('\n'))
+        {
+            sb.Append("<p>");
+            sb.Append(System.Net.WebUtility.HtmlEncode(line));
+            sb.Append("</p>");
+        }
+
+        // 既存の read-end 検知 JS（lanobe://read-end URI 発火）。
+        // OnWebViewNavigating 側と連動しているため変更禁止。
+        sb.Append("<script>");
+        sb.Append("(function(){var fired=false;function check(){if(fired)return;");
+        sb.Append("var el=document.scrollingElement||document.documentElement;");
+        sb.Append("var maxNeg=-(el.scrollWidth-el.clientWidth);");
+        sb.Append("if(el.scrollLeft<=maxNeg+10){fired=true;location.href='lanobe://read-end';}}");
+        sb.Append("window.addEventListener('scroll',check,{passive:true});setTimeout(check,100);})();");
+        sb.Append("</script>");
+        sb.Append("</body></html>");
+
+        return sb.ToString();
+    }
+}
+```
+
+**変更点サマリ**:
+- シグネチャ `Build(string content, double fontSizePx, double lineHeight, int backgroundTheme)` → `Build(string content, ReaderCssState state)`
+- 配色テーブル削除（`ThemeHelper` に一本化 — 呼び出し元で `ReaderViewModel.BackgroundColor`/`TextColor` を Hex に変換して渡す）
+- CSS 値は全て `var(--reader-*)` 参照、初期値は `:root` ブロックに集約
+- `lanobe://read-end` 発火 JS は**完全温存**
+
+### 4.4 `_Apps/ViewModels/ReaderViewModel.cs`（部分変更）
+
+using は追加不要（`ReaderCssState` は `LanobeReader.Helpers` 配下で、既に `using LanobeReader.Helpers;` 済み）。
+
+#### 4.4.1 `RefreshHtml` を新シグネチャ対応に変更
+
+**Before**:
+```csharp
+private void RefreshHtml()
+{
+    EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, FontSize, LineHeight, _backgroundThemeIndex);
+}
+```
+
+**After**:
+```csharp
+private void RefreshHtml()
+{
+    var state = new ReaderCssState(
+        FontSizePx: FontSize,
+        LineHeight: LineHeight,
+        BackgroundHex: ColorToHex(BackgroundColor),
+        ForegroundHex: ColorToHex(TextColor));
+    EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, state);
+}
+
+private static string ColorToHex(Color c) =>
+    $"#{(int)(c.Red * 255):X2}{(int)(c.Green * 255):X2}{(int)(c.Blue * 255):X2}";
+```
+
+> **注**: `Color.ToHex()` は MAUI バージョンにより `#RRGGBB` / `#RRGGBBAA` の返却形式が変わりうるため、Alpha なし前提で自前フォーマットする。`ThemeHelper.GetThemeColors` が返す 3 色はいずれも不透明のため問題なし。
+
+#### 4.4.2 `_backgroundThemeIndex` フィールドの扱い
+
+`RefreshHtml` 変更後は直接参照しなくなるが、`LoadSettingsAsync` 内で `ThemeHelper.GetThemeColors(_backgroundThemeIndex)` の引数としてまだ使われるので**温存**。
+
+### 4.5 `_Apps/Views/ReaderPage.xaml`（差分）
+
+#### 4.5.1 名前空間追加
+
+`ContentPage` ルート要素に:
+```xml
+xmlns:controls="clr-namespace:LanobeReader.Controls"
+```
+
+#### 4.5.2 WebView の置き換え
+
+**Before**:
+```xml
+<WebView Grid.Row="1" x:Name="VerticalWebView"
+         IsVisible="{Binding IsVerticalWriting}"
+         Navigating="OnWebViewNavigating" />
+```
+
+**After**:
+```xml
+<controls:ReaderWebView Grid.Row="1"
+                        IsVisible="{Binding IsVerticalWriting}"
+                        HtmlSource="{Binding EpisodeHtml}"
+                        Navigating="OnWebViewNavigating" />
+```
+
+`x:Name` はコードビハインドから参照されなくなるため削除。
+
+### 4.6 `_Apps/Views/ReaderPage.xaml.cs`（差分）
+
+#### 4.6.1 `_viewModel` フィールドと PropertyChanged 購読を削除
+
+**Before**:
+```csharp
+public partial class ReaderPage : ContentPage
+{
+    private readonly ReaderViewModel _viewModel;
+
+    public ReaderPage(ReaderViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = _viewModel = viewModel;
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ReaderViewModel.EpisodeHtml) or nameof(ReaderViewModel.IsVerticalWriting))
+        {
+            if (_viewModel.IsVerticalWriting && !string.IsNullOrEmpty(_viewModel.EpisodeHtml))
+            {
+                VerticalWebView.Source = new HtmlWebViewSource { Html = _viewModel.EpisodeHtml };
+            }
+        }
+    }
+
+    private async void OnScrolled(object? sender, ScrolledEventArgs e)
+    {
+        if (sender is not ScrollView scrollView) return;
+        if (scrollView.ScrollY + scrollView.Height >= scrollView.ContentSize.Height - 10)
+        {
+            await _viewModel.MarkAsReadCommand.ExecuteAsync(null);
+        }
+    }
+
+    private async void OnWebViewNavigating(object? sender, WebNavigatingEventArgs e)
+    {
+        if (e.Url?.StartsWith("lanobe://read-end", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            e.Cancel = true;
+            await _viewModel.MarkAsReadCommand.ExecuteAsync(null);
+        }
+    }
+}
+```
+
+**After**:
+```csharp
+using LanobeReader.ViewModels;
+
+namespace LanobeReader.Views;
+
+public partial class ReaderPage : ContentPage
+{
+    public ReaderPage(ReaderViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    private async void OnScrolled(object? sender, ScrolledEventArgs e)
+    {
+        if (sender is not ScrollView scrollView) return;
+        if (scrollView.ScrollY + scrollView.Height >= scrollView.ContentSize.Height - 10)
+        {
+            if (BindingContext is ReaderViewModel vm)
+            {
+                await vm.MarkAsReadCommand.ExecuteAsync(null);
+            }
+        }
+    }
+
+    private async void OnWebViewNavigating(object? sender, WebNavigatingEventArgs e)
+    {
+        if (e.Url?.StartsWith("lanobe://read-end", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            e.Cancel = true;
+            if (BindingContext is ReaderViewModel vm)
+            {
+                await vm.MarkAsReadCommand.ExecuteAsync(null);
+            }
+        }
+    }
+}
+```
+
+**変更点**:
+- `_viewModel` フィールド削除（`BindingContext` 経由で取得）
+- `OnViewModelPropertyChanged` 完全削除
+- コンストラクタの PropertyChanged 購読削除
+- `VerticalWebView` 参照削除
+
+---
+
+## 5. ビルド・動作確認手順
+
+### 5.1 ビルド
+```bash
+dotnet build /c/Work/Github/TBird.Library/_Apps/App.sln --no-restore
+```
+- 警告ゼロ
+- `ReaderHtmlBuilder.Build` のシグネチャ変更に伴う呼び出し元コンパイルエラーが `ReaderViewModel.RefreshHtml` 以外にないこと（Grep `ReaderHtmlBuilder` で事前確認）
+
+### 5.2 手動チェックリスト
+
+#### H2 検証（コードビハインド除去）
+- [ ] 縦書き設定 OFF の状態で小説を開く → 横書きで表示される
+- [ ] 縦書き設定 ON の状態で小説を開く → 縦書きで表示される
+- [ ] 設定画面で縦書きを OFF→ON 切り替え → Reader 画面で縦書きに切り替わる
+- [ ] 次の話へ遷移 → 縦書き WebView に新しい本文が表示される
+- [ ] 縦書き状態で最後までスクロール → `lanobe://read-end` 発火 → 既読化される
+- [ ] 横書き状態で最後までスクロール → `OnScrolled` 発火 → 既読化される
+- [ ] ★（お気に入り）ボタンが機能する（他 Binding が壊れていないことの確認）
+- [ ] **縦書き ON → OFF → 別エピソード遷移 → 再度 ON** で正しく新エピソードが縦書き表示される（古い HTML が残らない）
+
+#### H4 検証（CSS 変数化）
+- [ ] 縦書き表示で既定テーマ（白背景）の配色が従来と同じ
+- [ ] 縦書き表示でダークテーマ（`#121212` / `#E0E0E0`）が従来と同じ
+- [ ] 縦書き表示でセピアテーマ（`#F5E6C8` / `#3E2C1C`）が従来と同じ
+- [ ] 縦書き表示のフォントサイズ・行間が設定値どおり
+- [ ] `ReaderHtmlBuilder.Build` の戻り値をデバッガのウォッチで検査し、`<style>:root{--reader-fs:...;--reader-lh:...;--reader-bg:...;--reader-fg:...}` が含まれていること
+- [ ] `body` 内の CSS 値が `var(--reader-*)` 参照になっていること
+
+#### 回帰確認
+- [ ] 小説一覧 → 詳細 → 縦書き読書 → 目次 → 前/次 → 既読化 まで動作
+- [ ] オフライン状態でキャッシュありのエピソードを開ける
+- [ ] オフライン状態でキャッシュなしのエピソードを開くとエラーダイアログが出る
+
+### 5.3 パフォーマンス
+
+H4（縮退版）に直接的なパフォーマンス効果はない。計測不要。
+
+---
+
+## 6. リスク一覧と対策
+
+| # | リスク | 発生箇所 | 対策 |
+|---|---|---|---|
+| R1 | `HtmlSource` 空文字で初期化時に WebView が白紙のまま | `ReaderWebView.OnHtmlSourceChanged` | 空文字/null で早期 return。`LoadEpisodeAsync` 完了時に `EpisodeHtml` が確定し、その時点でバインドが発火する |
+| R2 | `_Apps/Controls/` フォルダが存在しない | 新規ファイル配置 | `Write` ツールは存在しないフォルダを自動作成する。問題なし |
+| R3 | `OnWebViewNavigating` ハンドラが `ReaderWebView` 派生型でも正しく動く | `ReaderPage.xaml` | `WebView.Navigating` イベントは継承先でも同じく発火する。MAUI 標準動作 |
+| R4 | PropertyChanged 購読を削除したことで `IsVerticalWriting` の視覚切替が効かなくなる | `ReaderPage.xaml` | `WebView` 側は `IsVisible="{Binding IsVerticalWriting}"` で表示/非表示が切り替わるため問題なし。旧ハンドラは WebView 表示切替ではなく「Source 再代入」が主目的だった |
+| R5 | `Color.ToHex()` が `#AARRGGBB` / `#RRGGBBAA` を返すバージョン差で色が壊れる | `ColorToHex` | `ToHex()` は使わず `$"#{R:X2}{G:X2}{B:X2}"` で自前フォーマット |
+
+### 事前に走らせる Grep（実装セッション開始時）
+
+```text
+pattern: ReaderHtmlBuilder\.Build
+path:    c:\Work\Github\TBird.Library\_Apps
+期待:    ReaderViewModel.cs の 1 箇所のみ
+```
+```text
+pattern: VerticalWebView
+path:    c:\Work\Github\TBird.Library\_Apps
+期待:    ReaderPage.xaml / ReaderPage.xaml.cs のみ（本 PR で両方から除去）
+```
+
+---
+
+## 7. コミット分割方針
+
+2 コミットに分割する。各コミット後にビルドが通ること。
+
+1. **`refactor(Reader): extract CSS custom properties and unify theme (H4)`**
+   - `_Apps/Helpers/ReaderCssState.cs` 新規
+   - `_Apps/Helpers/ReaderHtmlBuilder.cs` 書き換え（配色テーブル削除 → `ThemeHelper` 一本化、CSS 変数化）
+   - `_Apps/ViewModels/ReaderViewModel.cs` の `RefreshHtml` 書き換え、`ColorToHex` 追加
+   - この時点で XAML は旧 `WebView` のまま、コードビハインドも旧 `OnViewModelPropertyChanged` 経由で Source 更新が動き続ける → ビルド・動作とも既存と同等
+
+2. **`refactor(ReaderPage): introduce ReaderWebView and remove PropertyChanged codebehind (H2)`**
+   - `_Apps/Controls/ReaderWebView.cs` 新規
+   - `_Apps/Views/ReaderPage.xaml` の WebView を `controls:ReaderWebView` に差替、`HtmlSource` バインド追加、`x:Name` 削除
+   - `_Apps/Views/ReaderPage.xaml.cs` から `_viewModel` フィールド・PropertyChanged 購読・`OnViewModelPropertyChanged` 削除、残ハンドラは `BindingContext` 経由に
+   - 手動チェックリスト §5.2 全項目を実施
+
+---
+
+## 8. スコープ外（やらないこと）
+
+- **CSS 変数のライブ差し替え経路**（`CssVariables` Bindable / `EvaluateJavaScriptAsync` / `_pendingCss` / `partial void OnFontSizeChanged` 等 / `ReaderCss` ObservableProperty）
+  → [plan_2026-04-09_pr3b-reader-live-css.md](plan_2026-04-09_pr3b-reader-live-css.md) で扱う
+- `OnScrolled` / `OnWebViewNavigating` の Behavior 化（L2 相当）
+- 設定画面からの Reader ライブ反映 UI（別 PR）
+- `ReaderViewModel._backgroundThemeIndex` の `ObservableProperty` 化
+- `Helpers/ReaderHtmlBuilder` のテスト追加（テスト基盤なし）
+- `EpisodeContent.Split('\n')` の CRLF 対応（既存バグ、別 PR）
+- 他の H / M / L 課題（[audit_2026-04-08_apps-refactor.md](audit_2026-04-08_apps-refactor.md) 参照）
+
+---
+
+## 9. 完了条件（Definition of Done）
+
+1. 変更/新規は §3 の 6 ファイルのみ（`git diff --stat` で確認）
+2. `dotnet build` が警告ゼロ
+3. §5.2 手動チェックリスト全通過（特に 3 テーマの配色・縦書きスクロール既読化・縦書き ON→OFF→別エピソード→ON 遷移）
+4. 2 コミット構成
+5. PR 本文に本ファイル（`_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md`）と後続プラン（`plan_2026-04-09_pr3b-reader-live-css.md`）へのリンクを明記し、「H4 は CSS 変数化＋ThemeHelper 統合までの縮退版。ライブ反映経路は PR3b で実装」と書く
+6. ベースブランチは `app-novelviewer`

--- a/_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md
+++ b/_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md
@@ -1,0 +1,417 @@
+# PR3b: Reader CSS ライブ反映経路（PR3a から分離）
+
+作成日: 2026-04-09
+対象ブランチ: `app-novelviewer` から派生する作業ブランチ（例: `feature/pr3b-reader-live-css-YYYYMMDD`）
+前提: PR3a（[plan_2026-04-09_pr3a-reader-refactor.md](plan_2026-04-09_pr3a-reader-refactor.md)）マージ済み
+関連: [audit_2026-04-08_apps-refactor.md](audit_2026-04-08_apps-refactor.md)
+
+---
+
+## 0. 背景
+
+PR3a のレビュー時、H4 の以下の要素が「本 PR では 1 度も発火せずマージされるデッドコード相当」と指摘されたため、PR3a から切り出して本プランに分離した:
+
+- `ReaderWebView.CssVariables` Bindable + `EvaluateJavaScriptAsync` による `:root` CSS 変数の実行時差し替え
+- `_htmlLoaded` / `_pendingCss` 遅延適用フラグ
+- `ReaderViewModel.ReaderCss` ObservableProperty
+- `partial void OnFontSizeChanged` / `OnLineHeightChanged` / `OnBackgroundColorChanged` / `OnTextColorChanged` の 4 本
+- `UpdateCssStateIfReady` ヘルパ
+
+PR3a ではこれらを入れても発火経路が存在しなかった（`ReaderViewModel` に `FontSize` 等を再代入するルートがないため）。本 PR では **「設定画面 → Reader へのライブ反映」UI と同時に導入**し、実際に動作検証可能な状態で着地させる。
+
+## 0.1 PR3a で既に整った土台
+
+- `ReaderHtmlBuilder` は CSS カスタムプロパティ（`--reader-fs` / `--reader-lh` / `--reader-bg` / `--reader-fg`）を `:root` に定義済み
+- `body` 内の CSS 値は全て `var(--reader-*)` 参照
+- `ReaderCssState` record が `Helpers/` に存在
+- `ReaderWebView` カスタムコントロールが存在し `HtmlSource` Bindable を持つ
+
+本 PR はこの土台の上に、JS による変数書き換え経路と ViewModel 側の通知ルートを重ねる。
+
+---
+
+## 1. ゴール
+
+1. Reader 表示中にフォントサイズ・行間・テーマを変更したら、**WebView を再ロードせず**に縦書き表示がその場で更新される
+2. エピソード切替（HTML 再ロード）時と設定変更時で挙動を切り替える（前者は HTML 焼き込み、後者は JS 実行）
+3. 設定画面から Reader へ変更を伝えるルートが実装される（PR3a 時点では未実装）
+
+---
+
+## 2. 設計
+
+### 2.1 `ReaderWebView` への追加
+
+PR3a 版 `ReaderWebView` に以下を追加する。
+
+#### 新規 BindableProperty
+
+| プロパティ | 型 | 役割 |
+|---|---|---|
+| `CssVariables` | `ReaderCssState?` | 値が変化したら HTML ロード済みなら JS で `:root` の CSS 変数を更新。未ロードなら Navigated 時に保留適用 |
+
+#### 内部状態
+
+- `bool _htmlLoaded` — `Navigated` 成功で true、`HtmlSource` 再代入直前に false
+- `ReaderCssState? _pendingCss` — HTML 未ロード中に受け取った CssVariables 値
+
+#### 動作
+
+1. `HtmlSource` 変化 → `_htmlLoaded = false` → `_pendingCss = null`（古い保留を破棄）→ `Source` 再代入
+2. `CssVariables` 変化 → `_htmlLoaded == true` なら `ApplyCssAsync` を fire-and-forget、そうでなければ `_pendingCss = state`
+3. `Navigated` ハンドラ: `e.Result == Success` なら `_htmlLoaded = true`、`_pendingCss` があれば適用
+4. `ApplyCssAsync` 内の例外は `Debug.WriteLine` でログ出力してから握りつぶす（WebView 破棄後の呼び出し等を想定）
+
+> **PR3a レビュー時の指摘反映**:
+> - **代入順序**: `ReaderViewModel.RefreshHtml` は `EpisodeHtml` を先に、`ReaderCss` を後に代入する（古い document への無駄 JS を防ぐ）
+> - **pending 破棄**: HtmlSource 再代入時に必ず `_pendingCss = null` する（`Navigated` が失敗したケースで古い保留が永久に残るのを防ぐ）
+> - **サイレント catch 禁止**: `ApplyCssAsync` の catch で必ず `Debug.WriteLine`
+> - **UI スレッド前提コメント**: クラス冒頭に「プロパティ変更通知は UI スレッドからのみ前提」の説明を残す
+
+### 2.2 `ReaderViewModel` への追加
+
+#### 新規 ObservableProperty
+
+```csharp
+[ObservableProperty]
+private ReaderCssState? _readerCss;
+```
+
+#### 初期化タイミング
+
+`LoadSettingsAsync` 末尾（`IsHorizontal = !IsVerticalWriting;` の直後）で:
+
+```csharp
+ReaderCss = BuildCssState();
+```
+
+`BuildCssState()` は PR3a で `RefreshHtml` 内にインライン展開されているロジックを private メソッドに切り出したもの:
+
+```csharp
+private ReaderCssState BuildCssState() => new ReaderCssState(
+    FontSizePx: FontSize,
+    LineHeight: LineHeight,
+    BackgroundHex: ColorToHex(BackgroundColor),
+    ForegroundHex: ColorToHex(TextColor));
+```
+
+#### `RefreshHtml` の修正
+
+**PR3a 版**:
+```csharp
+private void RefreshHtml()
+{
+    var state = new ReaderCssState(...);
+    EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, state);
+}
+```
+
+**PR3b 版**（代入順序に注意 — EpisodeHtml 先、ReaderCss 後）:
+```csharp
+private void RefreshHtml()
+{
+    var state = BuildCssState();
+    EpisodeHtml = ReaderHtmlBuilder.Build(EpisodeContent, state);
+    ReaderCss = state; // record の value equality により、同値なら通知なし
+}
+```
+
+#### partial メソッド 4 本追加
+
+`OnIsVerticalWritingChanged` の近くに:
+
+```csharp
+partial void OnFontSizeChanged(double value) => UpdateCssStateIfReady();
+partial void OnLineHeightChanged(double value) => UpdateCssStateIfReady();
+partial void OnBackgroundColorChanged(Color value) => UpdateCssStateIfReady();
+partial void OnTextColorChanged(Color value) => UpdateCssStateIfReady();
+
+private void UpdateCssStateIfReady()
+{
+    // LoadSettingsAsync 内の初期化フェーズ（ReaderCss == null）では個別
+    // プロパティが順次変化するたびに CSS state を作り直すのは無駄なので、
+    // ReaderCss が既にセットされている場合のみ更新する。
+    if (ReaderCss is not null)
+    {
+        ReaderCss = BuildCssState();
+    }
+}
+```
+
+### 2.3 設定画面からのライブ反映ルート（本 PR の肝）
+
+PR3a 時点では `ReaderViewModel.FontSize` を再代入する UI が存在しない。本 PR で以下のいずれかの形で通知経路を作る（実装セッション開始時に方針確定すること）:
+
+**方針候補 A**: `MessagingCenter` / `WeakReferenceMessenger` による pub/sub
+- 設定画面がフォントサイズ等を保存したタイミングで `SettingsChangedMessage` を publish
+- `ReaderViewModel` のコンストラクタで subscribe し、受信時に `FontSize`/`LineHeight`/`BackgroundColor`/`TextColor` を再代入
+
+**方針候補 B**: `ReaderPage.OnAppearing` で `LoadSettingsAsync` を再実行
+- 設定画面から Reader に戻ってきたタイミングで設定値を再読込
+- フォント等の個別プロパティを再代入すれば partial void 経由で `ReaderCss` が更新される
+- ただしページ復帰時のみで、設定画面とのサイドバイサイド表示には非対応（本アプリは Shell 遷移のみなので実質問題なし）
+
+**推奨**: 方針 B（実装が単純で既存アーキテクチャに馴染む）。
+
+### 2.4 `ReaderPage.xaml`
+
+PR3a 版に `CssVariables` バインドを追加する:
+
+```xml
+<controls:ReaderWebView Grid.Row="1"
+                        IsVisible="{Binding IsVerticalWriting}"
+                        HtmlSource="{Binding EpisodeHtml}"
+                        CssVariables="{Binding ReaderCss}"
+                        Navigating="OnWebViewNavigating" />
+```
+
+---
+
+## 3. 変更対象ファイル一覧
+
+| 種類 | パス |
+|---|---|
+| 変更 | `_Apps/Controls/ReaderWebView.cs` |
+| 変更 | `_Apps/ViewModels/ReaderViewModel.cs` |
+| 変更 | `_Apps/Views/ReaderPage.xaml` |
+| 変更 | `_Apps/Views/ReaderPage.xaml.cs`（方針 B の場合 `OnAppearing` 追加） |
+
+`ReaderCssState` / `ReaderHtmlBuilder` は PR3a で最終形になっているため本 PR では触らない。
+
+---
+
+## 4. 実装詳細
+
+### 4.1 `ReaderWebView` 拡張
+
+```csharp
+using System.Diagnostics;
+using System.Globalization;
+using LanobeReader.Helpers;
+
+namespace LanobeReader.Controls;
+
+/// <summary>
+/// Reader 画面の縦書き表示用 WebView。
+///
+/// 本コントロールのプロパティ変更通知は UI スレッドからのみ発生する前提で実装されている
+/// （MAUI の BindableProperty 既定動作）。別スレッドから HtmlSource / CssVariables を
+/// 書き換える場合は呼び出し側で Dispatcher 経由にすること。
+/// </summary>
+public sealed class ReaderWebView : WebView
+{
+    private bool _htmlLoaded;
+    private ReaderCssState? _pendingCss;
+
+    public ReaderWebView()
+    {
+        Navigated += OnNavigated;
+    }
+
+    // --- HtmlSource ---
+
+    public static readonly BindableProperty HtmlSourceProperty = BindableProperty.Create(
+        nameof(HtmlSource), typeof(string), typeof(ReaderWebView),
+        default(string), propertyChanged: OnHtmlSourceChanged);
+
+    public string? HtmlSource
+    {
+        get => (string?)GetValue(HtmlSourceProperty);
+        set => SetValue(HtmlSourceProperty, value);
+    }
+
+    private static void OnHtmlSourceChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var self = (ReaderWebView)bindable;
+        var html = newValue as string;
+        if (string.IsNullOrEmpty(html)) return;
+
+        // 新しい HTML をロードする直前に、古い document 向けの保留 CSS を破棄する。
+        // Navigated が失敗したケースで _pendingCss が永久に残るのを防ぐ。
+        self._htmlLoaded = false;
+        self._pendingCss = null;
+        self.Source = new HtmlWebViewSource { Html = html };
+    }
+
+    // --- CssVariables ---
+
+    public static readonly BindableProperty CssVariablesProperty = BindableProperty.Create(
+        nameof(CssVariables), typeof(ReaderCssState), typeof(ReaderWebView),
+        default(ReaderCssState), propertyChanged: OnCssVariablesChanged);
+
+    public ReaderCssState? CssVariables
+    {
+        get => (ReaderCssState?)GetValue(CssVariablesProperty);
+        set => SetValue(CssVariablesProperty, value);
+    }
+
+    private static void OnCssVariablesChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var self = (ReaderWebView)bindable;
+        if (newValue is not ReaderCssState state) return;
+
+        if (self._htmlLoaded)
+        {
+            _ = self.ApplyCssAsync(state);
+        }
+        else
+        {
+            // HTML 未ロード時は保留。Navigated 成功時にまとめて適用する。
+            // 初回は HTML 側の :root{} に同じ値が埋まっているため厳密には不要だが、
+            // 後から値が変わった場合の安全網として保持する。
+            self._pendingCss = state;
+        }
+    }
+
+    private void OnNavigated(object? sender, WebNavigatedEventArgs e)
+    {
+        if (e.Result != WebNavigationResult.Success) return;
+        _htmlLoaded = true;
+        if (_pendingCss is not null)
+        {
+            var s = _pendingCss;
+            _pendingCss = null;
+            _ = ApplyCssAsync(s);
+        }
+    }
+
+    private async Task ApplyCssAsync(ReaderCssState state)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        // 変数名は ReaderHtmlBuilder の :root 定義と一致させること
+        var js =
+            "(function(){var s=document.documentElement.style;" +
+            $"s.setProperty('--reader-fs','{state.FontSizePx.ToString("0.##", inv)}px');" +
+            $"s.setProperty('--reader-lh','{state.LineHeight.ToString("0.##", inv)}');" +
+            $"s.setProperty('--reader-bg','{state.BackgroundHex}');" +
+            $"s.setProperty('--reader-fg','{state.ForegroundHex}');" +
+            "})();";
+        try
+        {
+            await EvaluateJavaScriptAsync(js);
+        }
+        catch (Exception ex)
+        {
+            // WebView 破棄後などに到達する可能性がある。致命的ではないが、
+            // 将来のデバッグのためログは必ず残す（サイレント catch にしない）。
+            Debug.WriteLine($"[ReaderWebView] ApplyCssAsync failed: {ex}");
+        }
+    }
+}
+```
+
+### 4.2 `ReaderViewModel` 変更点
+
+§2.2 参照。要点:
+- `ReaderCss` ObservableProperty 追加
+- `BuildCssState()` を private メソッドに切り出し
+- `LoadSettingsAsync` 末尾で `ReaderCss = BuildCssState();`
+- `RefreshHtml` は **EpisodeHtml 先・ReaderCss 後** の順
+- `partial void On{FontSize|LineHeight|BackgroundColor|TextColor}Changed` 4 本 + `UpdateCssStateIfReady`
+
+### 4.3 設定画面からの反映（方針 B 採用時）
+
+`ReaderPage.xaml.cs`:
+
+```csharp
+protected override void OnAppearing()
+{
+    base.OnAppearing();
+    if (BindingContext is ReaderViewModel vm)
+    {
+        _ = vm.ReloadSettingsAsync();
+    }
+}
+```
+
+`ReaderViewModel` に public な `ReloadSettingsAsync` を公開（既存 `LoadSettingsAsync` を public 化 or ラップ）:
+
+```csharp
+public Task ReloadSettingsAsync() => LoadSettingsAsync();
+```
+
+`LoadSettingsAsync` 内で `FontSize = fontSizeSp;` 等の代入が走ると、`ReaderCss != null` なので partial void 経由で `UpdateCssStateIfReady` → `ReaderCss` 更新 → WebView に JS が流れる。
+
+> **注**: `LoadSettingsAsync` では 4 プロパティが順次更新されるため、partial void が 4 回発火して `ReaderCss` も 4 回更新される（うち 3 回は中間状態）。CSS 変数の適用は冪等なので視覚的な問題はないが、気になるなら `LoadSettingsAsync` 内で一時的にフラグを立てて partial void を抑制し、末尾でまとめて `ReaderCss = BuildCssState();` する形にできる。
+
+---
+
+## 5. ビルド・動作確認手順
+
+### 5.1 ビルド
+```bash
+dotnet build /c/Work/Github/TBird.Library/_Apps/App.sln --no-restore
+```
+
+### 5.2 手動チェックリスト
+
+#### ライブ反映の検証（本 PR のコア）
+- [ ] 縦書き Reader を開いた状態で設定画面に遷移 → フォントサイズを変更 → Reader に戻る → **WebView をリロードせずに**フォントサイズが変わっている
+  - 検証方法: 変更前にスクロール位置を覚えておき、戻った後もスクロール位置が維持されていることを確認（リロードされていれば先頭に戻る）
+- [ ] 同様に行間変更が反映される
+- [ ] 同様にテーマ（背景色・文字色）変更が反映される
+- [ ] 設定を連続で複数回変更しても正しく反映される
+- [ ] `Debug.WriteLine` の `ApplyCssAsync failed` ログが出ていない
+
+#### `_pendingCss` 破棄の検証
+- [ ] 縦書きで別エピソードに遷移した直後にテーマ変更 → 新エピソードに正しく反映される（古いエピソードへの保留 JS が走らない）
+
+#### PR3a 回帰
+- [ ] PR3a の §5.2 全項目が引き続き通る
+
+### 5.3 Navigated 失敗時の挙動確認（任意）
+
+`e.Result != Success` を人為的に再現するのは難しいため、本 PR では `_pendingCss = null` を HtmlSource 再代入時に確実に実行していることをコードレビューで担保する。
+
+---
+
+## 6. リスク一覧と対策
+
+| # | リスク | 対策 |
+|---|---|---|
+| R1 | `EvaluateJavaScriptAsync` がプラットフォーム（iOS/Android/Windows）で挙動差がある | 手動チェックリストを主要 2 プラットフォーム以上で実行。失敗時は `Debug.WriteLine` ログで検知 |
+| R2 | `Navigated` イベントが HTML ロード失敗時に `_htmlLoaded = true` にならず `_pendingCss` が永久保留 | HtmlSource 再代入時に `_pendingCss = null` で破棄する安全網で対処済み |
+| R3 | `LoadSettingsAsync` 内で 4 プロパティが順次更新され partial void が 4 回発火 | `ReaderCssState` は record value equality で同値通知を抑制。視覚的問題なし。気になれば一時抑制フラグを導入 |
+| R4 | `RefreshHtml` の代入順序を誤ると古い document に無駄 JS が流れる | **EpisodeHtml 先・ReaderCss 後** をコード内コメントで明記 |
+| R5 | `Color.ToHex()` のバージョン差問題（PR3a と共通） | PR3a で導入済みの自前フォーマット `ColorToHex` をそのまま使う |
+
+---
+
+## 7. コミット分割方針
+
+1. **`feat(ReaderWebView): add CssVariables bindable with deferred apply`**
+   - `ReaderWebView.cs` に `CssVariables` Bindable、`_htmlLoaded` / `_pendingCss`、`ApplyCssAsync` 追加
+   - `OnHtmlSourceChanged` に `_pendingCss = null` 追加
+
+2. **`feat(ReaderViewModel): propagate setting changes to ReaderCss`**
+   - `ReaderCss` ObservableProperty、`BuildCssState`、partial void 4 本、`UpdateCssStateIfReady` 追加
+   - `RefreshHtml` を「EpisodeHtml 先・ReaderCss 後」順に修正
+   - `LoadSettingsAsync` 末尾で初期 `ReaderCss` セット
+   - `ReloadSettingsAsync` public メソッド追加
+
+3. **`feat(ReaderPage): reload settings on appearing for live CSS update`**
+   - `ReaderPage.xaml` に `CssVariables` バインド追加
+   - `ReaderPage.xaml.cs` の `OnAppearing` オーバーライドで `ReloadSettingsAsync` 呼び出し
+   - 手動チェックリスト §5.2 全項目を実施
+
+---
+
+## 8. スコープ外（やらないこと）
+
+- フォントサイズ等を Reader 画面内の UI（スライダー等）から直接変更する機能（設定画面経由のみ）
+- 他の Reader 設定項目（マージン、段組み等）の追加
+- `OnScrolled` / `OnWebViewNavigating` の Behavior 化
+- `EpisodeContent.Split('\n')` の CRLF 対応
+- 他の H / M / L 課題
+
+---
+
+## 9. 完了条件（Definition of Done）
+
+1. §5.2 のライブ反映チェックリスト全通過（特にスクロール位置維持で「リロードされていない」ことを確認）
+2. `dotnet build` 警告ゼロ
+3. PR3a の手動チェックリストも引き続き通る
+4. `ApplyCssAsync` の catch で `Debug.WriteLine` が実装されていること
+5. `OnHtmlSourceChanged` で `_pendingCss = null` が実装されていること
+6. `RefreshHtml` 内の代入順序が「EpisodeHtml → ReaderCss」になっていること
+7. ベースブランチは PR3a マージ後の `app-novelviewer`


### PR DESCRIPTION
## Summary

- PR3a (H2+H4 Reader リファクタ) と PR3b (CSS ライブ反映) の実装プランを追加

## Files
- `_Apps/Features/plan_2026-04-09_pr3a-reader-refactor.md`
- `_Apps/Features/plan_2026-04-09_pr3b-reader-live-css.md`