### PR TITLE
perf(SearchViewModel): batch N+1 query and surface ranking/genre errors (H8, M7)

### DIFF
--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -121,6 +121,13 @@ public class NovelRepository
         return await _db.Table<Novel>().FirstOrDefaultAsync(n => n.Id == id).ConfigureAwait(false);
     }
 
+    public async Task<HashSet<(int SiteType, string NovelId)>> GetExistingSiteNovelIdsAsync()
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        var novels = await _db.Table<Novel>().ToListAsync().ConfigureAwait(false);
+        return new HashSet<(int, string)>(novels.Select(n => (n.SiteType, n.NovelId)));
+    }
+
     public async Task<Novel?> GetBySiteAndNovelIdAsync(int siteType, string novelId)
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -218,13 +218,20 @@ public partial class SearchViewModel : ObservableObject
             var siteResults = await Task.WhenAll(narouTask, kakuyomuTask);
 
             var allHits = siteResults.SelectMany(r => r.hits).ToList();
-            foreach (var r in siteResults)
+            var errors = siteResults.Select(r => r.error).Where(e => e is not null).ToList();
+            if (errors.Count > 0)
             {
-                if (r.error is not null)
-                    LogHelper.Warn(nameof(SearchViewModel), r.error);
+                HasError = true;
+                ErrorMessage = string.Join("\n", errors);
             }
 
             await ShowResultsAsync(allHits);
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Error(nameof(SearchViewModel), $"Ranking fetch failed: {ex.Message}");
+            HasError = true;
+            ErrorMessage = "通信エラーが発生しました";
         }
         finally { IsLoading = false; }
     }
@@ -251,25 +258,30 @@ public partial class SearchViewModel : ObservableObject
             var siteResults = await Task.WhenAll(narouTask, kakuyomuTask);
 
             var allHits = siteResults.SelectMany(r => r.hits).ToList();
-            foreach (var r in siteResults)
+            var errors = siteResults.Select(r => r.error).Where(e => e is not null).ToList();
+            if (errors.Count > 0)
             {
-                if (r.error is not null)
-                    LogHelper.Warn(nameof(SearchViewModel), r.error);
+                HasError = true;
+                ErrorMessage = string.Join("\n", errors);
             }
 
             await ShowResultsAsync(allHits);
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Error(nameof(SearchViewModel), $"Genre fetch failed: {ex.Message}");
+            HasError = true;
+            ErrorMessage = "通信エラーが発生しました";
         }
         finally { IsLoading = false; }
     }
 
     private async Task ShowResultsAsync(List<SearchResult> results)
     {
-        var viewModels = new List<SearchResultViewModel>();
-        foreach (var result in results)
-        {
-            var existing = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
-            viewModels.Add(SearchResultViewModel.FromModel(result, existing is not null));
-        }
+        var existingIds = await _novelRepo.GetExistingSiteNovelIdsAsync();
+        var viewModels = results.Select(r =>
+            SearchResultViewModel.FromModel(r, existingIds.Contains(((int)r.SiteType, r.NovelId)))
+        ).ToList();
         SearchResults = new ObservableCollection<SearchResultViewModel>(viewModels);
         HasSearched = true;
     }


### PR DESCRIPTION
## Summary

- **H8**: `ShowResultsAsync` の N+1 クエリを解消。検索結果 N 件に対し `GetBySiteAndNovelIdAsync` を N 回呼んでいたのを、`GetExistingSiteNovelIdsAsync` で全 Novel の (SiteType, NovelId) ペアを 1 クエリで取得し HashSet で O(1) 判定に変更。PR4 の並列化でヒット数が最大 60 件に増加したため体感改善が大きい。
- **M7**: `FetchRankingAsync` / `FetchGenreAsync` でエラーが `LogHelper.Warn` のみだったのを、`SearchAsync` と同じ `HasError` + `ErrorMessage` パターンに統一。両サイト同時失敗時もユーザーにエラーが表示される。外側 `catch(Exception)` も追加。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `NovelRepository.cs` | `GetExistingSiteNovelIdsAsync` バルクメソッド追加 |
| `SearchViewModel.cs` | `ShowResultsAsync` 1クエリ化、`FetchRankingAsync`/`FetchGenreAsync` エラー可視化+catch |

## Test plan

- [ ] `dotnet build _Apps/App.sln` 成功
- [ ] 検索 → キーワード検索 → 結果表示（「登録済」表示が正しいこと）
- [ ] ランキング取得 → エラー時に赤字エラーメッセージ表示
- [ ] ジャンル別取得 → 同上