### PR TITLE
fix: コードレビュー発見13件のリスク修正 (R1-R14)

### DIFF
--- a/_Apps/App.xaml.cs
+++ b/_Apps/App.xaml.cs
@@ -60,7 +60,7 @@ public partial class App : Application
 
             // 2. Delete expired cache
             var cacheMonths = await _settingsRepo.GetIntValueAsync(SettingsKeys.CACHE_MONTHS, 3).ConfigureAwait(false);
-            _ = _cacheRepo.DeleteExpiredAsync(cacheMonths);
+            await _cacheRepo.DeleteExpiredAsync(cacheMonths).ConfigureAwait(false);
 
             // 3. Check novel count for navigation
             var novelCount = await _novelRepo.CountAsync().ConfigureAwait(false);
@@ -68,7 +68,15 @@ public partial class App : Application
             {
                 MainThread.BeginInvokeOnMainThread(async () =>
                 {
-                    await Shell.Current.GoToAsync("//search");
+                    try
+                    {
+                        if (Shell.Current is not null)
+                            await Shell.Current.GoToAsync("//search");
+                    }
+                    catch (Exception ex)
+                    {
+                        LogHelper.Warn("App", $"Navigation to search failed: {ex.Message}");
+                    }
                 });
             }
             else

--- a/_Apps/Features/plan_2026-04-16_risk-r1-r14.md
+++ b/_Apps/Features/plan_2026-04-16_risk-r1-r14.md
@@ -1,0 +1,411 @@
+# RISK修正プラン (R1-R14)
+
+コードレビューで発見された14件の潜在的リスク（RISK）を修正する。
+各修正は最小限の変更に留め、既存の動作を壊さないことを優先する。
+
+ブランチ: `app-novelviewer` から feature ブランチを作成 → `app-novelviewer` へ PR。
+
+---
+
+## 修正一覧（ファイル別、実装順）
+
+### 1. `_Apps/Services/Database/EpisodeRepository.cs` — R9（メソッド追加）
+
+**問題:** `GetByNovelAndEpisodeNoAsync(_novelDbId, episodeNo ± 1)` で固定値±1を使用。エピソード番号に欠番があるとナビゲーション不能。
+
+**修正:** 2つの新メソッドを追加（line 56の`GetByNovelAndEpisodeNoAsync`の後に配置）:
+
+```csharp
+public async Task<Episode?> GetPreviousEpisodeAsync(int novelId, int currentEpisodeNo)
+{
+    await EnsureAsync().ConfigureAwait(false);
+    var results = await _db.QueryAsync<Episode>(
+        "SELECT id, novel_id, episode_no, chapter_name, title, " +
+        "is_read, read_at, published_at, is_favorite, favorited_at " +
+        "FROM episodes WHERE novel_id = ? AND episode_no < ? " +
+        "ORDER BY episode_no DESC LIMIT 1",
+        novelId, currentEpisodeNo).ConfigureAwait(false);
+    return results.FirstOrDefault();
+}
+
+public async Task<Episode?> GetNextEpisodeAsync(int novelId, int currentEpisodeNo)
+{
+    await EnsureAsync().ConfigureAwait(false);
+    var results = await _db.QueryAsync<Episode>(
+        "SELECT id, novel_id, episode_no, chapter_name, title, " +
+        "is_read, read_at, published_at, is_favorite, favorited_at " +
+        "FROM episodes WHERE novel_id = ? AND episode_no > ? " +
+        "ORDER BY episode_no ASC LIMIT 1",
+        novelId, currentEpisodeNo).ConfigureAwait(false);
+    return results.FirstOrDefault();
+}
+```
+
+既存の複合インデックス `idx_episodes_novel_episode ON episodes (novel_id, episode_no)` を活用。
+`GetPagedByNovelIdAsync` (line 32-36) と同じカラム列挙パターンに準拠。
+
+---
+
+### 2. `_Apps/ViewModels/ReaderViewModel.cs` — R9（呼出側）+ R10
+
+**R9 呼出側の修正（4箇所）:**
+
+| 行 | 変更前 | 変更後 |
+|---|---|---|
+| 159 | `_episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo - 1)` | `_episodeRepo.GetPreviousEpisodeAsync(_novelDbId, _episode.EpisodeNo)` |
+| 160 | `_episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo + 1)` | `_episodeRepo.GetNextEpisodeAsync(_novelDbId, _episode.EpisodeNo)` |
+| 221 | `_episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo - 1)` | `_episodeRepo.GetPreviousEpisodeAsync(_novelDbId, _episode.EpisodeNo)` |
+| 235 | `_episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo + 1)` | `_episodeRepo.GetNextEpisodeAsync(_novelDbId, _episode.EpisodeNo)` |
+
+**R10 ScrollToTop の修正:**
+
+`ScrollToTop?.Invoke()` を `finally` ブロック (line 213) から `try` ブロック末尾 (line 196の後) に移動:
+
+```csharp
+        if (IsVerticalWriting) RefreshHtml();
+
+        ScrollToTop?.Invoke();  // ← try末尾に移動
+    }
+    catch (TaskCanceledException) { ... }
+    ...
+    finally
+    {
+        IsLoading = false;
+        // ScrollToTop を削除
+    }
+```
+
+---
+
+### 3. `_Apps/Services/Database/NovelRepository.cs` — R1
+
+**問題:** 3段階カスケード削除がトランザクションなし + N+1クエリ (S5も同時解消)。
+
+**修正:** line 167-178 の `DeleteAsync` メソッド本体を置換:
+
+```csharp
+public async Task DeleteAsync(int novelId)
+{
+    await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+    await _db.RunInTransactionAsync(conn =>
+    {
+        conn.Execute(
+            "DELETE FROM episode_cache WHERE episode_id IN (SELECT id FROM episodes WHERE novel_id = ?)",
+            novelId);
+        conn.Execute("DELETE FROM episodes WHERE novel_id = ?", novelId);
+        conn.Execute("DELETE FROM novels WHERE id = ?", novelId);
+    }).ConfigureAwait(false);
+}
+```
+
+`RunInTransactionAsync` は sqlite-net-pcl が提供。`BEGIN`/`COMMIT` を自動管理。
+シグネチャは `Task RunInTransactionAsync(Action<SQLiteConnection>)`。コールバック内では同期メソッド `conn.Execute` を使用する点に注意（`ExecuteAsync` ではない）。
+本コードベースで `RunInTransactionAsync` を使うのは初なので、1度だけ実装後に動作確認すること。
+サブクエリパターンは `EpisodeCacheRepository.DeleteByNovelIdAsync` (line 35-38) と同じ。
+
+---
+
+### 4. `_Apps/Services/Network/NetworkPolicyService.cs` — R2
+
+**問題:** `Dictionary<SiteType, DateTime>` が非スレッドセーフ。異なるサイトへの同時アクセスで内部状態破損の可能性。
+
+**修正:**
+
+1. `using System.Collections.Concurrent;` を追加
+2. line 25-29 を変更:
+
+```csharp
+private readonly ConcurrentDictionary<SiteType, DateTime> _lastRequestAt = new()
+{
+    [SiteType.Narou] = DateTime.MinValue,
+    [SiteType.Kakuyomu] = DateTime.MinValue,
+};
+```
+
+`_siteGates` (Dictionary<SiteType, SemaphoreSlim>) は初期化後読み取り専用のため変更不要。
+`KakuyomuApiService.cs:17` で `ConcurrentDictionary` が既に使用されており、プロジェクト内の既存パターン。
+
+---
+
+### 5. `_Apps/Services/Kakuyomu/KakuyomuApiService.cs` — R3 + R4
+
+**R3: JsonDocument の using 追加**
+
+line 160: `var doc = JsonDocument.Parse(json);` → `using var doc = JsonDocument.Parse(json);`
+
+line 164 の `apolloState.Clone()` でJsonElementは既にDocumentから独立するため安全。
+
+**R4: ParseEpisodeIds と ParseEpisodes の統合**
+
+`ParseEpisodeIdsFromApolloState` (lines 100-133) と `ParseEpisodesFromApolloState` (lines 167-221) を単一メソッドに統合し、同一のチャプター列挙から両方の結果を同時生成する。
+
+新メソッド `ParseApolloState`:
+```csharp
+private static (List<string> episodeIds, List<Episode> episodes) ParseApolloState(string html)
+{
+    var ids = new List<string>();
+    var episodes = new List<Episode>();
+    var apolloState = ExtractApolloState(html);
+    if (apolloState is null) return (ids, episodes);
+
+    var state = apolloState.Value;
+    var chapters = new List<JsonElement>();
+    foreach (var prop in state.EnumerateObject())
+    {
+        if (prop.Name.StartsWith("TableOfContentsChapter:", StringComparison.Ordinal))
+            chapters.Add(prop.Value);
+    }
+
+    int episodeNo = 0;
+    foreach (var chapter in chapters)
+    {
+        string? chapterTitle = null;
+        if (chapter.TryGetProperty("title", out var ct) && ct.ValueKind == JsonValueKind.String)
+        {
+            var t = ct.GetString();
+            if (!string.IsNullOrEmpty(t)) chapterTitle = t;
+        }
+
+        if (!chapter.TryGetProperty("episodeUnions", out var episodeUnions)) continue;
+        if (episodeUnions.ValueKind != JsonValueKind.Array) continue;
+
+        foreach (var union in episodeUnions.EnumerateArray())
+        {
+            if (!union.TryGetProperty("__ref", out var refProp)) continue;
+            var refKey = refProp.GetString();
+            if (string.IsNullOrEmpty(refKey)) continue;
+            var colonIdx = refKey.IndexOf(':');
+            if (colonIdx < 0) continue;
+            ids.Add(refKey.Substring(colonIdx + 1));
+
+            if (!state.TryGetProperty(refKey, out var episodeEntry)) continue;
+            if (!episodeEntry.TryGetProperty("__typename", out var typename)) continue;
+            if (typename.GetString() != "Episode") continue;
+
+            var title = episodeEntry.TryGetProperty("title", out var titleProp)
+                ? titleProp.GetString() ?? "" : "";
+
+            episodeNo++;
+            episodes.Add(new Episode
+            {
+                EpisodeNo = episodeNo, Title = title, ChapterName = chapterTitle,
+            });
+        }
+    }
+    return (ids, episodes);
+}
+```
+
+呼出側の変更:
+- line 89 `FetchEpisodeListAsync`: `return ParseApolloState(html).episodes;`
+- line 135 `GetEpisodeIdsAsync`: `var ids = ParseApolloState(tocHtml).episodeIds;`
+- line 260 `FetchNovelInfoAsync`: `var (episodeIds, _) = ParseApolloState(html);`
+
+旧メソッド `ParseEpisodeIdsFromApolloState` と `ParseEpisodesFromApolloState` は削除。
+
+**注意:** 統合版には元の `ParseEpisodesFromApolloState` にはない `colonIdx < 0` チェックが追加されている。Apollo state の `__ref` は常に `Type:id` 形式（例: `"Episode:12345"`）のため実用上の問題はないが、コロンを含まない `__ref` がある場合、元のコードではエピソードとして処理を試みるが統合版ではスキップされる。意図的な統一動作。
+
+---
+
+### 6. `_Apps/Services/Narou/NarouApiService.cs` — R5
+
+**問題:** `DateTime.Today`/`DateTime.Now` がデバイスローカル時間。JST以外の端末でランキング日付がずれる。
+
+**修正:** line 248-252 を変更:
+
+```csharp
+private static string BuildRtype(RankingPeriod period)
+{
+    var jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+    var now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+    var today = now.Date;
+    var dailyTarget = now.Hour < 8 ? today.AddDays(-2) : today.AddDays(-1);
+
+    return period switch
+    {
+        // ... switch 本体は変更なし
+    };
+}
+```
+
+ターゲットが `net9.0-android` 専用のため、IANA ID `"Asia/Tokyo"` で正しい。
+
+---
+
+### 7. `_Apps/App.xaml.cs` — R6 + R14
+
+**R14:** line 63 を `await` に変更（既にバックグラウンドスレッド上の async メソッド内。単一DELETE SQLなので即座に完了）:
+
+```csharp
+await _cacheRepo.DeleteExpiredAsync(cacheMonths).ConfigureAwait(false);
+```
+
+**R6:** lines 69-72 に null ガード + try-catch を追加:
+
+```csharp
+MainThread.BeginInvokeOnMainThread(async () =>
+{
+    try
+    {
+        if (Shell.Current is not null)
+            await Shell.Current.GoToAsync("//search");
+    }
+    catch (Exception ex)
+    {
+        LogHelper.Warn("App", $"Navigation to search failed: {ex.Message}");
+    }
+});
+```
+
+---
+
+### 8. `_Apps/Helpers/ReaderStyleResolver.cs` — R7
+
+**問題:** `Application.Current!` の null 抑制。アプリ終了中に NRE。
+
+**修正:** lines 15-18:
+
+```csharp
+var bg = Application.Current?.Resources.TryGetValue(bgKey, out var b) == true && b is Color bc
+    ? ColorToHex(bc) : "#FFFFFF";
+var fg = Application.Current?.Resources.TryGetValue(fgKey, out var f) == true && f is Color fc
+    ? ColorToHex(fc) : "#212121";
+```
+
+`?.` により `Application.Current` が null の場合は `bool?` → `== true` で `false` → デフォルト色にフォールバック。
+
+---
+
+### 9. `_Apps/Helpers/ReaderHtmlBuilder.cs` — R8
+
+**問題:** `content.Split('\n')` が `\r\n` を正しく処理しない。`\r` が残留。
+
+**修正:** line 42:
+
+```csharp
+foreach (var line in content.ReplaceLineEndings("\n").Split('\n'))
+```
+
+`ReplaceLineEndings` は .NET 6+ で利用可能。`\r\n`, `\r`, `\n` すべてを統一処理。
+
+---
+
+### 10. `_Apps/ViewModels/NovelListViewModel.cs` — R11
+
+**問題:** リロード判定が件数一致のみ。既読状態・お気に入り・メタデータ変更が反映されない。また `SearchViewModel.RegisterAsync` 等の外部からのDB変更も件数一致時に検知できない。
+
+**修正:** lines 65-70 の条件ブロックと `_needsReload` フィールド (line 46) を削除し、`OnAppearing` のたびに常にリロードする:
+
+```csharp
+// 変更前 (lines 65-70)
+if (!_needsReload)
+{
+    // 登録・削除でDB件数が変わった場合はリロード
+    var dbCount = await _novelRepo.CountAsync();
+    if (dbCount == Novels.Count) return;
+}
+
+// 変更後: 条件ブロックごと削除（常にLoadNovelsAsyncを実行）
+```
+
+併せて以下も削除:
+- line 46: `private bool _needsReload = true;` フィールド宣言
+- line 72: `_needsReload = false;` (InitializeAsync内)
+- line 136: `_needsReload = true;` (RefreshAsync内)
+- line 138: `_needsReload = false;` (RefreshAsync内)
+- line 201: `_needsReload = true;` (DeleteNovelAsync内)
+
+小説リストはユーザーの登録数（数十件程度）で、`GetAllWithUnreadCountAsync` は LEFT JOIN + GROUP BY 1回。SQLite on Android で数千行の episodes テーブルでも数ms程度。`OnAppearing` ごとの全リロードでパフォーマンス影響は無視可能。
+
+**修正後の最終形（参考）:**
+
+```csharp
+// InitializeAsync (line 49-)
+public async Task InitializeAsync()
+{
+    if (!_sortKeyLoaded)
+    {
+        _isInitializing = true;
+        try
+        {
+            SortKey = await _settingsRepo.GetValueAsync(SettingsKeys.NOVEL_SORT_KEY, "updated_desc");
+        }
+        finally
+        {
+            _isInitializing = false;
+        }
+        _sortKeyLoaded = true;
+        await _notificationPermission.EnsureRequestedAsync();
+    }
+    await LoadNovelsAsync();
+}
+
+// RefreshAsync (line 129-)
+[RelayCommand(CanExecute = nameof(CanRefresh))]
+private async Task RefreshAsync()
+{
+    IsLoading = true;
+    try
+    {
+        await _updateCheckService.CheckAllAsync();
+        await LoadNovelsAsync();
+    }
+    catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+    {
+        // ... 既存の catch/finally はそのまま
+    }
+    // ...
+}
+```
+
+`DeleteNovelAsync` は `_needsReload = true;` の1行を削除するのみ。
+
+---
+
+### ~~11. `_Apps/Services/Database/EpisodeCacheRepository.cs` — R12~~
+
+**削除:** コードは既に `DateTime.UtcNow` を使用しており、`"o"` 指定子は `DateTimeKind.Utc` で常に `Z` サフィックスを付加する。タイムゾーンオフセットの懸念は該当しない。むしろ明示フォーマット `"...Z"` は非UTC の DateTime でも `Z` を付けてしまうため、`"o"` の方が安全。変更不要。
+
+---
+
+### 12. `_Apps/ViewModels/SearchViewModel.cs` — R13
+
+**問題:** `RegisterAsync` で `FetchEpisodeListAsync`/`FetchNovelInfoAsync` に CancellationToken なし。
+
+**修正:** `try` ブロック先頭に CTS を追加し、2箇所にトークンを渡す:
+
+```csharp
+try
+{
+    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+    // ... (既存コード変更なし)
+
+    var episodes = await service.FetchEpisodeListAsync(result.NovelId, cts.Token);  // line 312
+
+    // ... (既存コード変更なし)
+
+    var (_, _, _, fetchedAuthor) = await service.FetchNovelInfoAsync(result.NovelId, cts.Token);  // line 330
+}
+```
+
+`SearchAsync` (line 144-145) 等と同じパターン。`TaskCanceledException` は既存の `catch (Exception ex)` でキャッチされる。
+
+---
+
+## 検証方法
+
+1. **ビルド確認:** `dotnet build _Apps/App.sln --no-restore`
+2. **R1:** 小説削除後、episodes / episode_cache テーブルに孤立データがないことを確認
+3. **R2:** 異なるサイトの小説を同時に更新チェックし、例外やデータ不整合が発生しないことを確認
+4. **R3:** カクヨムの目次ページ解析でメモリリークが発生しないことを確認（Diagnostic Toolsのマネージドヒープ）
+5. **R4:** カクヨムの複数章ある作品で、エピソードIDとエピソード番号の対応が正しいことを確認
+6. **R5:** デバイスのタイムゾーンを変更してランキング取得し、日付が正しいことを確認
+7. **R6:** アプリ起動直後にShell初期化前のタイミングでクラッシュしないことを確認
+8. **R7:** アプリ終了中（バックグラウンドキル時）にリーダー画面でNREが発生しないことを確認
+9. **R8:** `\r\n` 改行を含むエピソード本文で余分な空行が表示されないことを確認
+10. **R9:** エピソード番号に欠番がある作品で前後ナビゲーションが動作することを確認
+11. **R10:** ネットワークエラー時にスクロール位置が保持されることを確認
+12. **R11:** 検索画面で小説を登録後、一覧画面に戻った際に即座に反映されることを確認。既読状態変更後の未読数更新も確認
+13. **R13:** 低速回線で小説登録が60秒以内に完了しない場合、適切にタイムアウトエラーが表示されることを確認
+14. **R14:** アプリ起動時のキャッシュ削除が確実に完了してから後続処理に進むことを確認

--- a/_Apps/Helpers/ReaderHtmlBuilder.cs
+++ b/_Apps/Helpers/ReaderHtmlBuilder.cs
@@ -39,7 +39,7 @@ public static class ReaderHtmlBuilder
         sb.Append("p{margin:0 0 1em 0;text-indent:1em;}");
         sb.Append("</style></head><body>");
 
-        foreach (var line in content.Split('\n'))
+        foreach (var line in content.ReplaceLineEndings("\n").Split('\n'))
         {
             sb.Append("<p>");
             sb.Append(System.Net.WebUtility.HtmlEncode(line));

--- a/_Apps/Helpers/ReaderStyleResolver.cs
+++ b/_Apps/Helpers/ReaderStyleResolver.cs
@@ -12,9 +12,9 @@ public static class ReaderStyleResolver
         var bgKey = themeIndex switch { 1 => "ThemeDarkBg", 2 => "ThemeSepiaBg", _ => "ThemeWhiteBg" };
         var fgKey = themeIndex switch { 1 => "ThemeDarkText", 2 => "ThemeSepiaText", _ => "ThemeWhiteText" };
 
-        var bg = Application.Current!.Resources.TryGetValue(bgKey, out var b) && b is Color bc
+        var bg = Application.Current?.Resources.TryGetValue(bgKey, out var b) == true && b is Color bc
             ? ColorToHex(bc) : "#FFFFFF";
-        var fg = Application.Current!.Resources.TryGetValue(fgKey, out var f) && f is Color fc
+        var fg = Application.Current?.Resources.TryGetValue(fgKey, out var f) == true && f is Color fc
             ? ColorToHex(fc) : "#212121";
         return (bg, fg);
     }

--- a/_Apps/Services/Database/EpisodeRepository.cs
+++ b/_Apps/Services/Database/EpisodeRepository.cs
@@ -55,6 +55,30 @@ public class EpisodeRepository
             .FirstOrDefaultAsync(e => e.NovelId == novelId && e.EpisodeNo == episodeNo).ConfigureAwait(false);
     }
 
+    public async Task<Episode?> GetPreviousEpisodeAsync(int novelId, int currentEpisodeNo)
+    {
+        await EnsureAsync().ConfigureAwait(false);
+        var results = await _db.QueryAsync<Episode>(
+            "SELECT id, novel_id, episode_no, chapter_name, title, " +
+            "is_read, read_at, published_at, is_favorite, favorited_at " +
+            "FROM episodes WHERE novel_id = ? AND episode_no < ? " +
+            "ORDER BY episode_no DESC LIMIT 1",
+            novelId, currentEpisodeNo).ConfigureAwait(false);
+        return results.FirstOrDefault();
+    }
+
+    public async Task<Episode?> GetNextEpisodeAsync(int novelId, int currentEpisodeNo)
+    {
+        await EnsureAsync().ConfigureAwait(false);
+        var results = await _db.QueryAsync<Episode>(
+            "SELECT id, novel_id, episode_no, chapter_name, title, " +
+            "is_read, read_at, published_at, is_favorite, favorited_at " +
+            "FROM episodes WHERE novel_id = ? AND episode_no > ? " +
+            "ORDER BY episode_no ASC LIMIT 1",
+            novelId, currentEpisodeNo).ConfigureAwait(false);
+        return results.FirstOrDefault();
+    }
+
     public async Task<Episode?> GetByIdAsync(int id)
     {
         await EnsureAsync().ConfigureAwait(false);

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -167,14 +167,14 @@ public class NovelRepository
     public async Task DeleteAsync(int novelId)
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
-        // CASCADE: episode_cache → episodes → novels
-        var episodes = await _db.Table<Episode>().Where(e => e.NovelId == novelId).ToListAsync().ConfigureAwait(false);
-        foreach (var ep in episodes)
+        await _db.RunInTransactionAsync(conn =>
         {
-            await _db.ExecuteAsync("DELETE FROM episode_cache WHERE episode_id = ?", ep.Id).ConfigureAwait(false);
-        }
-        await _db.ExecuteAsync("DELETE FROM episodes WHERE novel_id = ?", novelId).ConfigureAwait(false);
-        await _db.DeleteAsync<Novel>(novelId).ConfigureAwait(false);
+            conn.Execute(
+                "DELETE FROM episode_cache WHERE episode_id IN (SELECT id FROM episodes WHERE novel_id = ?)",
+                novelId);
+            conn.Execute("DELETE FROM episodes WHERE novel_id = ?", novelId);
+            conn.Execute("DELETE FROM novels WHERE id = ?", novelId);
+        }).ConfigureAwait(false);
     }
 
     public async Task<int> CountAsync()

--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -94,42 +94,7 @@ public class KakuyomuApiService : INovelService
         var url = $"{BASE_URL}/works/{novelId}";
         var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
 
-        return ParseEpisodesFromApolloState(html);
-    }
-
-    private static List<string> ParseEpisodeIdsFromApolloState(string html)
-    {
-        var ids = new List<string>();
-        var apolloState = ExtractApolloState(html);
-        if (apolloState is null) return ids;
-
-        var state = apolloState.Value;
-        var chapters = new List<JsonElement>();
-        foreach (var prop in state.EnumerateObject())
-        {
-            if (prop.Name.StartsWith("TableOfContentsChapter:", StringComparison.Ordinal))
-            {
-                chapters.Add(prop.Value);
-            }
-        }
-
-        foreach (var chapter in chapters)
-        {
-            if (!chapter.TryGetProperty("episodeUnions", out var episodeUnions)) continue;
-            if (episodeUnions.ValueKind != JsonValueKind.Array) continue;
-
-            foreach (var union in episodeUnions.EnumerateArray())
-            {
-                if (!union.TryGetProperty("__ref", out var refProp)) continue;
-                var refKey = refProp.GetString();
-                if (string.IsNullOrEmpty(refKey)) continue;
-                var colonIdx = refKey.IndexOf(':');
-                if (colonIdx < 0) continue;
-                ids.Add(refKey.Substring(colonIdx + 1));
-            }
-        }
-
-        return ids;
+        return ParseApolloState(html).episodes;
     }
 
     private async Task<List<string>> GetEpisodeIdsAsync(string novelId, CancellationToken ct)
@@ -142,7 +107,7 @@ public class KakuyomuApiService : INovelService
 
         var tocUrl = $"{BASE_URL}/works/{novelId}";
         var tocHtml = await _network.GetStringAsync(SiteType.Kakuyomu, tocUrl, ct).ConfigureAwait(false);
-        var ids = ParseEpisodeIdsFromApolloState(tocHtml);
+        var ids = ParseApolloState(tocHtml).episodeIds;
         _episodeIdCache[novelId] = (DateTime.UtcNow, ids);
         return ids;
     }
@@ -157,18 +122,19 @@ public class KakuyomuApiService : INovelService
         if (end < 0) return null;
 
         var json = html.Substring(start, end - start);
-        var doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(json);
         if (!doc.RootElement.TryGetProperty("props", out var props)) return null;
         if (!props.TryGetProperty("pageProps", out var pageProps)) return null;
         if (!pageProps.TryGetProperty("__APOLLO_STATE__", out var apolloState)) return null;
         return apolloState.Clone();
     }
 
-    private static List<Episode> ParseEpisodesFromApolloState(string html)
+    private static (List<string> episodeIds, List<Episode> episodes) ParseApolloState(string html)
     {
+        var ids = new List<string>();
         var episodes = new List<Episode>();
         var apolloState = ExtractApolloState(html);
-        if (apolloState is null) return episodes;
+        if (apolloState is null) return (ids, episodes);
 
         var state = apolloState.Value;
         var chapters = new List<JsonElement>();
@@ -198,6 +164,9 @@ public class KakuyomuApiService : INovelService
                 if (!union.TryGetProperty("__ref", out var refProp)) continue;
                 var refKey = refProp.GetString();
                 if (string.IsNullOrEmpty(refKey)) continue;
+                var colonIdx = refKey.IndexOf(':');
+                if (colonIdx < 0) continue;
+                ids.Add(refKey.Substring(colonIdx + 1));
 
                 if (!state.TryGetProperty(refKey, out var episodeEntry)) continue;
                 if (!episodeEntry.TryGetProperty("__typename", out var typename)) continue;
@@ -217,7 +186,7 @@ public class KakuyomuApiService : INovelService
             }
         }
 
-        return episodes;
+        return (ids, episodes);
     }
 
     public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default)
@@ -267,7 +236,7 @@ public class KakuyomuApiService : INovelService
 
         // 更新チェックでフェッチした最新TOCでキャッシュを上書きする。
         // これにより直後の Prefetch が古いエピソードIDリストを使うリスクを防ぐ。
-        var episodeIds = ParseEpisodeIdsFromApolloState(html);
+        var (episodeIds, _) = ParseApolloState(html);
         _episodeIdCache[novelId] = (DateTime.UtcNow, episodeIds);
         var totalEpisodes = episodeIds.Count;
 

--- a/_Apps/Services/Narou/NarouApiService.cs
+++ b/_Apps/Services/Narou/NarouApiService.cs
@@ -247,9 +247,11 @@ public class NarouApiService : INovelService
 
     private static string BuildRtype(RankingPeriod period)
     {
-        var today = DateTime.Today;
+        var jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        var now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+        var today = now.Date;
         // 4:00-7:00頃集計のため、当日朝8時以前は2日前、それ以外は前日を採用
-        var dailyTarget = DateTime.Now.Hour < 8 ? today.AddDays(-2) : today.AddDays(-1);
+        var dailyTarget = now.Hour < 8 ? today.AddDays(-2) : today.AddDays(-1);
 
         return period switch
         {

--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using LanobeReader.Helpers;
 using LanobeReader.Models;
 using LanobeReader.Services.Database;
@@ -22,7 +23,7 @@ public class NetworkPolicyService
         [SiteType.Kakuyomu] = new SemaphoreSlim(1, 1),
     };
 
-    private readonly Dictionary<SiteType, DateTime> _lastRequestAt = new()
+    private readonly ConcurrentDictionary<SiteType, DateTime> _lastRequestAt = new()
     {
         [SiteType.Narou] = DateTime.MinValue,
         [SiteType.Kakuyomu] = DateTime.MinValue,

--- a/_Apps/ViewModels/NovelListViewModel.cs
+++ b/_Apps/ViewModels/NovelListViewModel.cs
@@ -43,7 +43,6 @@ public partial class NovelListViewModel : ObservableObject
     private string _sortKey = "updated_desc";
 
     private bool _sortKeyLoaded;
-    private bool _needsReload = true;
     private bool _isInitializing;
 
     public async Task InitializeAsync()
@@ -62,14 +61,7 @@ public partial class NovelListViewModel : ObservableObject
             _sortKeyLoaded = true;
             await _notificationPermission.EnsureRequestedAsync();
         }
-        if (!_needsReload)
-        {
-            // 登録・削除でDB件数が変わった場合はリロード
-            var dbCount = await _novelRepo.CountAsync();
-            if (dbCount == Novels.Count) return;
-        }
         await LoadNovelsAsync();
-        _needsReload = false;
     }
 
 
@@ -133,9 +125,7 @@ public partial class NovelListViewModel : ObservableObject
         try
         {
             await _updateCheckService.CheckAllAsync();
-            _needsReload = true;
             await LoadNovelsAsync();
-            _needsReload = false;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
@@ -198,7 +188,6 @@ public partial class NovelListViewModel : ObservableObject
         {
             await _novelRepo.DeleteAsync(card.Id);
             Novels.Remove(card);
-            _needsReload = true;
         }
     }
 }

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -156,8 +156,8 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
             _episode = await _episodeRepo.GetByIdAsync(episodeId);
             if (_episode is null) return;
 
-            var prev = await _episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo - 1);
-            var next = await _episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo + 1);
+            var prev = await _episodeRepo.GetPreviousEpisodeAsync(_novelDbId, _episode.EpisodeNo);
+            var next = await _episodeRepo.GetNextEpisodeAsync(_novelDbId, _episode.EpisodeNo);
 
             string content;
             var cache = await _cacheRepo.GetByEpisodeIdAsync(episodeId);
@@ -194,6 +194,8 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
             IsFooterVisible = true;
 
             if (IsVerticalWriting) RefreshHtml();
+
+            ScrollToTop?.Invoke();
         }
         catch (TaskCanceledException)
         {
@@ -210,7 +212,6 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         finally
         {
             IsLoading = false;
-            ScrollToTop?.Invoke();
         }
     }
 
@@ -218,7 +219,7 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private async Task PrevEpisodeAsync()
     {
         if (_episode is null) return;
-        var prev = await _episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo - 1);
+        var prev = await _episodeRepo.GetPreviousEpisodeAsync(_novelDbId, _episode.EpisodeNo);
         if (prev is not null)
         {
             _currentEpisodeId = prev.Id;
@@ -232,7 +233,7 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private async Task NextEpisodeAsync()
     {
         if (_episode is null) return;
-        var next = await _episodeRepo.GetByNovelAndEpisodeNoAsync(_novelDbId, _episode.EpisodeNo + 1);
+        var next = await _episodeRepo.GetNextEpisodeAsync(_novelDbId, _episode.EpisodeNo);
         if (next is not null)
         {
             _currentEpisodeId = next.Id;

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -294,6 +294,8 @@ public partial class SearchViewModel : ObservableObject
         result.IsRegistering = true;
         try
         {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             var novel = new Novel
             {
                 SiteType = (int)result.SiteType,
@@ -309,7 +311,7 @@ public partial class SearchViewModel : ObservableObject
             await _novelRepo.InsertAsync(novel);
 
             var service = _serviceFactory.GetService(result.SiteType);
-            var episodes = await service.FetchEpisodeListAsync(result.NovelId);
+            var episodes = await service.FetchEpisodeListAsync(result.NovelId, cts.Token);
 
             var dbNovel = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
             if (dbNovel is not null)
@@ -327,7 +329,7 @@ public partial class SearchViewModel : ObservableObject
                 {
                     try
                     {
-                        var (_, _, _, fetchedAuthor) = await service.FetchNovelInfoAsync(result.NovelId);
+                        var (_, _, _, fetchedAuthor) = await service.FetchNovelInfoAsync(result.NovelId, cts.Token);
                         if (!string.IsNullOrEmpty(fetchedAuthor))
                         {
                             dbNovel.Author = fetchedAuthor;


### PR DESCRIPTION
## Summary

コードレビューで検出された14件の潜在的リスク (R1-R14) のうち、実質修正が必要な13件を修正（R12は調査の結果、変更不要と判断）。

プラン: [_Apps/Features/plan_2026-04-16_risk-r1-r14.md](_Apps/Features/plan_2026-04-16_risk-r1-r14.md)

## 修正内容

| ID | 対象 | 変更概要 |
|----|------|----------|
| R1 | `NovelRepository.DeleteAsync` | 3段階カスケード削除を `RunInTransactionAsync` でトランザクション化し、N+1クエリをサブクエリ1本に統合 |
| R2 | `NetworkPolicyService._lastRequestAt` | `Dictionary` → `ConcurrentDictionary` で非スレッドセーフを解消 |
| R3 | `KakuyomuApiService.ExtractApolloState` | `JsonDocument` に `using` を付与（`JsonElement.Clone()` で戻り値は独立） |
| R4 | `KakuyomuApiService.ParseApolloState` | `ParseEpisodeIdsFromApolloState` と `ParseEpisodesFromApolloState` を単一メソッドに統合し重複走査を排除 |
| R5 | `NarouApiService.BuildRtype` | `DateTime.Today`/`DateTime.Now` → JST (`Asia/Tokyo`) 固定変換で端末タイムゾーン非依存化 |
| R6 | `App.InitializeAppAsync` | `MainThread.BeginInvokeOnMainThread` 内に null ガード + try-catch を追加 |
| R7 | `ReaderStyleResolver.ResolveThemeColors` | `Application.Current!` → `?.` で null 安全化、フォールバック色使用 |
| R8 | `ReaderHtmlBuilder.Build` | `ReplaceLineEndings("\n")` を追加し CRLF/CR/LF を統一 |
| R9 | `EpisodeRepository` | `GetPreviousEpisodeAsync` / `GetNextEpisodeAsync` を新設し、欠番対応。`ReaderViewModel` 4箇所も更新 |
| R10 | `ReaderViewModel.LoadEpisodeAsync` | `ScrollToTop?.Invoke()` を `finally` → 成功時の `try` 末尾へ移動 |
| R11 | `NovelListViewModel` | `_needsReload` とDB件数比較リロード条件を撤去し、OnAppearing ごとに常時リロード |
| ~~R12~~ | `EpisodeCacheRepository` | 既に `DateTime.UtcNow` + `"o"` で `Z` 付与されるため変更不要と判断 |
| R13 | `SearchViewModel.RegisterAsync` | 60秒 CancellationTokenSource を追加し `FetchEpisodeListAsync`/`FetchNovelInfoAsync` に `ct` を引き回し |
| R14 | `App.InitializeAppAsync` | `_cacheRepo.DeleteExpiredAsync` を fire-and-forget → `await` |

## Test plan

- [x] `dotnet build _Apps/App.sln --no-restore` 成功 (0 Warning / 0 Error)
- [ ] R1: 小説削除後 `episodes` / `episode_cache` に孤立行がないこと
- [ ] R2: 異サイト小説を同時更新チェックしても例外なし
- [ ] R4: 複数章作品でエピソードIDとエピソード番号の対応が正しい
- [ ] R5: 端末タイムゾーン変更後もランキング日付が JST ベース
- [ ] R8: `\r\n` 改行本文で余分な空行が出ない
- [ ] R9: エピソード番号欠番作品で前後ナビが動作
- [ ] R10: ネットワークエラー時にスクロール位置が保持される
- [ ] R11: 検索画面で登録→一覧戻りで即反映。既読状態変化の未読数にも追従
- [ ] R13: 低速回線で60秒超過時にタイムアウトメッセージが表示