### PR TITLE
fix: SMELL 修正 S1,S4-S13,S15 (12件)

### DIFF
--- a/_Apps/App.xaml.cs
+++ b/_Apps/App.xaml.cs
@@ -57,6 +57,7 @@ public partial class App : Application
         {
             // 1. Initialize database (background thread)
             await _dbService.InitializeAsync().ConfigureAwait(false);
+            await _settingsRepo.LoadAllAsync().ConfigureAwait(false);
 
             // 2. Delete expired cache
             var cacheMonths = await _settingsRepo.GetIntValueAsync(SettingsKeys.CACHE_MONTHS, 3).ConfigureAwait(false);

--- a/_Apps/App.xaml.cs
+++ b/_Apps/App.xaml.cs
@@ -81,36 +81,40 @@ public partial class App : Application
             }
             else
             {
-                // 4. Run update check (already on background thread)
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await _updateCheckService.CheckAllAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        LogHelper.Warn("App", $"Background update check failed: {ex.Message}");
-                    }
-                });
+                // 4. Run update check (fire-and-forget, already on background thread)
+                _ = RunUpdateCheckAsync();
 
                 // 5. Scan unread+uncached episodes and enqueue for prefetch
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await _prefetchService.EnqueueAllUnreadAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        LogHelper.Warn("App", $"Prefetch scan failed: {ex.Message}");
-                    }
-                });
+                _ = RunPrefetchAsync();
             }
         }
         catch (Exception ex)
         {
             LogHelper.Error("App", $"InitializeAppAsync failed: {ex.Message}");
+        }
+    }
+
+    private async Task RunUpdateCheckAsync()
+    {
+        try
+        {
+            await _updateCheckService.CheckAllAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn("App", $"Background update check failed: {ex.Message}");
+        }
+    }
+
+    private async Task RunPrefetchAsync()
+    {
+        try
+        {
+            await _prefetchService.EnqueueAllUnreadAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn("App", $"Prefetch scan failed: {ex.Message}");
         }
     }
 }

--- a/_Apps/Converters/BoolToColorConverter.cs
+++ b/_Apps/Converters/BoolToColorConverter.cs
@@ -2,10 +2,25 @@ using System.Globalization;
 
 namespace LanobeReader.Converters;
 
-public class BoolToColorConverter : IValueConverter
+public class BoolToColorConverter : BindableObject, IValueConverter
 {
-    public Color TrueColor { get; set; } = Colors.Black;
-    public Color FalseColor { get; set; } = Colors.Gray;
+    public static readonly BindableProperty TrueColorProperty =
+        BindableProperty.Create(nameof(TrueColor), typeof(Color), typeof(BoolToColorConverter), Colors.Black);
+
+    public static readonly BindableProperty FalseColorProperty =
+        BindableProperty.Create(nameof(FalseColor), typeof(Color), typeof(BoolToColorConverter), Colors.Gray);
+
+    public Color TrueColor
+    {
+        get => (Color)GetValue(TrueColorProperty);
+        set => SetValue(TrueColorProperty, value);
+    }
+
+    public Color FalseColor
+    {
+        get => (Color)GetValue(FalseColorProperty);
+        set => SetValue(FalseColorProperty, value);
+    }
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is true ? TrueColor : FalseColor;

--- a/_Apps/Features/plan_2026-04-21_smell-s1-s15.md
+++ b/_Apps/Features/plan_2026-04-21_smell-s1-s15.md
@@ -1,0 +1,591 @@
+# SMELL修正プラン (S1-S15)
+
+コードレビュー (`todo_2026-04-14_code-review.md`) で発見された 15 件のコード品質問題（SMELL）を修正する。
+
+ブランチ: `app-novelviewer` から `feature/smell-s1-s15` を作成 → `app-novelviewer` へ PR。
+
+---
+
+## スコープ判断（重要）
+
+| 区分 | 件数 | 項目 | 方針 |
+|---|---|---|---|
+| **本PRで実施** | 11 | S3, S4, S5, S6, S7, S8, S9, S10, S11, S12, S13, S15 | 1 PR にまとめる |
+| **本PRで実施（限定）** | 1 | S1 | int→bool は SQLite-net が型を吸収するため可能。XAML 側も併せて対応 |
+| **別PR分離を推奨** | 2 | S2, S14 | 影響範囲が広く独立性高い |
+
+### 別PR分離理由
+
+- **S2 (日時 string→DateTime)**: 既存DB列型 (TEXT) と SQLite-net マッピングの相互運用、ソート挙動、UI 全表示の `DateTime.TryParse` 削除など、1 ファイル変更で連鎖的に 10+ ファイル影響。リグレッション検出に独立 PR が望ましい。
+- **S14 (HttpClient → IHttpClientFactory)**: `Microsoft.Extensions.Http` パッケージ追加 + `NetworkPolicyService` のコンストラクタ DI 変更 + 既存 HttpClient 直接利用箇所の見直し。SMELL 修正と性質が異なる「依存関係導入」のため切り離す。
+
+### S1 についての注意
+
+`SearchResult.IsCompleted` (bool) との型不整合解消。SQLite-net は `bool` プロパティを INTEGER カラムにマップするため**既存DB互換**。
+
+**XAML への影響は限定的**: 全ページが ViewModel (EpisodeViewModel / NovelCardViewModel / SearchResultViewModel) 経由でバインドしており、VM 側は既に bool 型。**XAML/コンバータの変更は不要**（`IntToBoolConverter` は `NovelListPage.xaml:83` で `UnreadCount`(int件数) → bool 変換に使用中のため**残す**）。
+
+連鎖変更が発生するのは主に以下：
+- Model (Episode.cs, Novel.cs) の `int` → `bool`
+- Repository / Service の生SQL 引数 (`1`/`0` → `true`/`false`) および LINQ (`== 1`, `== 0`) 置換
+- `XxxViewModel.FromModel` 内の `int → bool` 変換 (`== 1`) 削除
+- ViewModel で Model を書き戻している箇所 (`? 1 : 0`) の削除
+- リスクを抑えるため **S1 のみで 1 コミット** に分離する
+
+---
+
+## 修正一覧（ファイル別、実装順）
+
+### 1. `_Apps/Helpers/LogHelper.cs` — S4
+
+**問題:** `Debug.WriteLine` は Release ビルドで除去され本番ログ取得不可。
+
+**修正:** `Console.WriteLine` を併用（Android 本番でも logcat に出力される）。ファイル全体置換：
+
+```csharp
+using System.Diagnostics;
+
+namespace LanobeReader.Helpers;
+
+public static class LogHelper
+{
+    public static void Info(string className, string message) => Write("INFO", className, message);
+    public static void Warn(string className, string message) => Write("WARN", className, message);
+    public static void Error(string className, string message) => Write("ERROR", className, message);
+
+    private static void Write(string level, string className, string message)
+    {
+        var line = $"[LanobeReader][{className}] {level}: {message}";
+        Debug.WriteLine(line);
+        Console.WriteLine(line);
+    }
+}
+```
+
+**根拠:** `ILogger<T>` 導入は影響範囲が広いため、最小変更で本番ログ取得を実現。
+
+---
+
+### 2. `_Apps/Resources/Styles/Converters.xaml` — S11
+
+**問題:** `BoolToGrayConverter` の `FalseColor="Black"` がダークテーマで黒背景に黒文字となり判読不能。
+
+**修正:** `Colors.xaml` 既存の `Gray500`/`Black`/`White` を `AppThemeBinding` で組み合わせる（`Styles.xaml:7,13` で使用されている既存パターンに準拠）：
+
+```xml
+<converters:BoolToColorConverter x:Key="BoolToGrayConverter"
+    TrueColor="{StaticResource Gray500}"
+    FalseColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+```
+
+- `TrueColor` (既読): Light/Dark 両方で `Gray500` (#6E6E6E) → どちらの背景でも判読可能なグレー
+- `FalseColor` (未読): Light=`Black`、Dark=`White` → 本文色に準拠
+
+**確認事項:** 該当バインドは `EpisodeListPage.xaml:46,53` の `IsRead` 用途のみ（grep で他なし）。他コンバータ用途への影響なし。
+
+---
+
+### 3. `_Apps/Views/SettingsPage.xaml` — S12
+
+**調査結果:** `<Frame>` の使用は `SettingsPage.xaml:59` の **1箇所のみ**（grep 実施済み、他の xaml/cs になし）。`Styles.xaml:19-30` に既存の `CardBorder` スタイル（Shadow + RoundRectangle 8px）が定義されており、`NovelListPage.xaml:46` 等で既に利用されているため**再利用が最善**。
+
+**修正:** line 59-61 を既存スタイル参照に置換：
+
+```xml
+<Border Padding="12" Style="{StaticResource CardBorder}">
+    <Label Text="{Binding PreviewText}" FontSize="{Binding FontSizeSp}" />
+</Border>
+```
+
+**根拠:** `CardBorder` は Shadow Radius=14 Offset=0,6 で SettingsPage のプレビュー枠として視覚的に自然。独自 Shadow を新規定義するより既存スタイルに統一することで S8/S9 と同じ「設計統一」方針に合致。
+
+**トレードオフ:** 既存 `CardBorder` の影は `NovelListPage` のカード用に調整されており、SettingsPage のプレビュー枠には若干強めに見える可能性。気になる場合は `Padding` 以外に `Margin="0,4"` 等で調整（目視確認必須）。
+
+---
+
+### 4. `_Apps/Views/NovelListPage.xaml` + `NovelListPage.xaml.cs` — S13
+
+**問題:** line 21-25 の `x:Name="EmptyView"` を持つ `VerticalStackLayout` は `IsVisible="False"` 固定で、表示制御コードが存在しない（grep で参照なし）。実際の空状態表示は line 99-103 の `<CollectionView.EmptyView>` で行われている。
+
+**修正:**
+- `NovelListPage.xaml`: line 21-25 の `<VerticalStackLayout IsVisible="False" x:Name="EmptyView">...</VerticalStackLayout>` を削除
+- `NovelListPage.xaml.cs`: `OnGoToSearchClicked` メソッド (line 21-24) も削除（該当 Button が消えるため未参照になる）
+
+---
+
+### 5. `_Apps/App.xaml.cs` — S15
+
+**問題:** `InitializeAppAsync` は既に `Task.Run` 経由で起動されたバックグラウンドスレッド上で実行されているのに、内部で更に `Task.Run(async () => ...)` でラップしている (line 85, 98)。スレッドプール枯渇要因。
+
+**修正:** line 84-108 の 2 箇所の `_ = Task.Run(async () => { ... });` を `try/catch` 直接実行に変更。ただし Fire-and-forget の意味（Initialize 完了を待たずに次へ進む）を保持するため `_ = Task.Run` ではなく `_ = (async () => { ... })();` 即時実行ラムダ＋fire-and-forget 化：
+
+```csharp
+_ = RunUpdateCheckAsync();
+_ = RunPrefetchAsync();
+```
+
+```csharp
+private async Task RunUpdateCheckAsync()
+{
+    try { await _updateCheckService.CheckAllAsync().ConfigureAwait(false); }
+    catch (Exception ex) { LogHelper.Warn("App", $"Background update check failed: {ex.Message}"); }
+}
+
+private async Task RunPrefetchAsync()
+{
+    try { await _prefetchService.EnqueueAllUnreadAsync().ConfigureAwait(false); }
+    catch (Exception ex) { LogHelper.Warn("App", $"Prefetch scan failed: {ex.Message}"); }
+}
+```
+
+**根拠:** 既にバックグラウンドスレッド上のため追加 `Task.Run` は無意味。並列性は `_ =` の fire-and-forget で確保される。
+
+---
+
+### 6. `_Apps/Services/Database/NovelRepository.cs` — S5
+
+**問題:** line 167-178 `DeleteAsync` の トランザクション内で `episode_cache` 削除を生 SQL でインライン実装 (line 172-174)。`EpisodeCacheRepository.DeleteByNovelIdAsync` (同じクエリ) と**重複**。
+
+> **注意:** `todo_2026-04-14_code-review.md` は「N+1 クエリ」と記述しているが、実際は `WHERE episode_id IN (SELECT ...)` のサブクエリを使った**1本のDELETE** であり N+1 ではない。真の問題は「同一クエリの重複実装」。
+
+**修正:** `EpisodeCacheRepository` への DI を追加し、トランザクション内で呼び出し。SQLite-net の `RunInTransactionAsync` は同期コールバックなので、`EpisodeCacheRepository` の **同期版メソッド** が必要：
+
+#### 6a. `EpisodeCacheRepository.cs` に同期版を追加
+
+```csharp
+internal void DeleteByNovelIdSync(SQLiteConnection conn, int novelId)
+{
+    conn.Execute(
+        "DELETE FROM episode_cache WHERE episode_id IN (SELECT id FROM episodes WHERE novel_id = ?)",
+        novelId);
+}
+```
+
+`SQLiteConnection` を引数で受け取ることで、`RunInTransactionAsync` の同期コールバック内で使える形に統一。
+
+#### 6b. `NovelRepository.cs` 修正
+
+- コンストラクタに `EpisodeCacheRepository cacheRepo` を追加
+- `DeleteAsync` 内のインライン SQL を `_cacheRepo.DeleteByNovelIdSync(conn, novelId)` に置換
+
+```csharp
+public NovelRepository(DatabaseService dbService, EpisodeCacheRepository cacheRepo)
+{
+    _dbService = dbService;
+    _db = dbService.Connection;
+    _cacheRepo = cacheRepo;
+}
+
+public async Task DeleteAsync(int novelId)
+{
+    await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+    await _db.RunInTransactionAsync(conn =>
+    {
+        _cacheRepo.DeleteByNovelIdSync(conn, novelId);
+        conn.Execute("DELETE FROM episodes WHERE novel_id = ?", novelId);
+        conn.Execute("DELETE FROM novels WHERE id = ?", novelId);
+    }).ConfigureAwait(false);
+}
+```
+
+**注意:** `MauiProgram.cs` の DI 順序は既に `EpisodeCacheRepository` → `NovelRepository` 登録順は問題ない（DI コンテナが解決）。
+
+---
+
+### 7. `_Apps/Services/Network/NetworkPolicyService.cs` — S6, S7
+
+#### 7a. S6: `IsOnline` 例外時 `false` 返却（fail-closed）
+
+**問題:** line 53-55 で例外時 `true` を返却（楽観的）。プラットフォーム API 失敗時に「オンライン扱い」となり、ネットワーク呼出が失敗してリトライループに陥るリスク。`IsWifiConnected` (line 67-68) は例外時 `false` を返す（fail-closed）ため**整合性が取れていない**。
+
+**修正:** line 54-55 を以下に変更：
+
+```csharp
+try { return Connectivity.Current.NetworkAccess == NetworkAccess.Internet; }
+catch (Exception ex)
+{
+    LogHelper.Warn(nameof(NetworkPolicyService), $"IsOnline check failed: {ex.Message}");
+    return false;
+}
+```
+
+**トレードオフ:** Connectivity API が常に失敗する環境では一切リクエストしなくなる。ただし `IsWifiConnected` も同様の挙動なので、整合性優先。
+
+#### 7b. S7: `AppSettingsRepository` に起動時一括ロードキャッシュを実装
+
+**問題:** `NetworkPolicyService.EnforceDelayAsync` がリクエスト毎に DB 読取。同様に `SettingsViewModel.InitializeAsync` でも 9 項目を順次 DB 読取。設定値は **数百バイト、書き込みも設定画面操作時のみ** のため全量メモリキャッシュが現実的。
+
+**修正方針:** `AppSettingsRepository` 自体にインメモリキャッシュを持たせ、
+- 起動時 `LoadAllAsync()` で全件メモリロード
+- `GetValueAsync`/`GetIntValueAsync` はキャッシュ参照のみ（DB 無し）
+- `SetValueAsync` は DB 書込 + キャッシュ更新を同時実行
+
+`AppSettingsRepository` は既に `MauiProgram.cs:35` で **Singleton 登録済み**のため、DI 同一インスタンスが全箇所に注入される。`public static` は不要（Singleton で同等を達成、かつテスタビリティ保持）。
+
+#### 修正後の `AppSettingsRepository.cs`
+
+```csharp
+using System.Collections.Concurrent;
+using LanobeReader.Models;
+using SQLite;
+
+namespace LanobeReader.Services.Database;
+
+public class AppSettingsRepository
+{
+    private readonly SQLiteAsyncConnection _db;
+    private readonly DatabaseService _dbService;
+    private readonly ConcurrentDictionary<string, string> _cache = new();
+    private volatile bool _loaded;
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
+
+    public AppSettingsRepository(DatabaseService dbService)
+    {
+        _dbService = dbService;
+        _db = dbService.Connection;
+    }
+
+    /// <summary>アプリ起動時に1回呼び出す。全設定値をメモリキャッシュする。</summary>
+    public async Task LoadAllAsync()
+    {
+        if (_loaded) return;
+        await _loadGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_loaded) return;
+            await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+            var rows = await _db.Table<AppSetting>().ToListAsync().ConfigureAwait(false);
+            foreach (var r in rows) _cache[r.Key] = r.Value;
+            _loaded = true;
+        }
+        finally { _loadGate.Release(); }
+    }
+
+    public async Task<string> GetValueAsync(string key, string defaultValue = "")
+    {
+        if (!_loaded) await LoadAllAsync().ConfigureAwait(false);
+        return _cache.TryGetValue(key, out var v) ? v : defaultValue;
+    }
+
+    public async Task<int> GetIntValueAsync(string key, int defaultValue = 0)
+    {
+        var value = await GetValueAsync(key).ConfigureAwait(false);
+        return int.TryParse(value, out var result) ? result : defaultValue;
+    }
+
+    public async Task SetValueAsync(string key, string value)
+    {
+        if (!_loaded) await LoadAllAsync().ConfigureAwait(false);
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        var setting = await _db.FindAsync<AppSetting>(key).ConfigureAwait(false);
+        if (setting is not null)
+        {
+            setting.Value = value;
+            await _db.UpdateAsync(setting).ConfigureAwait(false);
+        }
+        else
+        {
+            await _db.InsertAsync(new AppSetting { Key = key, Value = value }).ConfigureAwait(false);
+        }
+        _cache[key] = value; // キャッシュ同時更新
+    }
+}
+```
+
+#### App.xaml.cs の起動シーケンス修正
+
+`InitializeAppAsync` の DB 初期化直後に `LoadAllAsync` を追加：
+
+```csharp
+await _dbService.InitializeAsync().ConfigureAwait(false);
+await _settingsRepo.LoadAllAsync().ConfigureAwait(false);  // ← 追加
+var cacheMonths = await _settingsRepo.GetIntValueAsync(SettingsKeys.CACHE_MONTHS, 3).ConfigureAwait(false);
+```
+
+#### NetworkPolicyService の `GetDelayMsAsync` 簡素化
+
+キャッシュ前提なので `try/catch` と TTL 不要：
+
+```csharp
+private async Task<int> GetDelayMsAsync()
+{
+    var v = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, SettingsKeys.DEFAULT_REQUEST_DELAY_MS).ConfigureAwait(false);
+    return Math.Clamp(v, 100, 5000);
+}
+```
+
+**副次効果:**
+- `SettingsViewModel.InitializeAsync` の 9 項目 DB 読取も全てキャッシュヒットに（UI 表示高速化）
+- `App.xaml.cs:62` の `CACHE_MONTHS` 取得もキャッシュヒット
+- 全体として設定読取の DB アクセスがほぼゼロになる
+
+**トレードオフ:**
+- アプリ起動時に全設定行の一括読取が発生（現状設定値は10数件、数KB 以内のため影響なし）
+- Android `UpdateCheckWorker` が**別プロセス**で動く場合、そちらは独自に `LoadAllAsync` が必要。現状 `WorkManager` の `ListenableWorker` は同一プロセスで動作するが、念のため `UpdateCheckWorker` 内の設定読取パスを調査し、必要なら `LoadAllAsync` を先頭に追加（後述の検証チェックリストに含める）
+- ConcurrentDictionary は読み込み高速、書き込みもロックフリーに近い → スレッドセーフ要件を満たす
+
+---
+
+### 8. `_Apps/ViewModels/SettingsViewModel.cs` — S10
+
+**問題:** line 71-123 の全 `OnXxxChanged` が `_ = _settingsRepo.SetValueAsync(...)` で fire-and-forget 保存。スライダー高速操作時に DB 書込みが並列発生し、SQLite ロック衝突リスク。
+
+**修正:** デバウンス機構を導入。最小実装：
+
+```csharp
+private readonly Dictionary<string, CancellationTokenSource> _debounceCts = new();
+private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(400);
+
+private void DebounceSave(string key, string value)
+{
+    if (_isInitializing) return;
+    if (_debounceCts.TryGetValue(key, out var oldCts))
+    {
+        oldCts.Cancel();
+        oldCts.Dispose();
+    }
+    var cts = new CancellationTokenSource();
+    _debounceCts[key] = cts;
+    _ = Task.Run(async () =>
+    {
+        try
+        {
+            await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(false);
+            await _settingsRepo.SetValueAsync(key, value).ConfigureAwait(false);
+        }
+        catch (TaskCanceledException) { /* 新しい変更が来た */ }
+        catch (Exception ex) { LogHelper.Warn(nameof(SettingsViewModel), $"DebounceSave failed: {ex.Message}"); }
+    });
+}
+```
+
+各 `OnXxxChanged` を以下のパターンに変更。**既存コードの変換ロジック（clamp / bool→"1"/"0"）を呼び出し側で保持する**：
+
+```csharp
+// int 系（スライダー）
+partial void OnCacheMonthsChanged(int value)       => DebounceSave(SettingsKeys.CACHE_MONTHS, value.ToString());
+partial void OnUpdateIntervalHoursChanged(int value) => DebounceSave(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString());
+partial void OnFontSizeSpChanged(int value)         => DebounceSave(SettingsKeys.FONT_SIZE_SP, value.ToString());
+partial void OnBackgroundThemeChanged(int value)    => DebounceSave(SettingsKeys.BACKGROUND_THEME, value.ToString());
+partial void OnLineSpacingChanged(int value)        => DebounceSave(SettingsKeys.LINE_SPACING, value.ToString());
+partial void OnEpisodesPerPageChanged(int value)    => DebounceSave(SettingsKeys.EPISODES_PER_PAGE, value.ToString());
+
+// RequestDelayMs: 既存の Math.Clamp ロジックを保持（MIN_REQUEST_DELAY_MS/MAX_REQUEST_DELAY_MS）
+partial void OnRequestDelayMsChanged(int value) =>
+    DebounceSave(SettingsKeys.REQUEST_DELAY_MS,
+        Math.Clamp(value, SettingsKeys.MIN_REQUEST_DELAY_MS, SettingsKeys.MAX_REQUEST_DELAY_MS).ToString());
+
+// bool 系（Switch）: DB 側は "1"/"0" 保存のまま（GetIntValueAsync との整合性維持）
+// ⚠ value.ToString() だと "True"/"False" が保存され int.TryParse が失敗するため NG
+partial void OnVerticalWritingChanged(bool value)  => DebounceSave(SettingsKeys.VERTICAL_WRITING, value ? "1" : "0");
+partial void OnPrefetchEnabledChanged(bool value)  => DebounceSave(SettingsKeys.PREFETCH_ENABLED, value ? "1" : "0");
+```
+
+**注意:** デバウンス遅延 400ms はスライダー操作の連続性を考慮した値。Toggle 系は単発操作なので影響小だが、パターン統一のため同じ仕組みに寄せる。
+
+---
+
+### 9. SiteType ラベル / Factory / Service — S3, S8, S9
+
+設計を一括で整理する。3 件は連動するため同一コミット推奨。
+
+#### 9a. S8: `SiteType` 拡張メソッド導入
+
+**新規ファイル:** `_Apps/Models/SiteTypeExtension.cs`
+
+```csharp
+namespace LanobeReader.Models;
+
+public static class SiteTypeExtension
+{
+    public static string GetLabel(this SiteType siteType) => siteType switch
+    {
+        SiteType.Narou => "なろう",
+        SiteType.Kakuyomu => "カクヨム",
+        _ => siteType.ToString(),
+    };
+}
+```
+
+**使用箇所修正:**
+- `NovelCardViewModel.cs:48`: `SiteTypeLabel = ((SiteType)novel.SiteType).GetLabel()`
+- `SearchResultViewModel.cs:43`: `SiteTypeLabel = result.SiteType.GetLabel()`
+
+#### 9b. S3: `Novel.SiteType` プロパティ命名整理
+
+**問題:** `Novel.SiteType` (int, line 13) と `Novel.SiteTypeEnum` (enum, line 49-53) が併存し、利用側で混乱（`(SiteType)novel.SiteType` というキャストが多数）。
+
+**修正方針（最小変更案）:** `[Ignore]` プロパティの命名を `SiteTypeEnum` から `Site` に変更し、用途を明確化：
+
+```csharp
+[Column("site_type")]
+public int SiteType { get; set; }  // DB列マッピング（既存）
+
+[Ignore]
+public SiteType Site
+{
+    get => (SiteType)SiteType;
+    set => SiteType = (int)value;
+}
+```
+
+**呼出側修正:** `(SiteType)novel.SiteType` → `novel.Site` に置換。
+影響箇所（grep 結果より）:
+- `NovelCardViewModel.cs:48,49`
+- `UpdateCheckService.cs:52`
+- `EpisodeListViewModel.cs:186,195`
+- `PrefetchService.cs:49,80` (※書込側は `SiteType = novel.SiteType` のまま OK、または `Site = novel.Site` 統一)
+
+**トレードオフ:** プロパティ名変更は破壊的。ただし `[Ignore]` プロパティのため DB 影響なし。`SiteTypeEnum` という名は冗長で「型のEnum版」という意味になり S3 の核心問題なので、改名する価値あり。
+
+**代替案（より保守的）:** S3 を見送り、命名のみ変更しない。S8 のラベル拡張だけで読みやすさは大幅改善する。**👉 推奨: 代替案採用（S3 はスキップ、メモのみ残す）**
+
+#### 9c. S9: `INovelServiceFactory` の自動解決
+
+**問題:** `NovelServiceFactory` が `NarouApiService` / `KakuyomuApiService` の具象クラスを直接 DI で受け取り、`switch` で振り分け。新サイト追加時にファクトリ・switch・MauiProgram.cs DI 登録の 3 箇所変更が必要。
+
+**既存状態の確認（重要）:**
+- [`INovelService.cs:7`](../Services/INovelService.cs) に `SiteType SiteType { get; }` が**既に定義済み**
+- [`NarouApiService.cs:31`](../Services/Narou/NarouApiService.cs): `public SiteType SiteType => SiteType.Narou;` 実装済み
+- [`KakuyomuApiService.cs:30`](../Services/Kakuyomu/KakuyomuApiService.cs): `public SiteType SiteType => SiteType.Kakuyomu;` 実装済み
+
+→ インターフェース / 実装側の変更は不要。ファクトリと DI 登録の変更のみで完結する。
+
+**修正:**
+
+1. `NovelServiceFactory` を辞書化（既存の `INovelService.SiteType` プロパティを利用）：
+
+```csharp
+public class NovelServiceFactory : INovelServiceFactory
+{
+    private readonly Dictionary<SiteType, INovelService> _services;
+
+    public NovelServiceFactory(IEnumerable<INovelService> services)
+    {
+        _services = services.ToDictionary(s => s.SiteType);
+    }
+
+    public INovelService GetService(SiteType siteType)
+    {
+        if (_services.TryGetValue(siteType, out var service)) return service;
+        throw new ArgumentOutOfRangeException(nameof(siteType), siteType, "Unknown site type");
+    }
+}
+```
+
+2. `MauiProgram.cs` の DI 登録に `INovelService` インターフェースとしての登録を追加：
+
+```csharp
+builder.Services.AddSingleton<NarouApiService>();
+builder.Services.AddSingleton<INovelService>(sp => sp.GetRequiredService<NarouApiService>());
+builder.Services.AddSingleton<KakuyomuApiService>();
+builder.Services.AddSingleton<INovelService>(sp => sp.GetRequiredService<KakuyomuApiService>());
+```
+
+**トレードオフ:** 既存の具象クラス DI 解決（他で `NarouApiService` を直接注入されている箇所）は壊さないよう両方登録する。新サイト追加時は API クラス + DI 登録 2 行追加のみで済む（ファクトリ無変更）。
+
+---
+
+### 10. `_Apps/Models/Episode.cs` + `Novel.cs` + 利用全箇所 — S1（**独立コミット**）
+
+**問題:** `Episode.IsRead`, `Novel.IsCompleted`, `Novel.HasUnconfirmedUpdate`, `Novel.HasCheckError`, `Novel.IsFavorite`, `Episode.IsFavorite` が `int` 型。`SearchResult.IsCompleted` (bool) と型不整合。
+
+**修正方針:**
+- Model の `int` → `bool` 変更
+- SQLite-net は `bool` プロパティを INTEGER 列にマッピング → DB 互換維持
+- Repository / Service 側の `== 1`、`== 0`、`? 1 : 0`、`Where(e => e.IsRead == 0)` などを全置換
+- ViewModel.FromModel の `episode.IsRead == 1` → `episode.IsRead` へ簡素化
+- 生 SQL の `WHERE is_read = ?` 等は引数を `bool` 渡しで OK（SQLite-net がパラメータ変換）
+
+**XAML / コンバータは変更不要:**
+- 全ての XAML は ViewModel (EpisodeViewModel / NovelCardViewModel / SearchResultViewModel / NovelListViewModel) 経由でバインド
+- VM 側は既に bool 型（[EpisodeViewModel.cs:21,24](../ViewModels/EpisodeViewModel.cs) 等）
+- `IntToBoolConverter` は **`NovelListPage.xaml:83`** で `UnreadCount`（int 件数）→ bool 変換に利用中のため**残す**（S1 の対象外）
+
+**影響ファイル（grep 結果より）:**
+| ファイル | 変更内容 |
+|---|---|
+| `Models/Episode.cs` | `int IsRead` → `bool IsRead`, `int IsFavorite` → `bool IsFavorite` |
+| `Models/Novel.cs` | `int IsCompleted/HasUnconfirmedUpdate/HasCheckError/IsFavorite` → `bool` |
+| `Services/Database/NovelRepository.cs` | 生SQL 引数 `1`/`0` → `true`/`false`、`is_favorite DESC` は bool 列でも挙動変わらず |
+| `Services/Database/EpisodeRepository.cs` | LINQ `Where(e => e.IsRead == 0)` → `Where(e => !e.IsRead)` 等、`IsFavorite == 1` → `IsFavorite` |
+| `ViewModels/NovelCardViewModel.cs` | `FromModel` 内 `novel.IsCompleted == 1` → `novel.IsCompleted` 等（3 箇所） |
+| `ViewModels/EpisodeListViewModel.cs` | `_novel.IsFavorite == 1` → `_novel.IsFavorite`、`Where(e => e.IsRead == 0)` → `Where(e => !e.IsRead)`、`source.IsFavorite = newValue ? 1 : 0` → `source.IsFavorite = newValue`、`_novel.IsFavorite = newValue ? 1 : 0` → `_novel.IsFavorite = newValue`、`ep.IsRead = isRead ? 1 : 0` → `ep.IsRead = isRead` |
+| `ViewModels/EpisodeViewModel.cs` | `FromModel` 内 `episode.IsRead == 1` → `episode.IsRead`、`IsFavorite == 1` → `IsFavorite` |
+| `ViewModels/SearchViewModel.cs` | `IsCompleted = result.IsCompleted ? 1 : 0` → `IsCompleted = result.IsCompleted` |
+| `ViewModels/NovelListViewModel.cs` | `r.Novel.HasCheckError == 1` → `r.Novel.HasCheckError`、`novel.HasUnconfirmedUpdate == 1` → `novel.HasUnconfirmedUpdate`、`novel.HasUnconfirmedUpdate = 0` → `novel.HasUnconfirmedUpdate = false` |
+| `ViewModels/ReaderViewModel.cs` | `_episode.IsFavorite == 1` → `_episode.IsFavorite`、`_episode.IsFavorite = newValue ? 1 : 0` → `_episode.IsFavorite = newValue`、`_episode.IsRead == 1` → `_episode.IsRead`、`_episode.IsRead = 1` → `_episode.IsRead = true`、`novel.HasUnconfirmedUpdate == 1` → `novel.HasUnconfirmedUpdate`、`novel.HasUnconfirmedUpdate = 0` → `novel.HasUnconfirmedUpdate = false` |
+| `Services/Background/PrefetchService.cs` | `novel.IsFavorite == 1` → `novel.IsFavorite`、`OrderByDescending(n => n.IsFavorite)` は bool でも動作（false<true） |
+| `Services/UpdateCheckService.cs` | `novel.HasUnconfirmedUpdate == 1` → `novel.HasUnconfirmedUpdate`、`novel.HasUnconfirmedUpdate = 1` → `= true`、`novel.IsCompleted = isCompleted ? 1 : 0` → `= isCompleted`、`novel.HasCheckError = 1` → `= true`、`n.HasCheckError == 1` → `n.HasCheckError`、`novel.HasCheckError = 0` → `= false`、`novel.IsFavorite == 1 ? 1 : 0` → `novel.IsFavorite ? 1 : 0`（`Priority` は int のまま） |
+| `Services/Narou/NarouApiService.cs` | `IsCompleted = item.TryGetProperty(...) && end.GetInt32() == 0` は既に bool 式を返すため変更不要（代入先が bool になるだけ） |
+
+**XAML（変更不要）:**
+- `EpisodeListPage.xaml` / `NovelListPage.xaml` / `SearchPage.xaml` は VM にバインドするため影響なし
+- `Converters.xaml` / `IntToBoolConverter.cs` も残置（UnreadCount 用）
+
+**手順:**
+1. Model 2 ファイル変更
+2. ビルドエラーを 1 つずつ修正（型ミスマッチが発生する箇所のみ）
+3. 起動確認・既読/お気に入り Toggle 確認
+
+**リスク:**
+- 想定外の変換パスを見落とす可能性 → ビルド + 全画面動作確認必須
+- 既存DB との互換: SQLite-net 公式ドキュメントで bool→INTEGER mapping 確認済み（0/1 で保存）
+
+**コミット分割:** S1 は単独コミット (`fix(S1): boolean フィールドを int から bool に統一`)
+
+---
+
+## 実装順序とコミット粒度
+
+| # | コミット | 含まれる SMELL | 影響範囲 |
+|---|---|---|---|
+| 1 | `fix(S4,S15): LogHelper本番出力 + App.xaml.cs Task.Run除去` | S4, S15 | 小 |
+| 2 | `fix(S11,S12,S13): UI クリーンアップ` | S11, S12, S13 | 小 |
+| 3 | `fix(S5): NovelRepository Delete を CacheRepo 経由に` | S5 | 中 |
+| 4 | `fix(S6,S7): NetworkPolicyService の信頼性とキャッシュ` | S6, S7 | 中 |
+| 5 | `fix(S10): SettingsViewModel デバウンス保存` | S10 | 中 |
+| 6 | `refactor(S8,S9): SiteType ラベル拡張 + Service Factory 自動化` | S8, S9 | 中 |
+| 7 | `refactor(S1): boolean フィールドを int から bool に統一` | S1 | 大（独立） |
+
+**スキップ項目:**
+- **S2** (string→DateTime): 別 PR `feature/refactor-datetime-types` として別途実施。
+- **S3** (SiteType 命名): 効果が限定的、変更範囲が広いためスキップ。S8 で読みやすさは改善される。
+- **S14** (HttpClient→IHttpClientFactory): 別 PR `feature/refactor-http-factory` として別途実施。
+
+---
+
+## 検証
+
+### ビルド
+```bash
+dotnet build /c/Work/Github/TBird.Library/_Apps/App.sln --no-restore
+```
+
+### 動作確認チェックリスト（Android 実機 or エミュ）
+- [ ] アプリ起動 → 小説一覧表示
+- [ ] 小説詳細 → エピソード一覧 → リーダー
+- [ ] 既読切替（S1 影響: bool化）
+- [ ] お気に入り切替（S1 影響）
+- [ ] 削除（S5 影響: episode_cache カスケード）
+- [ ] 検索 → 登録 → 一覧に反映
+- [ ] 設定画面: 全スライダー高速操作で DB ロックエラーが出ないこと（S10 影響）
+- [ ] 設定変更後の `request_delay_ms` がリクエストに反映（S7 影響: 30秒以内は遅延あり）
+- [ ] ダークテーマ切替で既読タイトルが判読可能（S11 影響）
+- [ ] 機内モード ON でオフライン挙動（S6 影響: fail-closed）
+
+### コードレビュー
+- [ ] `EmptyView` 削除後、空状態表示が `<CollectionView.EmptyView>` で機能することを目視確認
+- [ ] `IntToBoolConverter` は `NovelListPage.xaml:83` の UnreadCount 用途で**残存**（削除されていないこと）
+- [ ] `_ = Task.Run(...)` パターンが App.xaml.cs から消えていること
+- [ ] `INovelService` インターフェースの DI 登録で Narou/Kakuyomu 両方が解決されていること（S9）
+- [ ] Settings 画面の Switch 系（VerticalWriting / PrefetchEnabled）が再起動後も正しく復元されること（S10: "1"/"0" 保存の維持確認）
+
+---
+
+## todo_2026-04-14_code-review.md の更新
+
+実施完了後、`todo_2026-04-14_code-review.md` の該当 SMELL 項目を `[x]` でマーク。スキップ項目には理由をメモ追記：
+- `[ ] S2 ... → 別PR feature/refactor-datetime-types に分離`
+- `[ ] S3 ... → S8 で実用上の読みやすさは改善されたためスキップ`
+- `[ ] S14 ... → 別PR feature/refactor-http-factory に分離`

--- a/_Apps/Features/todo_2026-04-14_code-review.md
+++ b/_Apps/Features/todo_2026-04-14_code-review.md
@@ -42,21 +42,21 @@ _Apps フォルダ全57ファイルの徹底レビュー結果。
 
 ## 🟠 SMELL（コード品質・保守性の問題）— 15件
 
-- [ ] **S1** `Episode.cs`, `Novel.cs` — boolean 値が `int` 型。`SearchResult.IsCompleted`(bool) との型不整合
-- [ ] **S2** `Episode.cs`, `Novel.cs`, `EpisodeCache.cs` — 日時フィールドが全て `string` 型。フォーマット依存のソートバグリスク
-- [ ] **S3** `Novel.cs:49-53` — `SiteType` が型名(enum)とプロパティ名(int)の両方で使用。可読性低下
-- [ ] **S4** `LogHelper.cs` — `Debug.WriteLine` はリリースビルドで除去。本番ログ不可
-- [ ] **S5** `NovelRepository.cs:171-175` — episode_cache 削除が N+1 クエリ。`EpisodeCacheRepository.DeleteByNovelIdAsync` の一括削除を使うべき
-- [ ] **S6** `NetworkPolicyService.cs:53-55` — `IsOnline` が例外時に `true` 返却。楽観的すぎ
-- [ ] **S7** `NetworkPolicyService.cs:120-131` — `EnforceDelayAsync` がリクエスト毎にDB読取。キャッシュすべき
-- [ ] **S8** `NovelCardViewModel.cs:48`, `SearchResultViewModel.cs:43` — `SiteTypeLabel` が三項演算子ハードコード。新サイトで "カクヨム" 固定
-- [ ] **S9** `NovelServiceFactory.cs` — ファクトリが具象クラスに依存。新サイト追加にファクトリ変更が必要
-- [ ] **S10** `SettingsViewModel.cs:62-87` — 全 `OnXxxChanged` が fire-and-forget DB 保存。スライダー高速操作で並列書き込み
-- [ ] **S11** `Converters.xaml:9-10` — `BoolToGrayConverter` の `FalseColor="Black"` がダークモード非対応
-- [ ] **S12** `SettingsPage.xaml:59` — 非推奨 `Frame` を使用。`Border` に移行すべき
-- [ ] **S13** `NovelListPage.xaml:21-25` — `x:Name="EmptyView"` が未使用デッドコード
-- [ ] **S14** `MauiProgram.cs:38` — `HttpClient` 直接シングルトン登録。`IHttpClientFactory` 未使用
-- [ ] **S15** `App.xaml.cs:77-100` — 既にバックグラウンドスレッドなのに `Task.Run` ラップ
+- [x] **S1** `Episode.cs`, `Novel.cs` — boolean 値が `int` 型。`SearchResult.IsCompleted`(bool) との型不整合
+- [ ] **S2** `Episode.cs`, `Novel.cs`, `EpisodeCache.cs` — 日時フィールドが全て `string` 型。フォーマット依存のソートバグリスク → 別PR `feature/refactor-datetime-types` に分離
+- [ ] **S3** `Novel.cs:49-53` — `SiteType` が型名(enum)とプロパティ名(int)の両方で使用。可読性低下 → S8 で実用上の読みやすさは改善されたためスキップ
+- [x] **S4** `LogHelper.cs` — `Debug.WriteLine` はリリースビルドで除去。本番ログ不可
+- [x] **S5** `NovelRepository.cs:171-175` — episode_cache 削除が N+1 クエリ。`EpisodeCacheRepository.DeleteByNovelIdAsync` の一括削除を使うべき
+- [x] **S6** `NetworkPolicyService.cs:53-55` — `IsOnline` が例外時に `true` 返却。楽観的すぎ
+- [x] **S7** `NetworkPolicyService.cs:120-131` — `EnforceDelayAsync` がリクエスト毎にDB読取。キャッシュすべき
+- [x] **S8** `NovelCardViewModel.cs:48`, `SearchResultViewModel.cs:43` — `SiteTypeLabel` が三項演算子ハードコード。新サイトで "カクヨム" 固定
+- [x] **S9** `NovelServiceFactory.cs` — ファクトリが具象クラスに依存。新サイト追加にファクトリ変更が必要
+- [x] **S10** `SettingsViewModel.cs:62-87` — 全 `OnXxxChanged` が fire-and-forget DB 保存。スライダー高速操作で並列書き込み
+- [x] **S11** `Converters.xaml:9-10` — `BoolToGrayConverter` の `FalseColor="Black"` がダークモード非対応
+- [x] **S12** `SettingsPage.xaml:59` — 非推奨 `Frame` を使用。`Border` に移行すべき
+- [x] **S13** `NovelListPage.xaml:21-25` — `x:Name="EmptyView"` が未使用デッドコード
+- [ ] **S14** `MauiProgram.cs:38` — `HttpClient` 直接シングルトン登録。`IHttpClientFactory` 未使用 → 別PR `feature/refactor-http-factory` に分離
+- [x] **S15** `App.xaml.cs:77-100` — 既にバックグラウンドスレッドなのに `Task.Run` ラップ
 
 ---
 

--- a/_Apps/Helpers/LogHelper.cs
+++ b/_Apps/Helpers/LogHelper.cs
@@ -4,18 +4,14 @@ namespace LanobeReader.Helpers;
 
 public static class LogHelper
 {
-    public static void Info(string className, string message)
-    {
-        Debug.WriteLine($"[LanobeReader][{className}] {message}");
-    }
+    public static void Info(string className, string message) => Write("INFO", className, message);
+    public static void Warn(string className, string message) => Write("WARN", className, message);
+    public static void Error(string className, string message) => Write("ERROR", className, message);
 
-    public static void Warn(string className, string message)
+    private static void Write(string level, string className, string message)
     {
-        Debug.WriteLine($"[LanobeReader][{className}] WARN: {message}");
-    }
-
-    public static void Error(string className, string message)
-    {
-        Debug.WriteLine($"[LanobeReader][{className}] ERROR: {message}");
+        var line = $"[LanobeReader][{className}] {level}: {message}";
+        Debug.WriteLine(line);
+        Console.WriteLine(line);
     }
 }

--- a/_Apps/MauiProgram.cs
+++ b/_Apps/MauiProgram.cs
@@ -44,7 +44,9 @@ public static class MauiProgram
 
         // API Services
         builder.Services.AddSingleton<NarouApiService>();
+        builder.Services.AddSingleton<INovelService>(sp => sp.GetRequiredService<NarouApiService>());
         builder.Services.AddSingleton<KakuyomuApiService>();
+        builder.Services.AddSingleton<INovelService>(sp => sp.GetRequiredService<KakuyomuApiService>());
         builder.Services.AddSingleton<INovelServiceFactory, NovelServiceFactory>();
         builder.Services.AddSingleton<UpdateCheckService>();
         builder.Services.AddSingleton<NotificationPermissionService>();

--- a/_Apps/Models/Episode.cs
+++ b/_Apps/Models/Episode.cs
@@ -23,7 +23,7 @@ public class Episode
     public string Title { get; set; } = string.Empty;
 
     [Column("is_read")]
-    public int IsRead { get; set; }
+    public bool IsRead { get; set; }
 
     [Column("read_at")]
     public string? ReadAt { get; set; }
@@ -32,7 +32,7 @@ public class Episode
     public string? PublishedAt { get; set; }
 
     [Column("is_favorite")]
-    public int IsFavorite { get; set; }
+    public bool IsFavorite { get; set; }
 
     [Column("favorited_at")]
     public string? FavoritedAt { get; set; }

--- a/_Apps/Models/Novel.cs
+++ b/_Apps/Models/Novel.cs
@@ -25,7 +25,7 @@ public class Novel
     public int TotalEpisodes { get; set; }
 
     [Column("is_completed")]
-    public int IsCompleted { get; set; }
+    public bool IsCompleted { get; set; }
 
     [Column("last_updated_at")]
     public string? LastUpdatedAt { get; set; }
@@ -34,13 +34,13 @@ public class Novel
     public string RegisteredAt { get; set; } = string.Empty;
 
     [Column("has_unconfirmed_update")]
-    public int HasUnconfirmedUpdate { get; set; }
+    public bool HasUnconfirmedUpdate { get; set; }
 
     [Column("has_check_error")]
-    public int HasCheckError { get; set; }
+    public bool HasCheckError { get; set; }
 
     [Column("is_favorite")]
-    public int IsFavorite { get; set; }
+    public bool IsFavorite { get; set; }
 
     [Column("favorited_at")]
     public string? FavoritedAt { get; set; }

--- a/_Apps/Models/SiteTypeExtension.cs
+++ b/_Apps/Models/SiteTypeExtension.cs
@@ -1,0 +1,11 @@
+namespace LanobeReader.Models;
+
+public static class SiteTypeExtension
+{
+    public static string GetLabel(this SiteType siteType) => siteType switch
+    {
+        SiteType.Narou => "なろう",
+        SiteType.Kakuyomu => "カクヨム",
+        _ => siteType.ToString(),
+    };
+}

--- a/_Apps/Resources/Styles/Converters.xaml
+++ b/_Apps/Resources/Styles/Converters.xaml
@@ -7,7 +7,8 @@
     <converters:HasValueConverter x:Key="HasValue" />
     <converters:InverseBoolConverter x:Key="InverseBool" />
     <converters:BoolToColorConverter x:Key="BoolToGrayConverter"
-        TrueColor="Gray" FalseColor="Black" />
+        TrueColor="{StaticResource Gray500}"
+        FalseColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
     <converters:BoolToColorConverter x:Key="BoolToGoldConverter"
         TrueColor="{StaticResource FavoriteGold}" FalseColor="{StaticResource Gray200}" />
     <converters:IntToBoolConverter x:Key="IntToBool" />

--- a/_Apps/Services/Background/PrefetchService.cs
+++ b/_Apps/Services/Background/PrefetchService.cs
@@ -48,7 +48,7 @@ public class PrefetchService
                 EpisodeNo = ep.EpisodeNo,
                 SiteType = novel.SiteType,
                 SiteNovelId = novel.NovelId,
-                Priority = (highPriority || novel.IsFavorite == 1) ? 1 : 0,
+                Priority = (highPriority || novel.IsFavorite) ? 1 : 0,
             });
             enqueued++;
         }
@@ -69,7 +69,7 @@ public class PrefetchService
             var episodes = await _episodeRepo.GetByNovelIdAsync(novel.Id).ConfigureAwait(false);
             var cachedIds = await _cacheRepo.GetCachedEpisodeIdsAsync(novel.Id).ConfigureAwait(false);
 
-            foreach (var ep in episodes.Where(e => e.IsRead == 0))
+            foreach (var ep in episodes.Where(e => !e.IsRead))
             {
                 if (cachedIds.Contains(ep.Id)) continue;
                 _queue.Enqueue(new PrefetchEpisodeJob
@@ -79,7 +79,7 @@ public class PrefetchService
                     EpisodeNo = ep.EpisodeNo,
                     SiteType = novel.SiteType,
                     SiteNovelId = novel.NovelId,
-                    Priority = novel.IsFavorite == 1 ? 1 : 0,
+                    Priority = novel.IsFavorite ? 1 : 0,
                 });
             }
         }

--- a/_Apps/Services/Database/AppSettingsRepository.cs
+++ b/_Apps/Services/Database/AppSettingsRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using LanobeReader.Models;
 using SQLite;
 
@@ -7,6 +8,9 @@ public class AppSettingsRepository
 {
     private readonly SQLiteAsyncConnection _db;
     private readonly DatabaseService _dbService;
+    private readonly ConcurrentDictionary<string, string> _cache = new();
+    private volatile bool _loaded;
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
 
     public AppSettingsRepository(DatabaseService dbService)
     {
@@ -14,11 +18,26 @@ public class AppSettingsRepository
         _db = dbService.Connection;
     }
 
+    /// <summary>アプリ起動時に1回呼び出す。全設定値をメモリキャッシュする。</summary>
+    public async Task LoadAllAsync()
+    {
+        if (_loaded) return;
+        await _loadGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_loaded) return;
+            await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+            var rows = await _db.Table<AppSetting>().ToListAsync().ConfigureAwait(false);
+            foreach (var r in rows) _cache[r.Key] = r.Value;
+            _loaded = true;
+        }
+        finally { _loadGate.Release(); }
+    }
+
     public async Task<string> GetValueAsync(string key, string defaultValue = "")
     {
-        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
-        var setting = await _db.FindAsync<AppSetting>(key).ConfigureAwait(false);
-        return setting?.Value ?? defaultValue;
+        if (!_loaded) await LoadAllAsync().ConfigureAwait(false);
+        return _cache.TryGetValue(key, out var v) ? v : defaultValue;
     }
 
     public async Task<int> GetIntValueAsync(string key, int defaultValue = 0)
@@ -29,6 +48,7 @@ public class AppSettingsRepository
 
     public async Task SetValueAsync(string key, string value)
     {
+        if (!_loaded) await LoadAllAsync().ConfigureAwait(false);
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
         var setting = await _db.FindAsync<AppSetting>(key).ConfigureAwait(false);
         if (setting is not null)
@@ -40,5 +60,6 @@ public class AppSettingsRepository
         {
             await _db.InsertAsync(new AppSetting { Key = key, Value = value }).ConfigureAwait(false);
         }
+        _cache[key] = value;
     }
 }

--- a/_Apps/Services/Database/EpisodeCacheRepository.cs
+++ b/_Apps/Services/Database/EpisodeCacheRepository.cs
@@ -38,6 +38,13 @@ public class EpisodeCacheRepository
         ).ConfigureAwait(false);
     }
 
+    internal void DeleteByNovelIdSync(SQLiteConnection conn, int novelId)
+    {
+        conn.Execute(
+            "DELETE FROM episode_cache WHERE episode_id IN (SELECT id FROM episodes WHERE novel_id = ?)",
+            novelId);
+    }
+
     public async Task DeleteAllAsync()
     {
         await EnsureAsync().ConfigureAwait(false);

--- a/_Apps/Services/Database/EpisodeRepository.cs
+++ b/_Apps/Services/Database/EpisodeRepository.cs
@@ -45,7 +45,7 @@ public class EpisodeRepository
     public async Task<int> CountUnreadByNovelIdAsync(int novelId)
     {
         await EnsureAsync().ConfigureAwait(false);
-        return await _db.Table<Episode>().Where(e => e.NovelId == novelId && e.IsRead == 0).CountAsync().ConfigureAwait(false);
+        return await _db.Table<Episode>().Where(e => e.NovelId == novelId && !e.IsRead).CountAsync().ConfigureAwait(false);
     }
 
     public async Task<Episode?> GetByNovelAndEpisodeNoAsync(int novelId, int episodeNo)
@@ -96,7 +96,7 @@ public class EpisodeRepository
     {
         await EnsureAsync().ConfigureAwait(false);
         return await _db.Table<Episode>()
-            .Where(e => e.NovelId == novelId && e.IsRead == 1)
+            .Where(e => e.NovelId == novelId && e.IsRead)
             .OrderByDescending(e => e.EpisodeNo)
             .FirstOrDefaultAsync().ConfigureAwait(false);
     }
@@ -105,7 +105,7 @@ public class EpisodeRepository
     {
         await EnsureAsync().ConfigureAwait(false);
         return await _db.Table<Episode>()
-            .Where(e => e.NovelId == novelId && e.IsRead == 0)
+            .Where(e => e.NovelId == novelId && !e.IsRead)
             .OrderBy(e => e.EpisodeNo)
             .FirstOrDefaultAsync().ConfigureAwait(false);
     }
@@ -127,7 +127,7 @@ public class EpisodeRepository
         await EnsureAsync().ConfigureAwait(false);
         var now = DateTime.UtcNow.ToString("o");
         await _db.ExecuteAsync(
-            "UPDATE episodes SET is_read = 1, read_at = ? WHERE id = ?", now, episodeId
+            "UPDATE episodes SET is_read = ?, read_at = ? WHERE id = ?", true, now, episodeId
         ).ConfigureAwait(false);
     }
 
@@ -135,7 +135,7 @@ public class EpisodeRepository
     {
         await EnsureAsync().ConfigureAwait(false);
         var count = await _db.Table<Episode>()
-            .Where(e => e.NovelId == novelId && e.IsRead == 0)
+            .Where(e => e.NovelId == novelId && !e.IsRead)
             .CountAsync().ConfigureAwait(false);
         return count == 0;
     }
@@ -146,14 +146,14 @@ public class EpisodeRepository
         var now = favorite ? DateTime.UtcNow.ToString("o") : null;
         await _db.ExecuteAsync(
             "UPDATE episodes SET is_favorite = ?, favorited_at = ? WHERE id = ?",
-            favorite ? 1 : 0, now, episodeId).ConfigureAwait(false);
+            favorite, now, episodeId).ConfigureAwait(false);
     }
 
     public async Task<List<Episode>> GetFavoritesByNovelIdAsync(int novelId)
     {
         await EnsureAsync().ConfigureAwait(false);
         return await _db.Table<Episode>()
-            .Where(e => e.NovelId == novelId && e.IsFavorite == 1)
+            .Where(e => e.NovelId == novelId && e.IsFavorite)
             .OrderBy(e => e.EpisodeNo)
             .ToListAsync().ConfigureAwait(false);
     }

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -15,11 +15,13 @@ public class NovelRepository
 
     private readonly SQLiteAsyncConnection _db;
     private readonly DatabaseService _dbService;
+    private readonly EpisodeCacheRepository _cacheRepo;
 
-    public NovelRepository(DatabaseService dbService)
+    public NovelRepository(DatabaseService dbService, EpisodeCacheRepository cacheRepo)
     {
         _dbService = dbService;
         _db = dbService.Connection;
+        _cacheRepo = cacheRepo;
     }
 
     public Task<List<Novel>> GetAllAsync()
@@ -169,9 +171,7 @@ public class NovelRepository
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
         await _db.RunInTransactionAsync(conn =>
         {
-            conn.Execute(
-                "DELETE FROM episode_cache WHERE episode_id IN (SELECT id FROM episodes WHERE novel_id = ?)",
-                novelId);
+            _cacheRepo.DeleteByNovelIdSync(conn, novelId);
             conn.Execute("DELETE FROM episodes WHERE novel_id = ?", novelId);
             conn.Execute("DELETE FROM novels WHERE id = ?", novelId);
         }).ConfigureAwait(false);

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -163,7 +163,7 @@ public class NovelRepository
         var now = favorite ? DateTime.UtcNow.ToString("o") : null;
         await _db.ExecuteAsync(
             "UPDATE novels SET is_favorite = ?, favorited_at = ? WHERE id = ?",
-            favorite ? 1 : 0, now, novelId).ConfigureAwait(false);
+            favorite, now, novelId).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(int novelId)

--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -52,7 +52,11 @@ public class NetworkPolicyService
         get
         {
             try { return Connectivity.Current.NetworkAccess == NetworkAccess.Internet; }
-            catch { return true; }
+            catch (Exception ex)
+            {
+                LogHelper.Warn(nameof(NetworkPolicyService), $"IsOnline check failed: {ex.Message}");
+                return false;
+            }
         }
     }
 
@@ -113,11 +117,7 @@ public class NetworkPolicyService
 
     private async Task<int> GetDelayMsAsync()
     {
-        try
-        {
-            var v = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, 800).ConfigureAwait(false);
-            return Math.Clamp(v, 100, 5000);
-        }
-        catch { return 800; }
+        var v = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, SettingsKeys.DEFAULT_REQUEST_DELAY_MS).ConfigureAwait(false);
+        return Math.Clamp(v, 100, 5000);
     }
 }

--- a/_Apps/Services/NovelServiceFactory.cs
+++ b/_Apps/Services/NovelServiceFactory.cs
@@ -1,24 +1,19 @@
 using LanobeReader.Models;
-using LanobeReader.Services.Kakuyomu;
-using LanobeReader.Services.Narou;
 
 namespace LanobeReader.Services;
 
 public class NovelServiceFactory : INovelServiceFactory
 {
-    private readonly NarouApiService _narouService;
-    private readonly KakuyomuApiService _kakuyomuService;
+    private readonly Dictionary<SiteType, INovelService> _services;
 
-    public NovelServiceFactory(NarouApiService narouService, KakuyomuApiService kakuyomuService)
+    public NovelServiceFactory(IEnumerable<INovelService> services)
     {
-        _narouService = narouService;
-        _kakuyomuService = kakuyomuService;
+        _services = services.ToDictionary(s => s.SiteType);
     }
 
-    public INovelService GetService(SiteType siteType) => siteType switch
+    public INovelService GetService(SiteType siteType)
     {
-        SiteType.Narou => _narouService,
-        SiteType.Kakuyomu => _kakuyomuService,
-        _ => throw new ArgumentOutOfRangeException(nameof(siteType), siteType, "Unknown site type"),
-    };
+        if (_services.TryGetValue(siteType, out var service)) return service;
+        throw new ArgumentOutOfRangeException(nameof(siteType), siteType, "Unknown site type");
+    }
 }

--- a/_Apps/Services/UpdateCheckService.cs
+++ b/_Apps/Services/UpdateCheckService.cs
@@ -45,7 +45,7 @@ public class UpdateCheckService
                 if (ct.IsCancellationRequested) break;
 
                 // Skip novels with unconfirmed updates
-                if (novel.HasUnconfirmedUpdate == 1) continue;
+                if (novel.HasUnconfirmedUpdate) continue;
 
                 try
                 {
@@ -69,8 +69,8 @@ public class UpdateCheckService
 
                             novel.TotalEpisodes = totalEpisodes;
                             novel.LastUpdatedAt = lastUpdatedAt ?? DateTime.UtcNow.ToString("o");
-                            novel.HasUnconfirmedUpdate = 1;
-                            novel.IsCompleted = isCompleted ? 1 : 0;
+                            novel.HasUnconfirmedUpdate = true;
+                            novel.IsCompleted = isCompleted;
                             if (!string.IsNullOrEmpty(author) && string.IsNullOrEmpty(novel.Author))
                             {
                                 novel.Author = author;
@@ -92,7 +92,7 @@ public class UpdateCheckService
                                         EpisodeNo = ep.EpisodeNo,
                                         SiteType = novel.SiteType,
                                         SiteNovelId = novel.NovelId,
-                                        Priority = novel.IsFavorite == 1 ? 1 : 0,
+                                        Priority = novel.IsFavorite ? 1 : 0,
                                     });
                                 }
                             }
@@ -102,7 +102,7 @@ public class UpdateCheckService
                 catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
                 {
                     LogHelper.Warn(nameof(UpdateCheckService), $"Failed to check {novel.Title}: {ex.Message}");
-                    novel.HasCheckError = 1;
+                    novel.HasCheckError = true;
                     await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
                     failedIds.Add(novel.Id);
                     continue;
@@ -110,9 +110,9 @@ public class UpdateCheckService
             }
 
             // Reset error flags on success
-            foreach (var novel in novels.Where(n => n.HasCheckError == 1 && !failedIds.Contains(n.Id)))
+            foreach (var novel in novels.Where(n => n.HasCheckError && !failedIds.Contains(n.Id)))
             {
-                novel.HasCheckError = 0;
+                novel.HasCheckError = false;
                 await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
             }
 

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -101,7 +101,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
             NovelTitle = _novel.Title;
             HasChapters = hasChapters;
             HasLastRead = lastRead is not null;
-            IsNovelFavorite = _novel.IsFavorite == 1;
+            IsNovelFavorite = _novel.IsFavorite;
 
             RecalcPaging();
             await LoadPageAsync();
@@ -119,8 +119,8 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
     private void RebuildFilterCache()
     {
         IEnumerable<Episode> src = _allEpisodes;
-        if (ShowUnreadOnly) src = src.Where(e => e.IsRead == 0);
-        if (ShowFavoritesOnly) src = src.Where(e => e.IsFavorite == 1);
+        if (ShowUnreadOnly) src = src.Where(e => !e.IsRead);
+        if (ShowFavoritesOnly) src = src.Where(e => e.IsFavorite);
         _filteredCache = src.ToList();
     }
 
@@ -147,12 +147,12 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         if (_allEpisodes.Count == 0) return;
 
         var freshEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
-        var readMap = freshEpisodes.ToDictionary(e => e.Id, e => e.IsRead == 1);
+        var readMap = freshEpisodes.ToDictionary(e => e.Id, e => e.IsRead);
 
         foreach (var ep in _allEpisodes)
         {
             if (readMap.TryGetValue(ep.Id, out var isRead))
-                ep.IsRead = isRead ? 1 : 0;
+                ep.IsRead = isRead;
         }
 
         foreach (var vm in Episodes)
@@ -203,7 +203,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         ep.IsFavorite = newValue;
 
         var source = _allEpisodes.FirstOrDefault(e => e.Id == ep.Id);
-        if (source is not null) source.IsFavorite = newValue ? 1 : 0;
+        if (source is not null) source.IsFavorite = newValue;
 
         if (ShowFavoritesOnly)
         {
@@ -220,7 +220,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         var newValue = !IsNovelFavorite;
         await _novelRepo.SetFavoriteAsync(_novel.Id, newValue);
         IsNovelFavorite = newValue;
-        _novel.IsFavorite = newValue ? 1 : 0;
+        _novel.IsFavorite = newValue;
     }
 
     [RelayCommand]

--- a/_Apps/ViewModels/EpisodeViewModel.cs
+++ b/_Apps/ViewModels/EpisodeViewModel.cs
@@ -34,8 +34,8 @@ public partial class EpisodeViewModel : ObservableObject
             EpisodeNo = episode.EpisodeNo,
             Title = episode.Title,
             ChapterName = episode.ChapterName,
-            IsRead = episode.IsRead == 1,
-            IsFavorite = episode.IsFavorite == 1,
+            IsRead = episode.IsRead,
+            IsFavorite = episode.IsFavorite,
             IsCached = isCached,
         };
     }

--- a/_Apps/ViewModels/NovelCardViewModel.cs
+++ b/_Apps/ViewModels/NovelCardViewModel.cs
@@ -45,7 +45,7 @@ public partial class NovelCardViewModel : ObservableObject
             Id = novel.Id,
             Title = novel.Title,
             Author = novel.Author,
-            SiteTypeLabel = ((SiteType)novel.SiteType) == SiteType.Narou ? "なろう" : "カクヨム",
+            SiteTypeLabel = ((SiteType)novel.SiteType).GetLabel(),
             SiteType = (SiteType)novel.SiteType,
             NovelId = novel.NovelId,
             UnreadCount = unreadCount,

--- a/_Apps/ViewModels/NovelCardViewModel.cs
+++ b/_Apps/ViewModels/NovelCardViewModel.cs
@@ -53,9 +53,9 @@ public partial class NovelCardViewModel : ObservableObject
                 System.Globalization.DateTimeStyles.RoundtripKind, out var dt)
                 ? dt.ToLocalTime().ToString("yyyy/MM/dd HH:mm:ss")
                 : novel.LastUpdatedAt ?? "",
-            IsCompleted = novel.IsCompleted == 1,
-            HasUnconfirmedUpdate = novel.HasUnconfirmedUpdate == 1,
-            IsFavorite = novel.IsFavorite == 1,
+            IsCompleted = novel.IsCompleted,
+            HasUnconfirmedUpdate = novel.HasUnconfirmedUpdate,
+            IsFavorite = novel.IsFavorite,
         };
     }
 }

--- a/_Apps/ViewModels/NovelListViewModel.cs
+++ b/_Apps/ViewModels/NovelListViewModel.cs
@@ -72,7 +72,7 @@ public partial class NovelListViewModel : ObservableObject
             var rows = await _novelRepo.GetAllWithUnreadCountAsync(SortKey);
             Novels = new ObservableCollection<NovelCardViewModel>(
                 rows.Select(r => NovelCardViewModel.FromModel(r.Novel, r.UnreadCount)));
-            HasCheckError = rows.Any(r => r.Novel.HasCheckError == 1);
+            HasCheckError = rows.Any(r => r.Novel.HasCheckError);
         }
         catch (Exception ex)
         {
@@ -144,9 +144,9 @@ public partial class NovelListViewModel : ObservableObject
     private async Task NavigateToDetail(NovelCardViewModel card)
     {
         var novel = await _novelRepo.GetByIdAsync(card.Id);
-        if (novel is not null && novel.HasUnconfirmedUpdate == 1)
+        if (novel is not null && novel.HasUnconfirmedUpdate)
         {
-            novel.HasUnconfirmedUpdate = 0;
+            novel.HasUnconfirmedUpdate = false;
             await _novelRepo.UpdateAsync(novel);
             card.HasUnconfirmedUpdate = false;
         }

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -187,7 +187,7 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
 
             EpisodeTitle = _episode.Title;
             EpisodeContent = content;
-            IsCurrentEpisodeFavorite = _episode.IsFavorite == 1;
+            IsCurrentEpisodeFavorite = _episode.IsFavorite;
             HasPrevEpisode = prev is not null;
             HasNextEpisode = next is not null;
             IsHeaderVisible = true;
@@ -262,25 +262,25 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         if (_episode is null) return;
         var newValue = !IsCurrentEpisodeFavorite;
         await _episodeRepo.SetFavoriteAsync(_episode.Id, newValue);
-        _episode.IsFavorite = newValue ? 1 : 0;
+        _episode.IsFavorite = newValue;
         IsCurrentEpisodeFavorite = newValue;
     }
 
     [RelayCommand]
     private async Task MarkAsReadAsync()
     {
-        if (_episode is null || _episode.IsRead == 1) return;
+        if (_episode is null || _episode.IsRead) return;
 
         await _episodeRepo.MarkAsReadAsync(_episode.Id);
-        _episode.IsRead = 1;
+        _episode.IsRead = true;
 
         var allRead = await _episodeRepo.AreAllReadAsync(_novelDbId);
         if (allRead)
         {
             var novel = await _novelRepo.GetByIdAsync(_novelDbId);
-            if (novel is not null && novel.HasUnconfirmedUpdate == 1)
+            if (novel is not null && novel.HasUnconfirmedUpdate)
             {
-                novel.HasUnconfirmedUpdate = 0;
+                novel.HasUnconfirmedUpdate = false;
                 await _novelRepo.UpdateAsync(novel);
             }
         }

--- a/_Apps/ViewModels/SearchResultViewModel.cs
+++ b/_Apps/ViewModels/SearchResultViewModel.cs
@@ -40,7 +40,7 @@ public partial class SearchResultViewModel : ObservableObject
             Author = result.Author,
             TotalEpisodes = result.TotalEpisodes,
             IsCompleted = result.IsCompleted,
-            SiteTypeLabel = result.SiteType == SiteType.Narou ? "なろう" : "カクヨム",
+            SiteTypeLabel = result.SiteType.GetLabel(),
             SiteType = result.SiteType,
             NovelId = result.NovelId,
             IsRegistered = isRegistered,

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -303,7 +303,7 @@ public partial class SearchViewModel : ObservableObject
                 Title = result.Title,
                 Author = result.Author,
                 TotalEpisodes = result.TotalEpisodes,
-                IsCompleted = result.IsCompleted ? 1 : 0,
+                IsCompleted = result.IsCompleted,
                 RegisteredAt = DateTime.UtcNow.ToString("o"),
                 LastUpdatedAt = DateTime.UtcNow.ToString("o"),
             };

--- a/_Apps/ViewModels/SettingsViewModel.cs
+++ b/_Apps/ViewModels/SettingsViewModel.cs
@@ -68,59 +68,44 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
-    partial void OnCacheMonthsChanged(int value)
+    private readonly Dictionary<string, CancellationTokenSource> _debounceCts = new();
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(400);
+
+    private void DebounceSave(string key, string value)
     {
         if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.CACHE_MONTHS, value.ToString());
+        if (_debounceCts.TryGetValue(key, out var oldCts))
+        {
+            oldCts.Cancel();
+            oldCts.Dispose();
+        }
+        var cts = new CancellationTokenSource();
+        _debounceCts[key] = cts;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(false);
+                await _settingsRepo.SetValueAsync(key, value).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException) { /* 新しい変更が来た */ }
+            catch (Exception ex) { LogHelper.Warn(nameof(SettingsViewModel), $"DebounceSave failed: {ex.Message}"); }
+        });
     }
 
-    partial void OnUpdateIntervalHoursChanged(int value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString());
-    }
+    partial void OnCacheMonthsChanged(int value)       => DebounceSave(SettingsKeys.CACHE_MONTHS, value.ToString());
+    partial void OnUpdateIntervalHoursChanged(int value) => DebounceSave(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString());
+    partial void OnFontSizeSpChanged(int value)        => DebounceSave(SettingsKeys.FONT_SIZE_SP, value.ToString());
+    partial void OnBackgroundThemeChanged(int value)   => DebounceSave(SettingsKeys.BACKGROUND_THEME, value.ToString());
+    partial void OnLineSpacingChanged(int value)       => DebounceSave(SettingsKeys.LINE_SPACING, value.ToString());
+    partial void OnEpisodesPerPageChanged(int value)   => DebounceSave(SettingsKeys.EPISODES_PER_PAGE, value.ToString());
 
-    partial void OnFontSizeSpChanged(int value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.FONT_SIZE_SP, value.ToString());
-    }
+    partial void OnRequestDelayMsChanged(int value) =>
+        DebounceSave(SettingsKeys.REQUEST_DELAY_MS,
+            Math.Clamp(value, SettingsKeys.MIN_REQUEST_DELAY_MS, SettingsKeys.MAX_REQUEST_DELAY_MS).ToString());
 
-    partial void OnBackgroundThemeChanged(int value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.BACKGROUND_THEME, value.ToString());
-    }
-
-    partial void OnLineSpacingChanged(int value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.LINE_SPACING, value.ToString());
-    }
-
-    partial void OnEpisodesPerPageChanged(int value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.EPISODES_PER_PAGE, value.ToString());
-    }
-
-    partial void OnVerticalWritingChanged(bool value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.VERTICAL_WRITING, value ? "1" : "0");
-    }
-
-    partial void OnPrefetchEnabledChanged(bool value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.PREFETCH_ENABLED, value ? "1" : "0");
-    }
-
-    partial void OnRequestDelayMsChanged(int value)
-    {
-        if (_isInitializing) return;
-        _ = _settingsRepo.SetValueAsync(SettingsKeys.REQUEST_DELAY_MS, Math.Clamp(value, SettingsKeys.MIN_REQUEST_DELAY_MS, SettingsKeys.MAX_REQUEST_DELAY_MS).ToString());
-    }
+    partial void OnVerticalWritingChanged(bool value)  => DebounceSave(SettingsKeys.VERTICAL_WRITING, value ? "1" : "0");
+    partial void OnPrefetchEnabledChanged(bool value)  => DebounceSave(SettingsKeys.PREFETCH_ENABLED, value ? "1" : "0");
 
     [RelayCommand]
     private async Task ClearCacheAsync()

--- a/_Apps/Views/NovelListPage.xaml
+++ b/_Apps/Views/NovelListPage.xaml
@@ -17,13 +17,6 @@
 		<ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
-		<!-- Empty state -->
-		<VerticalStackLayout IsVisible="False" x:Name="EmptyView"
-                             HorizontalOptions="Center" VerticalOptions="Center" Spacing="16">
-			<Label Text="タイトルを登録してください" FontSize="18" HorizontalTextAlignment="Center" />
-			<Button Text="検索画面へ" Clicked="OnGoToSearchClicked" />
-		</VerticalStackLayout>
-
 		<!-- Novel list -->
 		<CollectionView ItemsSource="{Binding Novels}" SelectionMode="None">
 			<CollectionView.ItemTemplate>

--- a/_Apps/Views/NovelListPage.xaml.cs
+++ b/_Apps/Views/NovelListPage.xaml.cs
@@ -17,9 +17,4 @@ public partial class NovelListPage : ContentPage
         base.OnAppearing();
         await _viewModel.InitializeAsync();
     }
-
-    private async void OnGoToSearchClicked(object? sender, EventArgs e)
-    {
-        await Shell.Current.GoToAsync("//search");
-    }
 }

--- a/_Apps/Views/SettingsPage.xaml
+++ b/_Apps/Views/SettingsPage.xaml
@@ -56,9 +56,9 @@
                         Style="{StaticResource ThemedSlider}" />
 
                 <!-- Preview -->
-                <Frame Padding="12" CornerRadius="8" HasShadow="True">
+                <Border Padding="12" Style="{StaticResource CardBorder}">
                     <Label Text="{Binding PreviewText}" FontSize="{Binding FontSizeSp}" />
-                </Frame>
+                </Border>
 
                 <!-- Background theme -->
                 <Label Text="背景色テーマ" Style="{StaticResource BodyLabel}" Margin="0,8,0,0" />


### PR DESCRIPTION
## Summary

コードレビュー (`todo_2026-04-14_code-review.md`) 発見の 15 件の SMELL のうち 12 件を修正。

| # | コミット | SMELL |
|---|---|---|
| 1 | `fix(S4,S15)` | LogHelper 本番ログ + App.xaml.cs 二重 Task.Run 除去 |
| 2 | `fix(S11,S12,S13)` | UI クリーンアップ (ダークテーマ対応 / Frame→Border / デッドコード削除) |
| 3 | `fix(S5)` | NovelRepository.DeleteAsync を EpisodeCacheRepository 経由に統一 |
| 4 | `fix(S6,S7)` | NetworkPolicyService 信頼性向上 + AppSettings インメモリキャッシュ |
| 5 | `fix(S10)` | SettingsViewModel デバウンス保存 (400ms) |
| 6 | `refactor(S8,S9)` | SiteType ラベル拡張 + NovelServiceFactory 辞書化 |
| 7 | `refactor(S1)` | boolean フィールドを int → bool 統一 (11ファイル) |

## スキップ項目

- **S2** (日時 string→DateTime): 影響範囲が広く独立性高いため別PR `feature/refactor-datetime-types` に分離
- **S3** (SiteType 命名): S8 で実用上の読みやすさは改善されたためスキップ
- **S14** (HttpClient→IHttpClientFactory): 依存関係導入を伴うため別PR `feature/refactor-http-factory` に分離

## 設計上の注意

- **S1**: SQLite-net は `bool ⇔ INTEGER` を自動マッピングするため DB 互換維持。`IntToBoolConverter` は `NovelListPage.xaml:83` の `UnreadCount`(int件数) → bool 変換用途で残置
- **S7**: `AppSettingsRepository` に起動時一括ロードキャッシュを実装。Get は DB アクセスなし、Set は DB と同時更新
- **S9**: `INovelService` インターフェースの登録を追加。新サイト追加時は API クラス + DI 2 行で済む
- **S11**: `BoolToColorConverter` を `BindableObject` 継承に変更し、`AppThemeBinding` をサポート
- **S13**: 未使用 `EmptyView` 削除に伴い `OnGoToSearchClicked` ハンドラも削除

## Test plan

- [ ] アプリ起動 → 小説一覧表示
- [ ] 小説詳細 → エピソード一覧 → リーダー
- [ ] 既読切替 (S1 影響: bool化)
- [ ] お気に入り切替 (S1 影響)
- [ ] 削除 (S5 影響: episode_cache カスケード)
- [ ] 検索 → 登録 → 一覧に反映
- [ ] 設定画面: 全スライダー高速操作で DB ロックエラーが出ないこと (S10)
- [ ] 設定変更後の `request_delay_ms` がリクエストに反映 (S7)
- [ ] ダークテーマ切替で既読タイトルが判読可能 (S11)
- [ ] 機内モード ON でオフライン挙動 (S6 影響: fail-closed)
- [ ] Settings 画面の Switch 系 (VerticalWriting / PrefetchEnabled) が再起動後も正しく復元されること (S10: "1"/"0" 保存の維持確認)

## ビルド確認

```
dotnet build _Apps/App.sln --no-restore
→ 0 warnings, 0 errors
```