### PR TITLE
refactor(F5): ReaderCssState のマジックナンバーを定数化

### DIFF
--- a/_Apps/Helpers/ReaderStyleResolver.cs
+++ b/_Apps/Helpers/ReaderStyleResolver.cs
@@ -9,8 +9,18 @@ public static class ReaderStyleResolver
 {
     public static (string bg, string fg) ResolveThemeColors(int themeIndex)
     {
-        var bgKey = themeIndex switch { 1 => "ThemeDarkBg", 2 => "ThemeSepiaBg", _ => "ThemeWhiteBg" };
-        var fgKey = themeIndex switch { 1 => "ThemeDarkText", 2 => "ThemeSepiaText", _ => "ThemeWhiteText" };
+        var bgKey = themeIndex switch
+        {
+            BackgroundTheme.Dark => "ThemeDarkBg",
+            BackgroundTheme.Sepia => "ThemeSepiaBg",
+            _ => "ThemeWhiteBg",
+        };
+        var fgKey = themeIndex switch
+        {
+            BackgroundTheme.Dark => "ThemeDarkText",
+            BackgroundTheme.Sepia => "ThemeSepiaText",
+            _ => "ThemeWhiteText",
+        };
 
         var bg = Application.Current?.Resources.TryGetValue(bgKey, out var b) == true && b is Color bc
             ? ColorToHex(bc) : "#FFFFFF";
@@ -21,8 +31,8 @@ public static class ReaderStyleResolver
 
     public static double ResolveLineHeight(int lineSpacingIndex) => lineSpacingIndex switch
     {
-        0 => 1.4,
-        2 => 2.1,
+        LineSpacing.Compact => 1.4,
+        LineSpacing.Relaxed => 2.1,
         _ => 1.7,
     };
 

--- a/_Apps/Helpers/ReaderThemeIndex.cs
+++ b/_Apps/Helpers/ReaderThemeIndex.cs
@@ -1,0 +1,23 @@
+namespace LanobeReader.Helpers;
+
+/// <summary>
+/// Reader 画面の背景テーマ設定値。AppSetting "background_theme" に int で保存される。
+/// XAML の DataTrigger は int リテラル ("0" / "1" / "2") のまま使用するため、
+/// ここは C# 側の自己文書化用途。値を変える場合は ReaderPage.xaml の DataTrigger Value も要同期更新。
+/// </summary>
+public static class BackgroundTheme
+{
+    public const int Light = 0;
+    public const int Dark = 1;
+    public const int Sepia = 2;
+}
+
+/// <summary>
+/// Reader 画面の行間設定値。AppSetting "line_spacing" に int で保存される。
+/// </summary>
+public static class LineSpacing
+{
+    public const int Compact = 0;   // CSS line-height: 1.4
+    public const int Normal = 1;    // CSS line-height: 1.7  (default)
+    public const int Relaxed = 2;   // CSS line-height: 2.1
+}

--- a/_Apps/Helpers/SettingsKeys.cs
+++ b/_Apps/Helpers/SettingsKeys.cs
@@ -17,8 +17,8 @@ public static class SettingsKeys
     public const int DEFAULT_CACHE_MONTHS = 3;
     public const int DEFAULT_UPDATE_INTERVAL_HOURS = 6;
     public const int DEFAULT_FONT_SIZE_SP = 16;
-    public const int DEFAULT_BACKGROUND_THEME = 0;
-    public const int DEFAULT_LINE_SPACING = 1;
+    public const int DEFAULT_BACKGROUND_THEME = BackgroundTheme.Light;
+    public const int DEFAULT_LINE_SPACING = LineSpacing.Normal;
     public const int DEFAULT_EPISODES_PER_PAGE = 50;
     public const int DEFAULT_PREFETCH_ENABLED = 1;
     public const int DEFAULT_REQUEST_DELAY_MS = 800;

--- a/_Apps/Views/ReaderPage.xaml
+++ b/_Apps/Views/ReaderPage.xaml
@@ -9,6 +9,7 @@
              Shell.NavBarIsVisible="False">
 
     <ContentPage.Triggers>
+        <!-- BackgroundThemeIndex: 0=Light / 1=Dark / 2=Sepia (see ReaderThemeIndex.cs) -->
         <DataTrigger TargetType="ContentPage" Binding="{Binding BackgroundThemeIndex}" Value="0">
             <Setter Property="BackgroundColor" Value="{StaticResource ThemeWhiteBg}" />
         </DataTrigger>
@@ -48,6 +49,7 @@
 					<SwipeGestureRecognizer Direction="Right" Command="{Binding PrevEpisodeCommand}" />
 				</Label.GestureRecognizers>
                 <Label.Triggers>
+                    <!-- BackgroundThemeIndex / LineSpacingIndex (see ReaderThemeIndex.cs) -->
                     <DataTrigger TargetType="Label" Binding="{Binding BackgroundThemeIndex}" Value="0">
                         <Setter Property="TextColor" Value="{StaticResource ThemeWhiteText}" />
                     </DataTrigger>


### PR DESCRIPTION
## 概要

コードレビュー REFACTOR F5 を実装。Reader 画面で散在していたマジックナンバー `0 / 1 / 2` を自己文書化する定数クラスに集約。

実装プラン: `_Apps/Features/plan_2026-04-22_refactor-f1-f8.md` PR-2 節

## 変更内容

### 新規: `_Apps/Helpers/ReaderThemeIndex.cs`
- `BackgroundTheme.Light / Dark / Sepia` (= 0 / 1 / 2)
- `LineSpacing.Compact / Normal / Relaxed` (= 0 / 1 / 2)

### `ReaderStyleResolver.cs`
- `themeIndex switch { 1 => ..., 2 => ..., _ => ... }` → `BackgroundTheme.Dark / Sepia` 参照
- `ResolveLineHeight` も `LineSpacing.Compact / Relaxed` 参照化

### `SettingsKeys.cs`
- `DEFAULT_BACKGROUND_THEME = 0` → `BackgroundTheme.Light`
- `DEFAULT_LINE_SPACING = 1` → `LineSpacing.Normal`

### `ReaderPage.xaml`
- DataTrigger の `Value="0/1/2"` はそのまま維持（MAUI の制約で `{x:Static}` が使えない）。
- 代わりに XAML コメントで `ReaderThemeIndex.cs` 参照を明示し、同期更新を促す。

## 非採用と理由
- **enum 化**: XAML DataTrigger の `Value="0"` と噛み合わず `{x:Static}` 化が必要だが、MAUI には既知制約あり。`const int` を採用して C# 側のみ自己文書化。

## 検証
- `dotnet build /c/Work/Github/TBird.Library/_Apps/App.sln --no-restore` → 警告 0 / エラー 0
- 値は従来と完全一致 (0/1/2)。DB に保存されている設定値も無変更で動作継続。

## テスト計画
- [ ] 設定画面で背景テーマ 3 種切替 → リーダーに反映
- [ ] 設定画面で行間 3 段階切替 → リーダーに反映
- [ ] アプリ再起動後も設定値が保持される