### PR TITLE
ニコニコ動画API nvapi移行

### DIFF
--- a/TBird.Core/Extensions/StringExtension.cs
+++ b/TBird.Core/Extensions/StringExtension.cs
@@ -1,10 +1,29 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace TBird.Core
 {
 	public static class StringExtension
 	{
+		/// <summary>
+		/// HTML文字列からタグを除去し、ﾌﾞﾛｯｸ系/改行系ﾀｸﾞは改行に置換します。
+		/// HtmlDecode は呼び出し側で別途行ってください。
+		/// </summary>
+		public static string StripHtml(this string s)
+		{
+			if (string.IsNullOrEmpty(s)) return s;
+			// <br>, <p>, <div>, <li>, <tr>, <h1>～<h6> 開きﾀｸﾞを改行に
+			var t = Regex.Replace(s, @"<\s*(br|p|div|li|tr|h[1-6])\b[^>]*/?>", "\n", RegexOptions.IgnoreCase);
+			// 同種の閉じﾀｸﾞも改行に
+			t = Regex.Replace(t, @"</\s*(p|div|li|tr|h[1-6])\s*>", "\n", RegexOptions.IgnoreCase);
+			// 残りの全ﾀｸﾞを除去
+			t = Regex.Replace(t, @"<[^>]+>", "");
+			// 3行以上の連続改行を2行に正規化
+			t = Regex.Replace(t, @"(\r?\n){3,}", "\n\n");
+			return t.Trim();
+		}
+
 		/// <summary>
 		/// 左辺から指定した長さの文字を取得します。
 		/// </summary>
@@ -104,4 +123,4 @@ namespace TBird.Core
 			return "".Left(count, c);
 		}
 	}
-}
+}

--- a/TBird.Web/_ROOT/WebUtil.cs
+++ b/TBird.Web/_ROOT/WebUtil.cs
@@ -127,7 +127,27 @@ namespace TBird.Web
 		/// <param name="url">URL</param>
 		public static async Task<dynamic> GetJsonAsync(string url)
 		{
-			return DynamicJson.Parse(await GetStringAsync(url).TryCatch().ConfigureAwait(false));
+			var body = await GetStringAsync(url).TryCatch().ConfigureAwait(false);
+			return string.IsNullOrEmpty(body) ? null : DynamicJson.Parse(body);
+		}
+
+		/// <summary>
+		/// 任意ヘッダ付きでURLの内容を取得します。
+		/// </summary>
+		public static async Task<string> GetStringAsync(string url, IDictionary<string, string> headers)
+		{
+			var req = new HttpRequestMessage(HttpMethod.Get, url);
+			foreach (var kv in headers) req.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+			return await SendStringAsync(req).ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// 任意ヘッダ付きでURLの内容をJson形式で取得します。
+		/// </summary>
+		public static async Task<dynamic> GetJsonAsync(string url, IDictionary<string, string> headers)
+		{
+			var body = await GetStringAsync(url, headers).TryCatch().ConfigureAwait(false);
+			return string.IsNullOrEmpty(body) ? null : DynamicJson.Parse(body);
 		}
 
 		/// <summary>
@@ -139,4 +159,4 @@ namespace TBird.Web
 			return XmlUtil.ToXml(await GetStringAsync(url).ConfigureAwait(false));
 		}
 	}
-}
+}

--- a/_Apps/Core.Controls/VideoModel.cs
+++ b/_Apps/Core.Controls/VideoModel.cs
@@ -1,6 +1,7 @@
 ﻿using Moviewer.Core.Windows;
 using System;
 using System.Web;
+using TBird.Core;
 using TBird.Wpf.Collections;
 
 namespace Moviewer.Core.Controls
@@ -39,7 +40,7 @@ namespace Moviewer.Core.Controls
 		public string Description
 		{
 			get => _Description;
-			set => SetProperty(ref _Description, HttpUtility.HtmlDecode(value));
+			set => SetProperty(ref _Description, HttpUtility.HtmlDecode(value).StripHtml());
 		}
 		private string _Description;
 
@@ -106,4 +107,4 @@ namespace Moviewer.Core.Controls
 				: VideoStatus.None;
 		}
 	}
-}
+}

--- a/_Apps/Core.Windows/MainViewModel.cs
+++ b/_Apps/Core.Windows/MainViewModel.cs
@@ -73,15 +73,22 @@ namespace Moviewer.Core.Windows
 		{
 			foreach (var m in NicoModel.Favorites)
 			{
-				var enumerable = await NicoUtil.GetVideoBySearchType(m.Word, m.Type, "regdate-");
-				var arr = enumerable.Where(x => m.Date < x.StartTime).ToArray();
-
-				foreach (var video in arr)
+				// IAsyncEnumerable は逐次評価。ループ内で m.Date を更新すると次の判定値が変わってしまうため
+				// 開始時点のしきい値を固定する。
+				var initialDate = m.Date;
+				try
 				{
-					VideoUtil.AddTemporary(MenuMode.Niconico, video.ContentId, false);
-
-					m.Date = Arr(m.Date, video.StartTime).Max();
+					await foreach (var video in NicoUtil.GetVideoBySearchType(m.Word, m.Type, "regdate-"))
+					{
+						// 比較フィールドの整合: nvapi `regdate-` は種別ごとに並びが異なる。
+						// User/Word/Tag は registeredAt 降順 (= StartTime)、Mylist は addedAt 降順 (= MylistAddedAt)。
+						var compareDate = video.MylistAddedAt ?? video.StartTime;
+						if (compareDate <= initialDate) break;
+						VideoUtil.AddTemporary(MenuMode.Niconico, video.ContentId, false);
+						m.Date = Arr(m.Date, compareDate).Max();
+					}
 				}
+				catch { }
 				VideoUtil.Save();
 			}
 		}
@@ -177,4 +184,4 @@ namespace Moviewer.Core.Windows
 		};
 
 	}
-}
+}

--- a/_Apps/Nico.Controls/NicoMylistModel.cs
+++ b/_Apps/Nico.Controls/NicoMylistModel.cs
@@ -1,35 +1,73 @@
-﻿using Moviewer.Core;
+using Moviewer.Core;
 using Moviewer.Core.Controls;
 using Moviewer.Nico.Core;
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using TBird.Core;
 
 namespace Moviewer.Nico.Controls
 {
 	public class NicoMylistModel : ControlModel, IThumbnailUrl
 	{
-		public static async Task<XElement> GetNicoMylistXml(string id)
+		public static async Task<dynamic> GetNicoMylistData(string id)
 		{
-			var xml = await NicoUtil.GetXmlChannelAsync($"http://www.nicovideo.jp/mylist/{NicoUtil.Url2Id(id)}?rss=2.0&numbers=1&sort=0");
-			return xml;
+			var cleanId = NicoUtil.Url2Id(id);
+			// 最新 addedAt を MylistDate に使うため、addedAt降順で1件取得
+			return await NicoUtil.GetNvapiJsonAsync(
+				$"https://nvapi.nicovideo.jp/v2/mylists/{cleanId}?sortKey=addedAt&sortOrder=desc&pageSize=1&page=1");
 		}
 
-		public NicoMylistModel(string id, XElement xml)
+		public NicoMylistModel(string id, dynamic json)
 		{
+			// json 非 null でも data または mylist が null/未定義のケース (権限不足時に
+			// meta だけ返るレスポンス等) をガード。
+			dynamic ml = null;
+			try
+			{
+				if (json != null && json.IsDefined("data") && json.data != null
+					&& json.data.IsDefined("mylist") && json.data.mylist != null)
+				{
+					ml = json.data.mylist;
+				}
+			}
+			catch { ml = null; }
+
+			if (ml == null)
+			{
+				MylistId = id;
+				MylistTitle = "";
+				MylistDate = DateTime.MinValue;
+				MylistDescription = "";
+				UserInfo = new NicoUserModel();
+				return;
+			}
+
 			MylistId = id;
-			MylistTitle = GetMylistTitle(xml.ElementS("title"));
-			MylistDate = DateTime.Parse(xml.ElementS("lastBuildDate"));
-			MylistDescription = xml.ElementS("description");
+			MylistTitle = GetMylistTitle(DynamicUtil.S(ml, "name") ?? "");
+			MylistDescription = DynamicUtil.S(ml, "description");
+
+			// RSS lastBuildDate 相当: 最新追加アイテムの addedAt を採用
+			// (nvapi v2 mylist には createdAt/updatedAt フィールドが存在しない)
+			string addedAt = null;
+			if (ml.IsDefined("items"))
+			{
+				foreach (var it in ml.items)
+				{
+					addedAt = DynamicUtil.S(it, "addedAt");
+					break;
+				}
+			}
+			MylistDate = string.IsNullOrEmpty(addedAt)
+				? DateTime.MinValue
+				: DateTimeOffset.Parse(addedAt).DateTime;
 
 			UserInfo = new NicoUserModel();
+			// owner は essential の owner と同形 (ownerType, id, name, iconUrl)。
+			// owner.id がチャンネル形式 "ch..." でも SetUserInfo が正しく分岐する。
 			UserInfo.SetUserInfo(
-				Regex.Match(xml.ElementS("link"), @"(?<=user\/)[\d]+").Value,          // user id
-				xml.ElementS(XName.Get("creator", "http://purl.org/dc/elements/1.1/")) // creator name
-			);
+				DynamicUtil.S(ml, "owner.id"),
+				DynamicUtil.S(ml, "owner.name"));
 
 			UserInfo.AddOnPropertyChanged(this, (sender, e) =>
 			{

--- a/_Apps/Nico.Controls/NicoSearchHistoryViewModel.cs
+++ b/_Apps/Nico.Controls/NicoSearchHistoryViewModel.cs
@@ -91,7 +91,11 @@ namespace Moviewer.Nico.Controls
 				case NicoSearchType.User:
 					return new NicoUserViewModel().SetUserInfo(await NicoUserModel.GetUserInfo(Word));
 				case NicoSearchType.Mylist:
-					return new NicoMylistViewModel(new NicoMylistModel(Word, await NicoMylistModel.GetNicoMylistXml(Word)));
+					// GetNicoMylistData はネットワーク例外時 ArgumentNullException を再投する
+					// (TryCatch<string> 経由)。null 戻りはコンストラクタが空モデルで吸収する。
+					dynamic json = null;
+					try { json = await NicoMylistModel.GetNicoMylistData(Word); } catch { }
+					return new NicoMylistViewModel(new NicoMylistModel(Word, json));
 				default:
 					return Word;
 			}
@@ -131,4 +135,4 @@ namespace Moviewer.Nico.Controls
 		private ICommand _OnFavoriteDel;
 
 	}
-}
+}

--- a/_Apps/Nico.Controls/NicoUserModel.cs
+++ b/_Apps/Nico.Controls/NicoUserModel.cs
@@ -1,9 +1,8 @@
 ﻿using Moviewer.Core.Controls;
+using Moviewer.Nico.Core;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using TBird.Core;
-using TBird.Web;
 
 namespace Moviewer.Nico.Controls
 {
@@ -45,29 +44,25 @@ namespace Moviewer.Nico.Controls
 
 				try
 				{
-					var url = $"https://seiga.nicovideo.jp/api/user/info?id={userid}";
-					var xml = await WebUtil.GetXmlAsync(url);
-					return _nicknames[userid] = (string)xml.Descendants("user")
-						.SelectMany(x => x.Descendants("nickname"))
-						.FirstOrDefault();
+					var json = await NicoUtil.GetNvapiJsonAsync(
+						$"https://nvapi.nicovideo.jp/v1/users/{userid}");
+					if (json == null) return userid;
+
+					var nickname = DynamicUtil.S(json, "data.user.nickname");
+
+					// 毒キャッシュ防止: nickname が null/空の場合は _nicknames に保存しない。
+					// 保存してしまうと次回以降ずっと null/空が返り続ける。
+					if (string.IsNullOrEmpty(nickname)) return userid;
+					return _nicknames[userid] = nickname;
 				}
 				catch
 				{
 					return userid;
 				}
 			}
-			/*
-            <?xml version="1.0" encoding="UTF-8"?>
-            <response>
-                <user>
-                    <id>1</id>
-                    <nickname>しんの</nickname>
-                </user>
-            </response>
-            */
 		}
 
 		private static Dictionary<string, string> _nicknames = new Dictionary<string, string>();
 		private static string _nicknamelock = typeof(NicoUserModel).FullName;
 	}
-}
+}

--- a/_Apps/Nico.Controls/NicoVideoModel.cs
+++ b/_Apps/Nico.Controls/NicoVideoModel.cs
@@ -1,10 +1,9 @@
-﻿using Moviewer.Core;
+using Moviewer.Core;
 using Moviewer.Core.Controls;
 using Moviewer.Nico.Core;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using TBird.Core;
 
 namespace Moviewer.Nico.Controls
@@ -50,127 +49,105 @@ namespace Moviewer.Nico.Controls
 			}
 		}
 
-		//public NicoVideoModel(dynamic json)
-		//{
-		//    ContentId = (string)json.data.video.id;
-		//    Title = (string)json.data.video.title;
-		//    Description = (string)json.data.video.description;
-		//    ThumbnailUrl = (string)json.data.video.thumbnail.url;
-		//    ViewCount = (long)json.data.video.count.view;
-		//    CommentCount = (long)json.data.video.count.comment;
-		//    MylistCount = (long)json.data.video.count.mylist;
-		//    StartTime = DateTime.Parse((string)json.data.video.registeredAt);
-		//    Duration = TimeSpan.FromSeconds((long)json.data.video.duration);
-		//    Tags.AddRange(string.Join(' ', ((IEnumerable<object>)json.data.tag.items).Select(x => ((dynamic)x).name))));
-		//    UserInfo = json.data.channel == null
-		//        ? new NicoUserModel($"{json.data.owner.id}", (string)json.data.owner.nickname)
-		//        : new NicoUserModel((string)json.data.channel.id, (string)json.data.channel.name);
-
-		//    RefreshStatus();
-
-		//    _beforedisplay = false;
-		//}
-
-		public NicoVideoModel(XElement xml) : this()
+		public static NicoVideoModel FromEssential(dynamic essential)
 		{
-			xml = xml.Descendants("thumb").First();
-			ContentId = NicoUtil.Url2Id(xml.ElementS("watch_url"));
-			Title = xml.ElementS("title");
-			Description = xml.ElementS("description");
-			ThumbnailUrl = xml.ElementS("thumbnail_url");
-			ViewCount = xml.ElementL("view_counter");
-			CommentCount = xml.ElementL("comment_num");
-			MylistCount = xml.ElementL("mylist_counter");
-			StartTime = DateTime.Parse(xml.ElementS("first_retrieve"));
-			Duration = ToDuration(xml.ElementS("length"));
-			Tags.AddRange(xml.Descendants("tags").First().Descendants("tag").Select(tag => (string)tag));
-			UserInfo.SetUserInfo(
-				CoreUtil.Nvl(xml.ElementS("user_id"), "ch" + xml.ElementS("ch_id")),
-				CoreUtil.Nvl(xml.ElementS("user_nickname"), xml.ElementS("ch_name"))
-			);
-			RefreshStatus();
-
-			_beforedisplay = false;
-		}
-
-		public NicoVideoModel(XElement item, string view, string mylist, string comment) : this()
-		{
+			var m = new NicoVideoModel();
 			try
 			{
-				// 明細部読み込み
-				var descriptionString = item.Element("description").Value;
-				descriptionString = descriptionString.Replace("&nbsp;", "&#x20;");
-				//descriptionString = HttpUtility.HtmlDecode(descriptionString);
-				descriptionString = descriptionString.Replace("&", "&amp;");
-				descriptionString = descriptionString.Replace("'", "&apos;");
-				var descriptionXml = XmlUtil.ToXml($"<root>{descriptionString}</root>");
+				m.ContentId = DynamicUtil.S(essential, "id");
+				m.Title = DynamicUtil.S(essential, "title");
+				m.Description = DynamicUtil.S(essential, "shortDescription");
+				m.ThumbnailUrl = DynamicUtil.S(essential, "thumbnail.url");
+				m.ViewCount = DynamicUtil.L(essential, "count.view");
+				m.CommentCount = DynamicUtil.L(essential, "count.comment");
+				m.MylistCount = DynamicUtil.L(essential, "count.mylist");
+				m.StartTime = DateTimeOffset.Parse(DynamicUtil.S(essential, "registeredAt")).DateTime;
+				m.Duration = TimeSpan.FromSeconds(DynamicUtil.L(essential, "duration"));
 
-				ContentId = NicoUtil.Url2Id(item.ElementS("link"));
-				Title = item.Element("title").Value;
-				Description = (string)descriptionXml.Descendants("p").FirstOrDefault(x => x.AttributeS("class") == "nico-description");
-				ThumbnailUrl = descriptionXml.Descendants("img").First().AttributeS("src");
-				ViewCount = ToCounter(descriptionXml, view);
-				CommentCount = ToCounter(descriptionXml, comment);
-				MylistCount = ToCounter(descriptionXml, mylist);
-				StartTime = ToRankingDatetime(descriptionXml, "nico-info-date");
-				Duration = ToDuration(descriptionXml);
-				RefreshStatus();
+				if (essential.IsDefined("owner") && essential.owner != null)
+				{
+					var ownerId = DynamicUtil.S(essential.owner, "id");
+					var ownerName = DynamicUtil.S(essential.owner, "name");
+					if (!string.IsNullOrEmpty(ownerId))
+					{
+						m.UserInfo.SetUserInfo(ownerId, ownerName);
+					}
+				}
 
-				_beforedisplay = true;
+				m.RefreshStatus();
+				m._beforedisplay = true;
 			}
-			catch
+			catch (Exception ex)
 			{
-				Status = VideoStatus.Delete;
+				MessageService.Exception(ex);
+				m.Status = VideoStatus.Delete;
 			}
+			return m;
 		}
 
-		private TimeSpan ToDuration(string lengthSecondsStr)
+		public static NicoVideoModel FromMylistItem(dynamic item)
 		{
-			var lengthSecondsIndex = 0;
-			var lengthSeconds = lengthSecondsStr
-					.Split(':')
-					.Reverse()
-					.Sum(s => int.Parse(s) * Math.Pow(60, lengthSecondsIndex++));
-			return TimeSpan.FromSeconds((long)lengthSeconds);
+			var m = FromEssential(item.video);
+			if (m.Status == VideoStatus.Delete) return m;
+			try
+			{
+				var addedAt = DynamicUtil.S(item, "addedAt");
+				if (!string.IsNullOrEmpty(addedAt))
+				{
+					m.MylistAddedAt = DateTimeOffset.Parse(addedAt).DateTime;
+				}
+			}
+			catch (Exception ex)
+			{
+				MessageService.Exception(ex);
+			}
+			return m;
 		}
 
-		private TimeSpan ToDuration(XElement xml)
+		public static NicoVideoModel FromWatchData(dynamic data)
 		{
-			var lengthSecondsStr = (string)xml
-				.Descendants("strong")
-				.Where(x => (string)x.Attribute("class") == "nico-info-length")
-				.First();
+			var m = new NicoVideoModel();
+			try
+			{
+				m.ContentId = DynamicUtil.S(data, "video.id");
+				m.Title = DynamicUtil.S(data, "video.title");
+				m.Description = DynamicUtil.S(data, "video.description");
+				m.ThumbnailUrl = DynamicUtil.S(data, "video.thumbnail.url");
+				m.ViewCount = DynamicUtil.L(data, "video.count.view");
+				m.CommentCount = DynamicUtil.L(data, "video.count.comment");
+				m.MylistCount = DynamicUtil.L(data, "video.count.mylist");
+				m.StartTime = DateTimeOffset.Parse(DynamicUtil.S(data, "video.registeredAt")).DateTime;
+				m.Duration = TimeSpan.FromSeconds(DynamicUtil.L(data, "video.duration"));
 
-			return ToDuration(lengthSecondsStr);
-		}
+				if (data.IsDefined("tag") && data.tag != null)
+				{
+					foreach (var t in data.tag.items)
+						m.Tags.Add(DynamicUtil.S(t, "name"));
+				}
 
-		private string GetData(XElement e, string name)
-		{
-			return (string)e
-				.Descendants("strong")
-				.Where(x => (string)x.Attribute("class") == name)
-				.FirstOrDefault();
-		}
+				// data.channel が非null → チャンネル動画 (id は既に "ch..." 形式)
+				if (data.IsDefined("channel") && data.channel != null)
+				{
+					m.UserInfo.SetUserInfo(
+						DynamicUtil.S(data.channel, "id"),
+						DynamicUtil.S(data.channel, "name"));
+				}
+				else if (data.IsDefined("owner") && data.owner != null)
+				{
+					m.UserInfo.SetUserInfo(
+						DynamicUtil.S(data.owner, "id"),
+						DynamicUtil.S(data.owner, "nickname"));
+				}
 
-		private long ToCounter(XElement e, string name)
-		{
-			var s = string.IsNullOrEmpty(name) ? null : GetData(e, name);
-
-			return string.IsNullOrEmpty(s)
-				? 0
-				: long.Parse(s.Replace(",", ""));
-		}
-
-		private DateTime ToRankingDatetime(XElement e, string name)
-		{
-			// 2018年02月27日 20：00：00
-			var s = GetData(e, name);
-
-			return DateTime.ParseExact(s,
-				"yyyy年MM月dd日 HH：mm：ss",
-				System.Globalization.DateTimeFormatInfo.InvariantInfo,
-				System.Globalization.DateTimeStyles.None
-			);
+				m.RefreshStatus();
+				m._beforedisplay = false;
+			}
+			catch (Exception ex)
+			{
+				MessageService.Exception(ex);
+				m.Status = VideoStatus.Delete;
+			}
+			return m;
 		}
 
 		public override MenuMode Mode { get; } = MenuMode.Niconico;
@@ -195,6 +172,10 @@ namespace Moviewer.Nico.Controls
 			set => _CommentCount.Count = value;
 		}
 		private CounterModel _CommentCount = new CounterModel(CounterType.Comment, 0);
+
+		// Mylist 経由で取得した場合の追加日時。お気に入り巡回(PatrolFavorites)で
+		// addedAt 順ソートと整合させるため。それ以外の経路では null。
+		public DateTime? MylistAddedAt { get; set; }
 
 		protected override UserModel CreateUserInfo()
 		{

--- a/_Apps/Nico.Core/NicoUtil.cs
+++ b/_Apps/Nico.Core/NicoUtil.cs
@@ -1,10 +1,9 @@
-﻿using Moviewer.Core;
+using Moviewer.Core;
 using Moviewer.Nico.Controls;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using TBird.Core;
 using TBird.Web;
 
@@ -14,6 +13,15 @@ namespace Moviewer.Nico.Core
 	{
 		public const string NicoBlankUserUrl = "https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg";
 
+		private static readonly Dictionary<string, string> NvapiHeaders = new()
+		{
+			["X-Frontend-Id"] = "6",
+			["X-Frontend-Version"] = "0",
+		};
+
+		public static Task<dynamic> GetNvapiJsonAsync(string url)
+			=> WebUtil.GetJsonAsync(url, NvapiHeaders);
+
 		public static string Url2Id(string url)
 		{
 			return CoreUtil.Nvl(url).Split('/').Last().Split('?').First();
@@ -21,35 +29,22 @@ namespace Moviewer.Nico.Core
 
 		public static async Task<NicoVideoModel> GetVideo(string videoid)
 		{
-			//// TODO この方法でも可能だけどﾚｽﾎﾟﾝｽが悪いので旧式を使用する
-			//// TODO 旧式はDescriptionが簡素になる
-			//var body = await WebUtil.GetStringAsync(GetNicoVideoUrl(videoid));
-			//var json = DynamicJson.Parse(body);
-
-			//if ((int)json.meta.status == 200)
-			//{
-			//    return video.SetFromJsonVideo(json);
-			//}
-			//else
-			//{
-			//    video.ContentId = videoid;
-			//    video.Status = VideoStatus.Delete;
-			//    return video;
-			//}
-
-			var xml = await WebUtil.GetXmlAsync($"http://ext.nicovideo.jp/api/getthumbinfo/{videoid}").TryCatch();
-
-			if (xml == null || xml.AttributeS("status") == "fail")
+			try
 			{
-				var video = new NicoVideoModel();
-				video.ContentId = videoid;
-				video.Status = VideoStatus.Delete;
-				return video;
+				var json = await WebUtil.GetJsonAsync(GetNicoVideoUrl(videoid));
+				if (json != null && (int)json.meta.status == 200)
+				{
+					return NicoVideoModel.FromWatchData(json.data);
+				}
 			}
-			else
+			catch (Exception ex)
 			{
-				return new NicoVideoModel(xml);
+				MessageService.Exception(ex);
 			}
+			var video = new NicoVideoModel();
+			video.ContentId = videoid;
+			video.Status = VideoStatus.Delete;
+			return video;
 		}
 
 		public static string GetNicoVideoUrl(string contentid)
@@ -59,27 +54,7 @@ namespace Moviewer.Nico.Core
 			return $"https://www.nicovideo.jp/api/watch/v3_guest/{contentid}?_frontendId=6&_frontendVersion=0&actionTrackId={trackid}&skips=harmful&noSideEffect=false&t={session}";
 		}
 
-		/// <summary>
-		/// URLのchannelﾀｸﾞの内容をXml形式で取得します。
-		/// </summary>
-		/// <param name="url">URL</param>
-		public static async Task<XElement> GetXmlChannelAsync(string url)
-		{
-			var xml = await WebUtil.GetXmlAsync(url);
-			var tmp = xml.Descendants("channel");
-			return tmp.First();
-		}
-
-		private static async Task<IEnumerable<NicoVideoModel>> GetVideosFromXmlUrl(string url, string view, string mylist, string comment)
-		{
-			var xml = await GetXmlChannelAsync(url);
-
-			return xml
-				.Descendants("item")
-				.Select(item => new NicoVideoModel(item, view, mylist, comment));
-		}
-
-		public static Task<IEnumerable<NicoVideoModel>> GetVideoBySearchType(string word, NicoSearchType type, string order)
+		public static IAsyncEnumerable<NicoVideoModel> GetVideoBySearchType(string word, NicoSearchType type, string order)
 		{
 			switch (type)
 			{
@@ -95,65 +70,108 @@ namespace Moviewer.Nico.Core
 			}
 		}
 
-		public static Task<IEnumerable<NicoVideoModel>> GetVideosByRanking(string genre, string tag, string term)
+		public static async IAsyncEnumerable<NicoVideoModel> GetVideosByRanking(string genre, string tag, string term)
 		{
-			var url = $"https://www.nicovideo.jp/ranking/genre/{genre}?video_ranking_menu&tag={tag}&term={term}&rss=2.0&lang=ja-jp";
-
-			return GetVideosFromXmlUrl(url,
-				"nico-info-total-view",
-				"nico-info-total-mylist",
-				"nico-info-total-res"
-			);
+			// 呼出側 (NicoRankingViewModel) は慣習的に "all" を渡してくるが、
+			// nvapi では `tag=all` は「all という文字列タグでフィルタ」のセマンティクスを取り得るため
+			// 無タグ呼出 (= ジャンル全体ランキング) と等価にならない。"all" を空扱いに正規化する。
+			var effectiveTag = (string.IsNullOrEmpty(tag) || tag == "all") ? null : tag;
+			var url = $"https://nvapi.nicovideo.jp/v1/ranking/genre/{genre}?term={term}&pageSize=100"
+				+ (string.IsNullOrEmpty(effectiveTag) ? "" : $"&tag={Uri.EscapeDataString(effectiveTag)}");
+			var json = await GetNvapiJsonAsync(url);
+			if (json == null) yield break;
+			int rank = 1;
+			foreach (var item in json.data.items)
+			{
+				var video = NicoVideoModel.FromEssential(item);
+				if (video.Status != VideoStatus.Delete && !string.IsNullOrEmpty(video.Title))
+				{
+					// OnLoaded 経由の `CoreUtil.Nvl(Title, m.Title)` は既存値優先のため
+					// このﾌﾟﾚﾌｨｯｸｽは保持される
+					video.Title = $"第{rank}位：{video.Title}";
+				}
+				rank++;
+				yield return video;
+			}
 		}
 
-		public static Task<IEnumerable<NicoVideoModel>> GetVideosByMylist(string mylistid, string orderby)
+		public static async IAsyncEnumerable<NicoVideoModel> GetVideosByMylist(string mylistid, string orderby)
 		{
-			var url = $"http://www.nicovideo.jp/mylist/{mylistid}?rss=2.0&numbers=1&sort={orderby}";
-
-			return GetVideosFromXmlUrl(url,
-				"nico-numbers-view",
-				"nico-numbers-mylist",
-				"nico-numbers-res"
-			);
+			var parts = orderby.Split(',');
+			var sortKey = parts[0];
+			var sortOrder = parts[1];
+			int page = 1;
+			while (true)
+			{
+				var url = $"https://nvapi.nicovideo.jp/v2/mylists/{mylistid}?sortKey={sortKey}&sortOrder={sortOrder}&pageSize=100&page={page}";
+				var json = await GetNvapiJsonAsync(url);
+				if (json == null) yield break;
+				var ml = json.data.mylist;
+				foreach (var it in ml.items)
+				{
+					yield return NicoVideoModel.FromMylistItem(it);
+				}
+				bool hasNext = false;
+				try { hasNext = (bool)ml.hasNext; } catch { hasNext = false; }
+				if (!hasNext) yield break;
+				page++;
+			}
 		}
 
-		public static Task<IEnumerable<NicoVideoModel>> GetVideosByNicouser(string userid, string order)
+		public static IAsyncEnumerable<NicoVideoModel> GetVideosByNicouser(string userid, string order)
 		{
-			var orderbyuser = ComboUtil.GetNicoDisplay("oyder_by_user", order).Split(',');
+			// user 動画では regdate(登録日時) と stadate(投稿日時) は同義 (= registeredAt)。
+			// oyder_by_user XMLから regdate を削除したため、ここで stadate に正規化してマッピング不在を回避。
+			var normalized = order switch
+			{
+				"regdate-" => "stadate-",
+				"regdate+" => "stadate+",
+				_ => order,
+			};
+			var orderbyuser = ComboUtil.GetNicoDisplay("oyder_by_user", normalized).Split(',');
 			return GetVideosByNicouser(userid, orderbyuser[0], orderbyuser[1]);
 		}
 
-		private static Task<IEnumerable<NicoVideoModel>> GetVideosByNicouser(string userid, string key, string order)
+		private static async IAsyncEnumerable<NicoVideoModel> GetVideosByNicouser(string userid, string key, string order)
 		{
-			var url = $"https://www.nicovideo.jp/user/{userid}/video?sortKey={key}&sortOrder={order}&rss=2.0";
-
-			return GetVideosFromXmlUrl(url, null, null, null);
+			int page = 1;
+			while (true)
+			{
+				var url = $"https://nvapi.nicovideo.jp/v2/users/{userid}/videos?sortKey={key}&sortOrder={order}&pageSize=100&page={page}";
+				var json = await GetNvapiJsonAsync(url);
+				if (json == null) yield break;
+				int count = 0;
+				foreach (var it in json.data.items)
+				{
+					count++;
+					yield return NicoVideoModel.FromEssential(it.essential);
+				}
+				if (count < 100) yield break;
+				page++;
+			}
 		}
 
-		public static Task<IEnumerable<NicoVideoModel>> GetVideosByWord(string word, string order, int offset = 0, int limit = 50)
+		public static IAsyncEnumerable<NicoVideoModel> GetVideosByWord(string word, string order, int offset = 0, int limit = 50)
 		{
 			const string target = "title,description,tags";
 			return SearchApiV2(word, target, order, offset, limit);
 		}
 
-		public static Task<IEnumerable<NicoVideoModel>> GetVideosByTag(string word, string order, int offset = 0, int limit = 50)
+		public static IAsyncEnumerable<NicoVideoModel> GetVideosByTag(string word, string order, int offset = 0, int limit = 50)
 		{
 			const string target = "tagsExact";
 			return SearchApiV2(word, target, order, offset, limit);
 		}
 
-		private static async Task<IEnumerable<NicoVideoModel>> SearchApiV2(string word, string target, string order, int offset = 0, int limit = 50)
+		private static async IAsyncEnumerable<NicoVideoModel> SearchApiV2(string word, string target, string order, int offset = 0, int limit = 50)
 		{
 			var context = CoreSetting.Instance.ApplicationKey;
 			var orderbyapiv2 = ComboUtil.GetNicoDisplay("oyder_by_apiv2", order);
 			var field = "contentId,title,description,userId,viewCounter,mylistCounter,lengthSeconds,thumbnailUrl,startTime,commentCounter,tags,channelId,thumbnailUrl";
 			var url = $"https://snapshot.search.nicovideo.jp/api/v2/snapshot/video/contents/search?q={word}&targets={target}&fields={field}&_sort={orderbyapiv2}&_offset={offset}&_limit={limit}&_context={context}";
 
-			return SearchApiV2(await WebUtil.GetJsonAsync(url));
-		}
-
-		private static IEnumerable<NicoVideoModel> SearchApiV2(dynamic json)
-		{
+			var json = await WebUtil.GetJsonAsync(url);
+			if (json == null) yield break;
 			foreach (var item in json.data)
 			{
 				yield return new NicoVideoModel(item);

--- a/_Apps/Nico.Workspaces/NicoFavoriteViewModel.cs
+++ b/_Apps/Nico.Workspaces/NicoFavoriteViewModel.cs
@@ -2,6 +2,7 @@
 using Moviewer.Core.Windows;
 using Moviewer.Nico.Controls;
 using Moviewer.Nico.Core;
+using System.Threading;
 using System.Windows.Input;
 using TBird.Core;
 using TBird.Wpf;
@@ -47,13 +48,22 @@ namespace Moviewer.Nico.Workspaces
 
 		public BindableContextCollection<NicoSearchHistoryViewModel> Favorites { get; private set; }
 
+		// 連続発火対策: NicoSearch と同パターン (§3.7 / 確定事項 #30, #33)
+		private int _searchGen;
+
 		public ICommand OnSearch => _OnSearch = _OnSearch ?? RelayCommand.Create<NicoSearchHistoryViewModel>(async vm =>
 		{
-			await NicoUtil.GetVideoBySearchType(vm.Word, vm.Type, Orderby.SelectedItem.Value).ContinueWith(x =>
+			var myGen = Interlocked.Increment(ref _searchGen);
+			Sources.Clear();
+			try
 			{
-				Sources.Clear();
-				Sources.AddRange(x.Result);
-			}).TryCatch();
+				await foreach (var item in NicoUtil.GetVideoBySearchType(vm.Word, vm.Type, Orderby.SelectedItem.Value))
+				{
+					if (Volatile.Read(ref _searchGen) != myGen) return;
+					Sources.Add(item);
+				}
+			}
+			catch { }
 		});
 		private ICommand _OnSearch;
 
@@ -67,4 +77,4 @@ namespace Moviewer.Nico.Workspaces
 			NicoModel.DelFavorite(vm.Word, vm.Type);
 		}
 	}
-}
+}

--- a/_Apps/Nico.Workspaces/NicoRankingViewModel.cs
+++ b/_Apps/Nico.Workspaces/NicoRankingViewModel.cs
@@ -66,14 +66,15 @@ namespace Moviewer.Nico.Workspaces
 
 		private async Task Reload()
 		{
-			await NicoUtil.GetVideosByRanking(Genre.SelectedItem.Value, "all", Period.SelectedItem.Value).ContinueWith(x =>
+			try
 			{
 				Sources.Clear();
-				foreach (var item in x.Result)
+				await foreach (var item in NicoUtil.GetVideosByRanking(Genre.SelectedItem.Value, "all", Period.SelectedItem.Value))
 				{
 					Sources.Add(item);
 				}
-			}).TryCatch();
+			}
+			catch { }
 		}
 	}
-}
+}

--- a/_Apps/Nico.Workspaces/NicoSearchViewModel.cs
+++ b/_Apps/Nico.Workspaces/NicoSearchViewModel.cs
@@ -2,6 +2,7 @@
 using Moviewer.Core.Windows;
 using Moviewer.Nico.Controls;
 using Moviewer.Nico.Core;
+using System.Threading;
 using System.Windows.Input;
 using TBird.Core;
 using TBird.Wpf;
@@ -60,15 +61,25 @@ namespace Moviewer.Nico.Workspaces
 
 		public BindableContextCollection<NicoSearchHistoryViewModel> Histories { get; private set; }
 
+		// 連続発火対策: 後発の OnSearch が走り出したら前回のループは離脱する。
+		// HTTP 自体はキャンセルしない (既存と同等の握り潰し方針)。
+		private int _searchGen;
+
 		public ICommand OnSearch => _OnSearch = _OnSearch ?? RelayCommand.Create<NicoSearchType>(async t =>
 		{
-			await NicoUtil.GetVideoBySearchType(Word, t, Orderby.SelectedItem.Value).ContinueWith(x =>
+			var myGen = Interlocked.Increment(ref _searchGen);
+			Sources.Clear();
+			try
 			{
-				Sources.Clear();
-				Sources.AddRange(x.Result);
-			}).TryCatch();
+				await foreach (var item in NicoUtil.GetVideoBySearchType(Word, t, Orderby.SelectedItem.Value))
+				{
+					if (Volatile.Read(ref _searchGen) != myGen) return;
+					Sources.Add(item);
+				}
+			}
+			catch { }
 
-			NicoModel.AddSearch(Word, t);
+			if (Volatile.Read(ref _searchGen) == myGen) NicoModel.AddSearch(Word, t);
 		});
 		private ICommand _OnSearch;
 
@@ -83,4 +94,4 @@ namespace Moviewer.Nico.Workspaces
 			NicoModel.DelSearch(vm.Word, vm.Type);
 		}
 	}
-}
+}

--- a/_Apps/lib/nico-combo-setting.xml
+++ b/_Apps/lib/nico-combo-setting.xml
@@ -1,103 +1,101 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xml>
-    <combo group="video_type">
-        <item value="sm"   display="個人動画" />
-        <item value="so"   display="チャンネル動画" />
-    </combo>
-    <combo group="mylist_title_removes">
-        <item value="0"   display="‐ニコニコ動画" />
-        <item value="1"   display="マイリスト " />
-    </combo>
-    <combo group="rank_genre">
-        <item value="all"                   display="全ジャンル" />
-        <item value="hot_topic"             display="話題" />
-        <item value="entertainment"         display="エンターテイメント" />
-        <item value="radio"                 display="ラジオ" />
-        <item value="music_sound"           display="音楽・サウンド" />
-        <item value="dance"                 display="ダンス" />
-        <item value="animal"                display="動物" />
-        <item value="nature"                display="自然" />
-        <item value="cooking"               display="料理" />
-        <item value="traveling_outdoor"     display="旅行・アウトドア" />
-        <item value="vehicle"               display="乗り物" />
-        <item value="sports"                display="スポーツ" />
-        <item value="society_politics_news" display="社会・政治・時事" />
-        <item value="technology_craft"      display="技術・工作" />
-        <item value="commentary_lecture"    display="解説・講座" />
-        <item value="anime"                 display="アニメ" />
-        <item value="game"                  display="ゲーム" />
-        <item value="other"                 display="その他" />
-        <item value="r18"                   display="R-18" />
-    </combo>
-    <combo group="rank_period">
-        <item value="hourly"  display="時間" />
-        <item value="daily"   display="日間" />
-        <item value="weekly"  display="週間" />
-        <item value="monthly" display="月間" />
-        <item value="total"   display="総合" />
-    </combo>
-    <combo group="order_by">
-        <item value="regdate-"   display="登録日時(降順)" />
-        <item value="regdate+"   display="登録日時(昇順)" />
-        <item value="stadate-"   display="投稿日時(降順)" />
-        <item value="stadate+"   display="投稿日時(昇順)" />
-        <item value="viewcnt-"   display="再生数(降順)" />
-        <item value="viewcnt+"   display="再生数(昇順)" />
-        <item value="commcnt-"   display="コメント数(降順)" />
-        <item value="commcnt+"   display="コメント数(昇順)" />
-        <item value="listcnt-"   display="マイリスト数(降順)" />
-        <item value="listcnt+"   display="マイリスト数(昇順)" />
-        <item value="likecnt-"   display="いいね！数(降順)" />
-        <item value="likecnt+"   display="いいね！数(昇順)" />
-        <item value="lengsec-"   display="再生時間(降順)" />
-        <item value="lengsec+"   display="再生時間(昇順)" />
-    </combo>
-    <combo group="oyder_by_apiv2">
-        <item value="regdate-"   display="-startTime" />
-        <item value="regdate+"   display="+startTime" />
-        <item value="stadate-"   display="-startTime" />
-        <item value="stadate+"   display="+startTime" />
-        <item value="viewcnt-"   display="-viewCounter" />
-        <item value="viewcnt+"   display="+viewCounter" />
-        <item value="commcnt-"   display="-commentCounter" />
-        <item value="commcnt+"   display="+commentCounter" />
-        <item value="listcnt-"   display="-mylistCounter" />
-        <item value="listcnt+"   display="+mylistCounter" />
-        <item value="likecnt-"   display="-likeCounter" />
-        <item value="likecnt+"   display="+likeCounter" />
-        <item value="lengsec-"   display="-lengthSeconds" />
-        <item value="lengsec+"   display="+lengthSeconds" />
-    </combo>
-    <combo group="oyder_by_mylist">
-        <item value="regdate-"   display="1" />
-        <item value="regdate+"   display="0" />
-        <item value="stadate-"   display="6" />
-        <item value="stadate+"   display="7" />
-        <item value="viewcnt-"   display="8" />
-        <item value="viewcnt+"   display="9" />
-        <item value="commcnt-"   display="12" />
-        <item value="commcnt+"   display="13" />
-        <item value="listcnt-"   display="14" />
-        <item value="listcnt+"   display="15" />
-        <item value="likecnt-"   display="14" />
-        <item value="likecnt+"   display="15" />
-        <item value="lengsec-"   display="16" />
-        <item value="lengsec+"   display="17" />
-    </combo>
-    <combo group="oyder_by_user">
-        <item value="regdate-"   display="registeredAt,desc" />
-        <item value="regdate+"   display="registeredAt,asc" />
-        <item value="stadate-"   display="registeredAt,desc" />
-        <item value="stadate+"   display="registeredAt,asc" />
-        <item value="viewcnt-"   display="viewCount,desc" />
-        <item value="viewcnt+"   display="viewCount,asc" />
-        <item value="commcnt-"   display="commentCount,desc" />
-        <item value="commcnt+"   display="commentCount,asc" />
-        <item value="listcnt-"   display="mylistCount,desc" />
-        <item value="listcnt+"   display="mylistCount,asc" />
-        <item value="likecnt-"   display="likeCount,desc" />
-        <item value="likecnt+"   display="likeCount,asc" />
-        <item value="lengsec-"   display="duration,desc" />
-        <item value="lengsec+"   display="duration,asc" />
-    </combo>
+	<combo group="video_type">
+		<item value="sm"   display="個人動画" />
+		<item value="so"   display="チャンネル動画" />
+	</combo>
+	<combo group="mylist_title_removes">
+		<item value="0"   display="‐ニコニコ動画" />
+		<item value="1"   display="マイリスト " />
+	</combo>
+	<combo group="rank_genre">
+		<item value="all"                   display="全ジャンル" />
+		<item value="hot_topic"             display="話題" />
+		<item value="entertainment"         display="エンターテイメント" />
+		<item value="radio"                 display="ラジオ" />
+		<item value="music_sound"           display="音楽・サウンド" />
+		<item value="dance"                 display="ダンス" />
+		<item value="animal"                display="動物" />
+		<item value="nature"                display="自然" />
+		<item value="cooking"               display="料理" />
+		<item value="traveling_outdoor"     display="旅行・アウトドア" />
+		<item value="vehicle"               display="乗り物" />
+		<item value="sports"                display="スポーツ" />
+		<item value="society_politics_news" display="社会・政治・時事" />
+		<item value="technology_craft"      display="技術・工作" />
+		<item value="commentary_lecture"    display="解説・講座" />
+		<item value="anime"                 display="アニメ" />
+		<item value="game"                  display="ゲーム" />
+		<item value="other"                 display="その他" />
+		<item value="r18"                   display="R-18" />
+	</combo>
+	<combo group="rank_period">
+		<item value="hour"   display="時間" />
+		<item value="24h"    display="日間" />
+		<item value="week"   display="週間" />
+		<item value="month"  display="月間" />
+		<item value="total"  display="総合" />
+	</combo>
+	<combo group="order_by">
+		<item value="regdate-"   display="登録日時(降順)" />
+		<item value="regdate+"   display="登録日時(昇順)" />
+		<item value="stadate-"   display="投稿日時(降順)" />
+		<item value="stadate+"   display="投稿日時(昇順)" />
+		<item value="viewcnt-"   display="再生数(降順)" />
+		<item value="viewcnt+"   display="再生数(昇順)" />
+		<item value="commcnt-"   display="コメント数(降順)" />
+		<item value="commcnt+"   display="コメント数(昇順)" />
+		<item value="listcnt-"   display="マイリスト数(降順)" />
+		<item value="listcnt+"   display="マイリスト数(昇順)" />
+		<item value="likecnt-"   display="いいね！数(降順)" />
+		<item value="likecnt+"   display="いいね！数(昇順)" />
+		<item value="lengsec-"   display="再生時間(降順)" />
+		<item value="lengsec+"   display="再生時間(昇順)" />
+	</combo>
+	<combo group="oyder_by_apiv2">
+		<item value="regdate-"   display="-startTime" />
+		<item value="regdate+"   display="+startTime" />
+		<item value="stadate-"   display="-startTime" />
+		<item value="stadate+"   display="+startTime" />
+		<item value="viewcnt-"   display="-viewCounter" />
+		<item value="viewcnt+"   display="+viewCounter" />
+		<item value="commcnt-"   display="-commentCounter" />
+		<item value="commcnt+"   display="+commentCounter" />
+		<item value="listcnt-"   display="-mylistCounter" />
+		<item value="listcnt+"   display="+mylistCounter" />
+		<item value="likecnt-"   display="-likeCounter" />
+		<item value="likecnt+"   display="+likeCounter" />
+		<item value="lengsec-"   display="-lengthSeconds" />
+		<item value="lengsec+"   display="+lengthSeconds" />
+	</combo>
+	<combo group="oyder_by_mylist">
+		<item value="regdate-"   display="addedAt,desc" />
+		<item value="regdate+"   display="addedAt,asc" />
+		<item value="stadate-"   display="registeredAt,desc" />
+		<item value="stadate+"   display="registeredAt,asc" />
+		<item value="viewcnt-"   display="viewCount,desc" />
+		<item value="viewcnt+"   display="viewCount,asc" />
+		<item value="commcnt-"   display="commentCount,desc" />
+		<item value="commcnt+"   display="commentCount,asc" />
+		<item value="listcnt-"   display="mylistCount,desc" />
+		<item value="listcnt+"   display="mylistCount,asc" />
+		<item value="likecnt-"   display="likeCount,desc" />
+		<item value="likecnt+"   display="likeCount,asc" />
+		<item value="lengsec-"   display="duration,desc" />
+		<item value="lengsec+"   display="duration,asc" />
+	</combo>
+	<combo group="oyder_by_user">
+		<item value="stadate-"   display="registeredAt,desc" />
+		<item value="stadate+"   display="registeredAt,asc" />
+		<item value="viewcnt-"   display="viewCount,desc" />
+		<item value="viewcnt+"   display="viewCount,asc" />
+		<item value="commcnt-"   display="commentCount,desc" />
+		<item value="commcnt+"   display="commentCount,asc" />
+		<item value="listcnt-"   display="mylistCount,desc" />
+		<item value="listcnt+"   display="mylistCount,asc" />
+		<item value="likecnt-"   display="likeCount,desc" />
+		<item value="likecnt+"   display="likeCount,asc" />
+		<item value="lengsec-"   display="duration,desc" />
+		<item value="lengsec+"   display="duration,asc" />
+	</combo>
 </xml>


### PR DESCRIPTION
## 背景

RSS取得時に `XmlException: 'id' is an unexpected token` が発生するようになった。原因は `www.nicovideo.jp/ranking/genre/{g}?rss=2.0` が HTML/SPA レスポンスを返すようになり、RSS API として死亡したため。他の RSS / 旧 XML 系エンドポイントも不安定化が予想されるため、ニコニコ公式 SPA が利用している nvapi (JSON API) に全面置換する。

## 主要な変更

### API 置換
| 旧 | 新 |
|---|---|
| `www.nicovideo.jp/ranking/genre/{g}?rss=2.0` | `nvapi.nicovideo.jp/v1/ranking/genre/{genre}` |
| `www.nicovideo.jp/mylist/{id}?rss=2.0` | `nvapi.nicovideo.jp/v2/mylists/{id}` |
| `www.nicovideo.jp/user/{id}/video?rss=2.0` | `nvapi.nicovideo.jp/v2/users/{id}/videos` |
| `ext.nicovideo.jp/api/getthumbinfo/{id}` | `www.nicovideo.jp/api/watch/v3_guest/{id}` |
| `seiga.nicovideo.jp/api/user/info?id={id}` | `nvapi.nicovideo.jp/v1/users/{id}` |

### 認証
- `nvapi.nicovideo.jp` は HTTP ヘッダ `X-Frontend-Id: 6` / `X-Frontend-Version: 0` 必須
- `watch/v3_guest` はクエリ `_frontendId=6&_frontendVersion=0` で完結 (ヘッダ不要)

### IAsyncEnumerable 化
- mylist/user は最大 100 件/コールのため、戻り値を全て `IAsyncEnumerable<NicoVideoModel>` に統一して全件遅延ロード対応
- ranking は 100 件固定、search 系も統一のため変換

### 連続発火対策 (世代カウンタ)
- NicoSearch / NicoFavorite で `Interlocked.Increment(ref _searchGen)` + `Volatile.Read` チェック → 後発呼出が前回ループを離脱させる
- NicoRanking は既存 `LockAsync` で対応済み
- HTTP 自体のキャンセルはしない (既存と同等の握り潰し方針)

### PatrolFavorites の判定整合
- nvapi `regdate-` は種別ごとに並びが異なる (User/Word/Tag は registeredAt 降順、Mylist は addedAt 降順)
- `NicoVideoModel.MylistAddedAt` プロパティを新設、`FromMylistItem` で設定
- 比較は `video.MylistAddedAt ?? video.StartTime` で揃え、降順前提で `break` 打ち切り
- `initialDate` で開始時点しきい値を固定 (逐次評価で `m.Date` 更新が次判定に影響するバグ回避)

### combo XML 改訂
- `rank_period`: `hourly/daily/weekly/monthly/total` → `hour/24h/week/month/total`
- `oyder_by_mylist`: 数値コード → `sortKey,sortOrder` 文字列形式
- `oyder_by_user`: `regdate-/+` 削除 (registeredAt に集約・display 重複だったため)。コード側で `regdate→stadate` 正規化

### バグ修正
- `WebUtil.GetJsonAsync(url)`: `DynamicJson.Parse(null)` の NRE バグを null 吸収に修正
- `NicoUserModel.GetNickname`: nickname が null/空のときキャッシュに保存していた毒キャッシュバグを修正

## 追加機能 (PR追加分)

- **ランキング一覧タイトルに `第N位：` プレフィックス付与** (`GetVideosByRanking`)。OnLoaded 経由の `CoreUtil.Nvl(Title, m.Title)` で既存値優先のため保持される
- **`VideoModel.Description` で HTML タグ剥離**。`StringExtension.StripHtml()` 拡張メソッド新設。`<br>` `<p>` `<div>` 系は改行に置換、その他のタグは除去、HtmlDecode 後に適用

## 既知のリスク・未決事項

- **nvapi は非公式 API**。仕様変更リスクは RSS 廃止と同じ
- **設定値ミグレーション**: `rank_period` の旧値 (`hourly` 等) を持つユーザー設定は `GetItemNotNull` のフォールバックで先頭項目 (`hour`) になる。クラッシュは無いが、過去選択 ("日間" 等) が初回起動で "時間" に化ける UX 劣化あり
- **PatrolFavorites の Mylist 種別**: 旧 RSS の `m.Date` は StartTime ベース、新 nvapi は addedAt ベース。意味的軸が異なるため移行直後の初回パトロールで過去アイテムを再 AddTemporary する可能性あり。`VideoHistoryModel.AddModel` は冪等のためデータ破壊なし、Date 上書きによる Temporary タブの一時的なソート順乱れのみ
- **チャンネル所有マイリストの owner 構造未検証**: 通常ユーザー所有マイリストでのみ実機検証済み。チャンネル所有時の owner フィールド構造は要動作確認

## テストプラン

- [ ] ランキング表示 (各ジャンル × 各期間)
- [ ] マイリスト検索 (通常 / 大規模 / 公開停止)
- [ ] ユーザー投稿動画検索 (通常 / 大量投稿)
- [ ] チャンネル動画の owner 表示 (`ch...` プレフィックスの正常表示)
- [ ] 検索ボタン連打時に最終結果のみ表示される
- [ ] お気に入り巡回 (Mylist/User 両種別)
- [ ] 動画詳細の Description が HTML タグなしで読みやすく表示される
- [ ] ランキング一覧で "第N位：" プレフィックスが表示される