### PR TITLE
fix(h-1〜h-4 + l-2): rollback orphan novel / fetch unconfirmed / refresh filter / sync dedup ids / clamp delay

### DIFF
--- a/_Apps/Services/Background/BackgroundJobQueue.cs
+++ b/_Apps/Services/Background/BackgroundJobQueue.cs
@@ -94,6 +94,11 @@ public class BackgroundJobQueue
         if (oldCts is null) return;
         try { oldCts.Cancel(); }
         catch (ObjectDisposedException) { return; }
+
+        // キューに残っている job の dedup HashSet を再開可能な状態に戻す。
+        // キュー本体は消さない（Wi-Fi 復帰時にそのまま再消費される）。
+        SyncEnqueuedIdsFromQueues();
+
         if (oldTask is not null)
         {
             _ = oldTask.ContinueWith(_ => oldCts.Dispose(), TaskScheduler.Default);
@@ -101,6 +106,21 @@ public class BackgroundJobQueue
         else
         {
             oldCts.Dispose();
+        }
+    }
+
+    private void SyncEnqueuedIdsFromQueues()
+    {
+        // ConcurrentQueue.GetEnumerator はスナップショットを返すため列挙中の変更で例外にはならない。
+        // 旧 Enqueue が HashSet.Add 後に lock を抜けてから Queue.Enqueue する race window が
+        // 残るが、PR-3 (M-2) で Enqueue を async 化して同一 lock 内に統合し恒久解消する。
+        lock (_enqueuedEpisodeIds)
+        {
+            var live = new HashSet<int>();
+            foreach (var j in _highPriority) live.Add(j.EpisodeDbId);
+            foreach (var j in _normalPriority) live.Add(j.EpisodeDbId);
+            _enqueuedEpisodeIds.Clear();
+            foreach (var id in live) _enqueuedEpisodeIds.Add(id);
         }
     }
 

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -177,6 +177,27 @@ public class NovelRepository
         }).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// (site_type, novel_id) で Novel を補償削除。
+    /// SearchViewModel.RegisterAsync の Insert 成功後ネットワーク失敗時に使用。
+    /// </summary>
+    public async Task DeleteBySiteAndNovelIdAsync(int siteType, string novelId)
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        await _db.RunInTransactionAsync(conn =>
+        {
+            var rows = conn.Query<Novel>(
+                "SELECT * FROM novels WHERE site_type = ? AND novel_id = ?",
+                siteType, novelId);
+            foreach (var n in rows)
+            {
+                _cacheRepo.DeleteByNovelIdSync(conn, n.Id);
+                conn.Execute("DELETE FROM episodes WHERE novel_id = ?", n.Id);
+                conn.Execute("DELETE FROM novels WHERE id = ?", n.Id);
+            }
+        }).ConfigureAwait(false);
+    }
+
     public async Task<int> CountAsync()
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);

--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -118,6 +118,6 @@ public class NetworkPolicyService
     private async Task<int> GetDelayMsAsync()
     {
         var v = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, SettingsKeys.DEFAULT_REQUEST_DELAY_MS).ConfigureAwait(false);
-        return Math.Clamp(v, 100, 5000);
+        return Math.Clamp(v, SettingsKeys.MIN_REQUEST_DELAY_MS, SettingsKeys.MAX_REQUEST_DELAY_MS);
     }
 }

--- a/_Apps/Services/UpdateCheckService.cs
+++ b/_Apps/Services/UpdateCheckService.cs
@@ -44,8 +44,9 @@ public class UpdateCheckService
             {
                 if (ct.IsCancellationRequested) break;
 
-                // Skip novels with unconfirmed updates
-                if (novel.HasUnconfirmedUpdate) continue;
+                // 取得自体は常に行う。HasUnconfirmedUpdate=true の小説をスキップすると、
+                // ユーザがアプリを開かない限り更新追跡から脱落する問題があったため (H-2)。
+                // 通知は notificationId=novel.Id で上書き表示されるため重複通知にはならない。
 
                 try
                 {

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -155,10 +155,21 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
                 ep.IsRead = isRead;
         }
 
-        foreach (var vm in Episodes)
+        if (ShowUnreadOnly)
         {
-            if (readMap.TryGetValue(vm.Id, out var isRead))
-                vm.IsRead = isRead;
+            // 未読フィルタ ON のときは既読化した話をリストから外す必要がある
+            RebuildFilterCache();
+            RecalcPaging();
+            await LoadPageAsync();
+        }
+        else
+        {
+            // フィルタが OFF なら現在表示中のアイテムだけ in-place 更新
+            foreach (var vm in Episodes)
+            {
+                if (readMap.TryGetValue(vm.Id, out var isRead))
+                    vm.IsRead = isRead;
+            }
         }
     }
 

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -249,6 +249,7 @@ public partial class SearchViewModel : ObservableObject
         if (result.IsRegistered || result.IsRegistering) return;
 
         result.IsRegistering = true;
+        bool novelInserted = false;
         try
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -266,47 +267,63 @@ public partial class SearchViewModel : ObservableObject
             };
 
             await _novelRepo.InsertAsync(novel);
+            novelInserted = true;
 
             var service = _serviceFactory.GetService(result.SiteType);
             var episodes = await service.FetchEpisodeListAsync(result.NovelId, cts.Token);
 
-            var dbNovel = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
-            if (dbNovel is not null)
+            var dbNovel = await _novelRepo.GetBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId)
+                ?? throw new InvalidOperationException("登録レコードを取得できませんでした");
+
+            foreach (var ep in episodes)
             {
-                foreach (var ep in episodes)
-                {
-                    ep.NovelId = dbNovel.Id;
-                }
-                await _episodeRepo.InsertAllAsync(episodes);
-
-                dbNovel.TotalEpisodes = episodes.Count;
-
-                // 作者名が空の場合、FetchNovelInfoAsync で補完
-                if (string.IsNullOrEmpty(dbNovel.Author))
-                {
-                    try
-                    {
-                        var (_, _, _, fetchedAuthor) = await service.FetchNovelInfoAsync(result.NovelId, cts.Token);
-                        if (!string.IsNullOrEmpty(fetchedAuthor))
-                        {
-                            dbNovel.Author = fetchedAuthor;
-                        }
-                    }
-                    catch { /* 作者名取得失敗は無視 */ }
-                }
-
-                await _novelRepo.UpdateAsync(dbNovel);
-
-                // Auto-enqueue prefetch for newly registered novel (Wi-Fi only)
-                _ = _prefetch.EnqueueNovelAsync(dbNovel.Id);
+                ep.NovelId = dbNovel.Id;
             }
+            await _episodeRepo.InsertAllAsync(episodes);
+
+            dbNovel.TotalEpisodes = episodes.Count;
+
+            // 作者名が空の場合、FetchNovelInfoAsync で補完
+            if (string.IsNullOrEmpty(dbNovel.Author))
+            {
+                try
+                {
+                    var (_, _, _, fetchedAuthor) = await service.FetchNovelInfoAsync(result.NovelId, cts.Token);
+                    if (!string.IsNullOrEmpty(fetchedAuthor))
+                    {
+                        dbNovel.Author = fetchedAuthor;
+                    }
+                }
+                catch { /* 作者名取得失敗は無視 */ }
+            }
+
+            await _novelRepo.UpdateAsync(dbNovel);
+
+            // Auto-enqueue prefetch for newly registered novel (Wi-Fi only)
+            _ = _prefetch.EnqueueNovelAsync(dbNovel.Id);
 
             result.IsRegistered = true;
             result.TotalEpisodes = episodes.Count;
+
+            // rollback スコープを「Insert 〜 全 await 完了」までに広げる意図でフラグを最後に下ろす。
+            // 途中の FetchEpisodeList / InsertAll / UpdateAsync 等で例外が出た場合は catch で補償削除に到達する。
+            novelInserted = false;
         }
         catch (Exception ex)
         {
             LogHelper.Error(nameof(SearchViewModel), $"Register failed: {ex.Message}");
+            if (novelInserted)
+            {
+                try
+                {
+                    await _novelRepo.DeleteBySiteAndNovelIdAsync((int)result.SiteType, result.NovelId);
+                }
+                catch (Exception rbEx)
+                {
+                    LogHelper.Warn(nameof(SearchViewModel),
+                        $"Rollback delete failed for ({result.SiteType}, {result.NovelId}): {rbEx.Message}");
+                }
+            }
             await Shell.Current.DisplayAlert("エラー", $"登録に失敗しました: {ex.Message}", "OK");
         }
         finally


### PR DESCRIPTION
## Summary

`plan_2026-04-30_review-c1-l11.md` の **PR-2**。機能バグ High 4 件 + 事実バグ L-2（PR-4 から格上げ移動）の合計 5 件を修正。

### H-1: 登録失敗時に Novel が DB に孤立して再登録不能
- **問題**: `SearchViewModel.RegisterAsync` で `_novelRepo.InsertAsync` 成功後の `FetchEpisodeListAsync` / `InsertAllAsync` / `UpdateAsync` 等で例外（HttpRequestException, TaskCanceledException 等）が出ると Novel だけ DB に残り、再検索しても `IsRegistered=true` で再登録不能、目次も空。
- **修正**:
  - `NovelRepository.DeleteBySiteAndNovelIdAsync` を追加。`(site_type, novel_id)` キーで `episode_cache` → `episodes` → `novels` をトランザクション内で連鎖削除。
  - `RegisterAsync` 内で `bool novelInserted` フラグを立て、catch で補償削除を呼ぶ。フラグはメソッド末尾（result.* セット後）で false に下ろし、Insert〜全 await 完了の全範囲を rollback スコープでカバー。
- **影響ファイル**: `_Apps/Services/Database/NovelRepository.cs` / `_Apps/ViewModels/SearchViewModel.cs`

### H-2: `HasUnconfirmedUpdate=true` で取得そのものをスキップ
- **問題**: `UpdateCheckService` が「再通知抑制」のつもりで取得自体をスキップしていた。`HasUnconfirmedUpdate` は目次タップか全話既読でしか false に戻らないため、ユーザがアプリを開かない限り更新追跡から脱落していた。
- **修正**: スキップ条件を削除。通知は `notificationId=novel.Id` で同 ID 上書き表示されるため重複通知にはならず、`newEpisodes.Count`（差分のみ）が表示される。
- **影響ファイル**: `_Apps/Services/UpdateCheckService.cs`

### H-3: `ShowUnreadOnly=true` で RefreshReadStatus 後にリスト不整合
- **問題**: `EpisodeListViewModel.RefreshReadStatusAsync` が `_filteredCache` を再構築しないため、未読フィルタ ON でリーダー → 戻ると本来消えるはずの既読化済み話が「既読印」付きで残る。
- **修正**: `ShowUnreadOnly=true` のときだけ `RebuildFilterCache` + `RecalcPaging` + `LoadPageAsync` を呼ぶ分岐を追加。フィルタ OFF 時は従来の in-place 更新を維持。
- **影響ファイル**: `_Apps/ViewModels/EpisodeListViewModel.cs`

### H-4: Cancel 時に dedup HashSet がクリアされず再 Enqueue 不能
- **問題**: `BackgroundJobQueue` Worker ループは Wi-Fi 切断 / `StopWorker` 時に break で抜けるが、キューに残った job の EpisodeId が `_enqueuedEpisodeIds` に残ったまま → 同じ episode を再 Enqueue できなくなる。
- **修正**: `SyncEnqueuedIdsFromQueues` メソッドを新設し、`StopWorker` 内で呼び出す。live キューに残っている ID だけ HashSet に再構成することで、(a) キューに居る重複抑止は保たれ、(b) キューに無いものは再 Enqueue 可能になる。
- **影響ファイル**: `_Apps/Services/Background/BackgroundJobQueue.cs`

#### ⚠ 既知の race window（PR-3 で恒久解消）

本 PR 段階では旧 `Enqueue` の lock 構造（HashSet.Add 後に lock を抜けてから Queue.Enqueue）のままで、Wi-Fi 切断中に発生する Enqueue で「HashSet にも Queue にもない job」が生まれる race が残ります。実害は同一 episode の重複 prefetch 1 回程度で UX 影響は無視できる範囲。**PR-3 (M-2)** で `Enqueue` を `async` 化して HashSet.Add と Queue.Enqueue を同一 lock 内に統合し恒久解消します。推奨マージ順は `PR-1 → PR-2 → PR-4 → PR-7 → PR-3 → ...` のため、その間 (PR-4 / PR-7 マージ期間) はこの race window が残存します。

### L-2: リクエストディレイ Clamp が UI 範囲と乖離（事実バグ格上げ）
- **問題**: `NetworkPolicyService.GetDelayMsAsync` の Clamp が `(v, 100, 5000)` で、UI スライダー範囲 `(500, 2000)` と不一致。設定 UI 経由でない経路（旧バージョン DB 値継承等）で UI 範囲外の遅延値が通っていた。Low 分類だが事実バグのため PR-4 → PR-2 に格上げ。
- **修正**: `Math.Clamp(v, SettingsKeys.MIN_REQUEST_DELAY_MS, SettingsKeys.MAX_REQUEST_DELAY_MS)` に変更。
- **注意**: 旧 DB に 100ms（下振れ）が保存されているユーザは MIN(500ms) に引き上げ → サイト負荷の観点で望ましい。逆に 5000ms（上振れ）が保存されていた場合は MAX(2000ms) に引き下げ → 「設定したはずより速くリクエストされる」と感じられる可能性あり。
- **影響ファイル**: `_Apps/Services/Network/NetworkPolicyService.cs`

## 事前確認結果

- **P-3** (idx_novels_site_novel UNIQUE INDEX): `DatabaseService.cs:52` で確認済み。
- **P-4** (DeleteByNovelIdSync シグネチャ): `EpisodeCacheRepository.cs:41` で `internal void DeleteByNovelIdSync(SQLiteConnection conn, int novelId)` を確認。同一アセンブリから呼び出し可能。

## ビルド

`dotnet build _Apps/App.sln --no-restore` で **0 Warning / 0 Error**。

## Test plan

- [ ] H-1: 登録中にネットワーク切断 → 再検索すると `IsRegistered=false` のまま再登録可能
- [ ] H-2: 更新通知を確認しないまま (HasUnconfirmedUpdate=true) 次の更新チェック周期で新々話が追加 → 通知に最新差分話数が表示される
- [ ] H-3: 未読フィルタ ON で全話既読化 → 戻ると episode list が空 (or 残ページに移動)
- [ ] H-4: Wi-Fi 切断 → 同 episode を再 Enqueue するシナリオで HashSet に残らないこと（実機テストは難しいので code review で確認）
- [ ] L-2: 旧 DB に 100ms or 5000ms が保存されたユーザの実 delay が 500ms / 2000ms に揃うこと
- [ ] PR-1 で導入した update_interval_hours の動作が崩れていないこと（regression）

## 参考

- 計画書: `_Apps/Features/plan_2026-04-30_review-c1-l11.md` (v10)
- 前 PR: #121 (PR-1 / C-1〜C-3)
- 後続 PR: PR-4 (L-1, L-5〜L-10) → PR-7 (L-3 + N-1〜N-4 + B-4) → PR-3 (M-1〜M-5) → PR-6 (L-9) → PR-5 (要件書)