### PR TITLE
refactor(l-1, l-5〜l-8, l-10): code quality cleanup — constants, exception handler, cache sweep, timezone, manifest, selectors

### DIFF
--- a/_Apps/App.xaml.cs
+++ b/_Apps/App.xaml.cs
@@ -36,6 +36,13 @@ public partial class App : Application
         {
             LogHelper.Error("App", $"Unhandled exception: {args.ExceptionObject}");
         };
+
+        // fire-and-forget Task の未観測例外を捕捉してプロセス終了を抑止する
+        TaskScheduler.UnobservedTaskException += (sender, args) =>
+        {
+            LogHelper.Error("App", $"Unobserved task exception: {args.Exception}");
+            args.SetObserved();
+        };
     }
 
     protected override Window CreateWindow(IActivationState? activationState)

--- a/_Apps/Helpers/SettingsKeys.cs
+++ b/_Apps/Helpers/SettingsKeys.cs
@@ -24,6 +24,7 @@ public static class SettingsKeys
     public const int DEFAULT_PREFETCH_ENABLED = 1;
     public const int DEFAULT_REQUEST_DELAY_MS = 800;
     public const int DEFAULT_VERTICAL_WRITING = 0;
+    public const string DEFAULT_NOVEL_SORT_KEY = "updated_desc";
     public const int MIN_REQUEST_DELAY_MS = 500;
     public const int MAX_REQUEST_DELAY_MS = 2000;
 }

--- a/_Apps/Platforms/Android/AndroidManifest.xml
+++ b/_Apps/Platforms/Android/AndroidManifest.xml
@@ -7,5 +7,4 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 </manifest>

--- a/_Apps/Services/Database/DatabaseService.cs
+++ b/_Apps/Services/Database/DatabaseService.cs
@@ -104,17 +104,17 @@ public class DatabaseService
     {
         var defaults = new Dictionary<string, string>
         {
-            ["cache_months"] = "3",
-            ["update_interval_hours"] = "6",
-            ["font_size_sp"] = "16",
-            ["background_theme"] = "0",
-            ["line_spacing"] = "1",
-            ["episodes_per_page"] = "50",
-            ["prefetch_enabled"] = "1",
-            ["request_delay_ms"] = "800",
-            ["vertical_writing"] = "0",
-            ["novel_sort_key"] = "updated_desc",
-            ["last_scheduled_hours"] = "6",
+            [SettingsKeys.CACHE_MONTHS]          = SettingsKeys.DEFAULT_CACHE_MONTHS.ToString(),
+            [SettingsKeys.UPDATE_INTERVAL_HOURS] = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS.ToString(),
+            [SettingsKeys.FONT_SIZE_SP]          = SettingsKeys.DEFAULT_FONT_SIZE_SP.ToString(),
+            [SettingsKeys.BACKGROUND_THEME]      = SettingsKeys.DEFAULT_BACKGROUND_THEME.ToString(),
+            [SettingsKeys.LINE_SPACING]          = SettingsKeys.DEFAULT_LINE_SPACING.ToString(),
+            [SettingsKeys.EPISODES_PER_PAGE]     = SettingsKeys.DEFAULT_EPISODES_PER_PAGE.ToString(),
+            [SettingsKeys.PREFETCH_ENABLED]      = SettingsKeys.DEFAULT_PREFETCH_ENABLED.ToString(),
+            [SettingsKeys.REQUEST_DELAY_MS]      = SettingsKeys.DEFAULT_REQUEST_DELAY_MS.ToString(),
+            [SettingsKeys.VERTICAL_WRITING]      = SettingsKeys.DEFAULT_VERTICAL_WRITING.ToString(),
+            [SettingsKeys.NOVEL_SORT_KEY]        = SettingsKeys.DEFAULT_NOVEL_SORT_KEY,
+            [SettingsKeys.LAST_SCHEDULED_HOURS]  = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS.ToString(),
         };
 
         foreach (var (key, value) in defaults)

--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -16,6 +16,7 @@ public class KakuyomuApiService : INovelService
     private readonly NetworkPolicyService _network;
     private readonly ConcurrentDictionary<string, (DateTime cachedAt, List<string> episodeIds)> _episodeIdCache = new();
     private static readonly TimeSpan EpisodeIdCacheTtl = TimeSpan.FromMinutes(5);
+    private const int EpisodeIdCacheMaxEntries = 100;
 
     public KakuyomuApiService(HttpClient httpClient, NetworkPolicyService network)
     {
@@ -97,8 +98,30 @@ public class KakuyomuApiService : INovelService
         return ParseApolloState(html).episodes;
     }
 
+    private void SweepExpiredEpisodeIdCache()
+    {
+        var now = DateTime.UtcNow;
+        var expired = _episodeIdCache
+            .Where(kv => now - kv.Value.cachedAt >= EpisodeIdCacheTtl)
+            .Select(kv => kv.Key)
+            .ToList();
+        foreach (var k in expired) _episodeIdCache.TryRemove(k, out _);
+
+        if (_episodeIdCache.Count > EpisodeIdCacheMaxEntries)
+        {
+            var oldest = _episodeIdCache
+                .OrderBy(kv => kv.Value.cachedAt)
+                .Take(_episodeIdCache.Count - EpisodeIdCacheMaxEntries)
+                .Select(kv => kv.Key)
+                .ToList();
+            foreach (var k in oldest) _episodeIdCache.TryRemove(k, out _);
+        }
+    }
+
     private async Task<List<string>> GetEpisodeIdsAsync(string novelId, CancellationToken ct)
     {
+        SweepExpiredEpisodeIdCache();
+
         if (_episodeIdCache.TryGetValue(novelId, out var cached)
             && DateTime.UtcNow - cached.cachedAt < EpisodeIdCacheTtl)
         {
@@ -210,7 +233,12 @@ public class KakuyomuApiService : INovelService
         var context = BrowsingContext.New(config);
         var episodeDoc = await context.OpenAsync(req => req.Content(episodeHtml), cts.Token).ConfigureAwait(false);
 
-        var contentEl = episodeDoc.QuerySelector(".widget-episodeBody, [class*='EpisodeBody']");
+        // CSS3 の [class~='X'] は「スペース区切り単語の完全一致」のため、
+        // EpisodeBodyHeader 等の連結クラス名にはマッチしない（過剰マッチ回避）。
+        var contentEl =
+            episodeDoc.QuerySelector(".widget-episodeBody") ??
+            episodeDoc.QuerySelector("[class~='EpisodeBody']");
+
         if (contentEl is null)
         {
             throw new InvalidOperationException("本文の取得に失敗しました（サイト構造が変わった可能性があります）");

--- a/_Apps/Services/Narou/NarouApiService.cs
+++ b/_Apps/Services/Narou/NarouApiService.cs
@@ -247,8 +247,17 @@ public class NarouApiService : INovelService
 
     private static string BuildRtype(RankingPeriod period)
     {
-        var jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
-        var now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+        DateTime now;
+        try
+        {
+            var jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+            now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            // フォールバック: UTC + 9h（DST なし、JST 固定オフセット）
+            now = DateTime.UtcNow.AddHours(9);
+        }
         var today = now.Date;
         // 4:00-7:00頃集計のため、当日朝8時以前は2日前、それ以外は前日を採用
         var dailyTarget = now.Hour < 8 ? today.AddDays(-2) : today.AddDays(-1);


### PR DESCRIPTION
## Summary

`plan_2026-04-30_review-c1-l11.md` の **PR-4**。コード品質クリーンアップ 6 件（L-1, L-5, L-6, L-7, L-8, L-10）。dead code 削除と定数差し替え中心の安全度の高い PR。

| 項目 | 内容 |
|---|---|
| L-1 | SeedSettingsAsync のリテラル → `SettingsKeys.DEFAULT_*` 定数化 |
| L-5 | `TaskScheduler.UnobservedTaskException` ハンドラ追加 |
| L-6 | Kakuyomu `_episodeIdCache` の expired sweep + 上限 100 |
| L-7 | `Asia/Tokyo` TZ 未検出時の UTC+9h フォールバック |
| L-8 | `RECEIVE_BOOT_COMPLETED` 宣言削除（dead code） |
| L-10 | Kakuyomu `[class*='EpisodeBody']` の過剰マッチ回避 |

注: **L-2 は PR-2 に格上げ移動済み**（事実バグのため）、**L-3 は PR-7 に移動**（N-1 と同ファイル）、**L-4 は PR-5**（要件書専用）、**L-9 は PR-6**（エラー UI 統一専用）、**L-11 は取り下げ**（H-4 で完結）。

### L-1: SeedSettingsAsync のハードコード解消
- `SettingsKeys.cs` に `DEFAULT_NOVEL_SORT_KEY = \"updated_desc\"` を追加。
- `DatabaseService.SeedSettingsAsync` の defaults 辞書を全エントリ `SettingsKeys.*` 定数経由に書き換え。
- PR-1 で追加した `LAST_SCHEDULED_HOURS = \"6\"` も `SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS.ToString()` 経由に揃え、`update_interval_hours` との既定値同期を明示化。
- **AUTO_MARK_READ_ENABLED は PR-7 (B-4) で defaults 辞書に追加予定**（本 PR のスコープ外）。
- **影響ファイル**: `_Apps/Helpers/SettingsKeys.cs`, `_Apps/Services/Database/DatabaseService.cs`

### L-5: 未観測 Task 例外のロギング
- `App.xaml.cs` の既存 `AppDomain.CurrentDomain.UnhandledException` ハンドラに加え、`TaskScheduler.UnobservedTaskException` を登録。
- `Task.Run(InitializeAppAsync)` 等の fire-and-forget 例外をログに残し、`SetObserved()` でプロセス終了を抑止。
- **影響ファイル**: `_Apps/App.xaml.cs`

### L-6: Kakuyomu episodeId キャッシュの蓄積
- `KakuyomuApiService._episodeIdCache` は Get 時のみ TTL 判定で Remove していなかったため、登録小説数 × 5 分以上残存し数 MB の HTML JSON が残留。
- `SweepExpiredEpisodeIdCache()` を追加し、`GetEpisodeIdsAsync` 入口で TTL 切れエントリと上限超過分（100 件超）を sweep。
- **影響ファイル**: `_Apps/Services/Kakuyomu/KakuyomuApiService.cs`

### L-7: TZ 未検出時のフォールバック
- `NarouApiService.BuildRtype` が `TimeZoneInfo.FindSystemTimeZoneById(\"Asia/Tokyo\")` を try/catch なしで呼んでおり、`TimeZoneNotFoundException` 時にランキング取得が落ちる。
- `catch (TimeZoneNotFoundException)` で `DateTime.UtcNow.AddHours(9)` にフォールバック（DST なしの JST 固定オフセット）。
- **影響ファイル**: `_Apps/Services/Narou/NarouApiService.cs`

### L-8: 不要な権限宣言の削除
- `AndroidManifest.xml` から `<uses-permission android:name=\"android.permission.RECEIVE_BOOT_COMPLETED\" />` を削除。
- WorkManager は OS 再起動後も自動再開するため不要、明示的な BroadcastReceiver も実装していない。
- **注意**: `androidx.work` AAR が同権限を内部宣言するため、APK 最終 manifest には manifest merger により残る。Play 審査対策ではなく、アプリ独自宣言として冗長な記載の整理。
- **影響ファイル**: `_Apps/Platforms/Android/AndroidManifest.xml`

### L-10: CSS セレクタの過剰マッチ回避
- `KakuyomuApiService.FetchEpisodeContentAsync` の CSS セレクタ `[class*='EpisodeBody']` は class 名部分一致のため `EpisodeBodyHeader` 等にも誤マッチし得た。
- `.widget-episodeBody` を主、`[class~='EpisodeBody']`（CSS3 word-match） を fallback とする 2 段階に変更。
- **影響ファイル**: `_Apps/Services/Kakuyomu/KakuyomuApiService.cs`

## ビルド

`dotnet build _Apps/App.sln --no-restore` で **0 Warning / 0 Error**。

## Test plan

- [ ] L-1: 新規インストール時に DB に既定値が正しくシードされる（特に `last_scheduled_hours=6`, `novel_sort_key=updated_desc`）
- [ ] L-5: 意図的に Task の中で例外を投げてもプロセスがクラッシュせず、ログに `Unobserved task exception:` が出る
- [ ] L-6: Kakuyomu の作品 100+ 件で TOC 取得を繰り返してもメモリが線形に増えない
- [ ] L-7: ランキング取得が `Asia/Tokyo` TZ 利用可能環境で従来どおり動作（regression なし）
- [ ] L-8: ビルド・起動が正常に通る（OS 再起動後の Worker 自動再開も WorkManager 側で動作するため変化なし）
- [ ] L-10: Kakuyomu 本文取得が従来どおり動作（regression なし）
- [ ] PR-1〜PR-2 で導入済みの修正が崩れていないこと

## 参考

- 計画書: `_Apps/Features/plan_2026-04-30_review-c1-l11.md` (v10)
- 前 PR: #122 (PR-2 / H-1〜H-4 + L-2)
- 後続 PR: PR-7 (L-3 + N-1〜N-4 + B-4) → PR-3 (M-1〜M-5) → PR-6 (L-9) → PR-5 (要件書)