### PR TITLE
fix(l-3 + n-1〜n-4 + b-4): search precision / read-position mark / genre / ranking bugs

### DIFF
--- a/_Apps/Helpers/SettingsKeys.cs
+++ b/_Apps/Helpers/SettingsKeys.cs
@@ -13,6 +13,7 @@ public static class SettingsKeys
     public const string VERTICAL_WRITING = "vertical_writing";
     public const string NOVEL_SORT_KEY = "novel_sort_key";
     public const string LAST_SCHEDULED_HOURS = "last_scheduled_hours";
+    public const string AUTO_MARK_READ_ENABLED = "auto_mark_read_enabled";
 
     // Default values
     public const int DEFAULT_CACHE_MONTHS = 3;
@@ -24,6 +25,7 @@ public static class SettingsKeys
     public const int DEFAULT_PREFETCH_ENABLED = 1;
     public const int DEFAULT_REQUEST_DELAY_MS = 800;
     public const int DEFAULT_VERTICAL_WRITING = 0;
+    public const int DEFAULT_AUTO_MARK_READ_ENABLED = 1;
     public const string DEFAULT_NOVEL_SORT_KEY = "updated_desc";
     public const int MIN_REQUEST_DELAY_MS = 500;
     public const int MAX_REQUEST_DELAY_MS = 2000;

--- a/_Apps/Helpers/SettingsKeys.cs
+++ b/_Apps/Helpers/SettingsKeys.cs
@@ -25,7 +25,7 @@ public static class SettingsKeys
     public const int DEFAULT_PREFETCH_ENABLED = 1;
     public const int DEFAULT_REQUEST_DELAY_MS = 800;
     public const int DEFAULT_VERTICAL_WRITING = 0;
-    public const int DEFAULT_AUTO_MARK_READ_ENABLED = 1;
+    public const int DEFAULT_AUTO_MARK_READ_ENABLED = 0;
     public const string DEFAULT_NOVEL_SORT_KEY = "updated_desc";
     public const int MIN_REQUEST_DELAY_MS = 500;
     public const int MAX_REQUEST_DELAY_MS = 2000;

--- a/_Apps/Services/Database/DatabaseService.cs
+++ b/_Apps/Services/Database/DatabaseService.cs
@@ -115,6 +115,7 @@ public class DatabaseService
             [SettingsKeys.VERTICAL_WRITING]      = SettingsKeys.DEFAULT_VERTICAL_WRITING.ToString(),
             [SettingsKeys.NOVEL_SORT_KEY]        = SettingsKeys.DEFAULT_NOVEL_SORT_KEY,
             [SettingsKeys.LAST_SCHEDULED_HOURS]  = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS.ToString(),
+            [SettingsKeys.AUTO_MARK_READ_ENABLED] = SettingsKeys.DEFAULT_AUTO_MARK_READ_ENABLED.ToString(),
         };
 
         foreach (var (key, value) in defaults)

--- a/_Apps/Services/Database/EpisodeRepository.cs
+++ b/_Apps/Services/Database/EpisodeRepository.cs
@@ -122,13 +122,29 @@ public class EpisodeRepository
         return await _db.UpdateAsync(episode).ConfigureAwait(false);
     }
 
-    public async Task MarkAsReadAsync(int episodeId)
+    /// <summary>
+    /// 読了点 (episode_no) を境に既読状態を一括更新する。
+    /// 1..N: is_read=1（既存 read_at は COALESCE で保持、未設定なら now を入れる）
+    /// N+1..max: is_read=0、read_at=NULL に巻き戻し
+    /// 過去話を再読した場合は意図的に N+1 以降を未読化する仕様（ユーザ承認済み）。
+    /// </summary>
+    public async Task SetReadStateUpToAsync(int novelId, int episodeNo)
     {
         await EnsureAsync().ConfigureAwait(false);
         var now = DateTime.UtcNow.ToString("o");
-        await _db.ExecuteAsync(
-            "UPDATE episodes SET is_read = ?, read_at = ? WHERE id = ?", true, now, episodeId
-        ).ConfigureAwait(false);
+
+        await _db.RunInTransactionAsync(conn =>
+        {
+            conn.Execute(
+                "UPDATE episodes SET is_read = 1, read_at = COALESCE(read_at, ?) " +
+                "WHERE novel_id = ? AND episode_no <= ?",
+                now, novelId, episodeNo);
+
+            conn.Execute(
+                "UPDATE episodes SET is_read = 0, read_at = NULL " +
+                "WHERE novel_id = ? AND episode_no > ?",
+                novelId, episodeNo);
+        }).ConfigureAwait(false);
     }
 
     public async Task<bool> AreAllReadAsync(int novelId)

--- a/_Apps/Services/INovelService.cs
+++ b/_Apps/Services/INovelService.cs
@@ -5,7 +5,7 @@ namespace LanobeReader.Services;
 public interface INovelService
 {
     SiteType SiteType { get; }
-    Task<List<SearchResult>> SearchAsync(string keyword, string searchTarget, CancellationToken ct = default);
+    Task<List<SearchResult>> SearchAsync(string keyword, CancellationToken ct = default);
     Task<List<Episode>> FetchEpisodeListAsync(string novelId, CancellationToken ct = default);
     Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default);
     Task<(int totalEpisodes, string? lastUpdatedAt, bool isCompleted, string? author)> FetchNovelInfoAsync(string novelId, CancellationToken ct = default);

--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using AngleSharp;
 using AngleSharp.Dom;
 using LanobeReader.Models;
@@ -345,7 +346,7 @@ public class KakuyomuApiService : INovelService
             var isCompleted = statusLabel?.TextContent.Trim() == "完結";
 
             var episodeCountText = card.QuerySelector("span.widget-workCard-episodeCount")?.TextContent ?? "";
-            var episodeMatch = System.Text.RegularExpressions.Regex.Match(episodeCountText, @"\d+");
+            var episodeMatch = Regex.Match(episodeCountText, @"\d+");
             var totalEpisodes = episodeMatch.Success && int.TryParse(episodeMatch.Value, out var n) ? n : 0;
 
             results.Add(new SearchResult

--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -302,6 +302,8 @@ public class KakuyomuApiService : INovelService
 
     /// <summary>
     /// ランキングページをスクレイピングして作品一覧を返す。
+    /// `div.widget-work` のうち `p.widget-work-rank` を持つカードのみを対象とすることで
+    /// 広告/おすすめ枠の混入を排除し、DOM 順 = ランキング順を保つ。
     /// </summary>
     public async Task<List<SearchResult>> FetchRankingAsync(string genreSlug, string periodSlug, CancellationToken ct = default)
     {
@@ -316,35 +318,35 @@ public class KakuyomuApiService : INovelService
         var document = await context.OpenAsync(req => req.Content(html), cts.Token).ConfigureAwait(false);
 
         var results = new List<SearchResult>();
-        var seen = new HashSet<string>();
+        var seen = new HashSet<string>(); // サイト構造変化への保険（事前調査では重複なし）
 
-        var links = document.QuerySelectorAll("a[href*='/works/']");
-        foreach (var link in links)
+        var workCards = document.QuerySelectorAll("div.widget-work");
+        foreach (var card in workCards)
         {
-            var href = link.GetAttribute("href") ?? "";
-            if (href.Contains("/reviews") || href.Contains("/episodes/")) continue;
+            // ランキング順位を持つカードに限定（広告/おすすめ枠を除外）
+            var rankEl = card.QuerySelector("p.widget-work-rank");
+            if (rankEl is null) continue;
 
+            var titleLink = card.QuerySelector("a.widget-workCard-titleLabel");
+            if (titleLink is null) continue;
+
+            var href = titleLink.GetAttribute("href") ?? "";
             var workId = ExtractWorkId(href);
-            if (string.IsNullOrEmpty(workId) || !seen.Add(workId)) continue;
+            if (string.IsNullOrEmpty(workId)) continue;
+            if (!seen.Add(workId)) continue;
 
-            var title = link.TextContent.Trim();
-            if (string.IsNullOrEmpty(title))
-                title = link.GetAttribute("title")?.Trim() ?? "";
+            var title = titleLink.TextContent.Trim();
             if (string.IsNullOrEmpty(title)) continue;
 
-            // 作者名抽出: 親要素から /users/ アンカーを探す
-            var author = "";
-            var parent = link.ParentElement;
-            for (int i = 0; i < 4 && parent is not null; i++)
-            {
-                var userLink = parent.QuerySelector("a[href*='/users/']");
-                if (userLink is not null)
-                {
-                    author = userLink.TextContent.Trim();
-                    break;
-                }
-                parent = parent.ParentElement;
-            }
+            var authorLink = card.QuerySelector("a.widget-workCard-authorLabel");
+            var author = authorLink?.TextContent.Trim() ?? "";
+
+            var statusLabel = card.QuerySelector("span.widget-workCard-statusLabel");
+            var isCompleted = statusLabel?.TextContent.Trim() == "完結";
+
+            var episodeCountText = card.QuerySelector("span.widget-workCard-episodeCount")?.TextContent ?? "";
+            var episodeMatch = System.Text.RegularExpressions.Regex.Match(episodeCountText, @"\d+");
+            var totalEpisodes = episodeMatch.Success && int.TryParse(episodeMatch.Value, out var n) ? n : 0;
 
             results.Add(new SearchResult
             {
@@ -352,8 +354,8 @@ public class KakuyomuApiService : INovelService
                 NovelId = workId,
                 Title = title,
                 Author = author,
-                TotalEpisodes = 0,
-                IsCompleted = false,
+                TotalEpisodes = totalEpisodes,
+                IsCompleted = isCompleted,
             });
 
             if (results.Count >= 30) break;

--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -30,7 +30,7 @@ public class KakuyomuApiService : INovelService
 
     public SiteType SiteType => SiteType.Kakuyomu;
 
-    public async Task<List<SearchResult>> SearchAsync(string keyword, string searchTarget, CancellationToken ct = default)
+    public async Task<List<SearchResult>> SearchAsync(string keyword, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(10));

--- a/_Apps/Services/Narou/NarouApiService.cs
+++ b/_Apps/Services/Narou/NarouApiService.cs
@@ -30,17 +30,12 @@ public class NarouApiService : INovelService
 
     public SiteType SiteType => SiteType.Narou;
 
-    public async Task<List<SearchResult>> SearchAsync(string keyword, string searchTarget, CancellationToken ct = default)
+    public async Task<List<SearchResult>> SearchAsync(string keyword, CancellationToken ct = default)
     {
-        var wordParam = searchTarget switch
-        {
-            "Title" => "title",
-            "Author" => "wname",
-            _ => "word", // Both
-        };
-
         var encoded = Uri.EscapeDataString(keyword);
-        var url = $"{API_BASE}?out=json&lim=20&{wordParam}={encoded}";
+        // title=1 + wname=1 で「タイトル or 作者名」にマッチする作品のみ取得。
+        // word 単独だとあらすじ・キーワード・作者名まで全文検索され、無関係な作品が大量にヒットする。
+        var url = $"{API_BASE}?out=json&lim=20&word={encoded}&title=1&wname=1";
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(10));

--- a/_Apps/Services/Narou/NarouApiService.cs
+++ b/_Apps/Services/Narou/NarouApiService.cs
@@ -226,15 +226,18 @@ public class NarouApiService : INovelService
     }
 
     /// <summary>
-    /// ジャンル別の新着・人気作品取得（novelapi）。
+    /// 大ジャンル別の新着・人気作品取得（novelapi）。biggenre=null で全ジャンル。
+    /// 旧シグネチャは `genre=` パラメータ（サブジャンル ID）を渡していたが、
+    /// UI は大ジャンル ID（1=恋愛 等）を扱うため `biggenre=` が正しい。
     /// </summary>
-    public async Task<List<SearchResult>> FetchByGenreAsync(int genre, string order, int limit, CancellationToken ct = default)
+    public async Task<List<SearchResult>> FetchByGenreAsync(int? biggenre, string order, int limit, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(20));
 
         var lim = Math.Clamp(limit, 1, 100);
-        var url = $"{API_BASE}?out=json&lim={lim}&genre={genre}&order={Uri.EscapeDataString(order)}";
+        var url = $"{API_BASE}?out=json&lim={lim}&order={Uri.EscapeDataString(order)}";
+        if (biggenre.HasValue) url += $"&biggenre={biggenre.Value}";
 
         var json = await _network.GetStringAsync(SiteType.Narou, url, cts.Token).ConfigureAwait(false);
         return ParseNovelApiJson(json);

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -80,6 +80,18 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     [NotifyCanExecuteChangedFor(nameof(NextEpisodeCommand))]
     private bool _hasNextEpisode;
 
+    [ObservableProperty]
+    private bool _autoMarkReadEnabled = true;
+
+    public bool IsManualReadButtonOverlayVisible
+        => !AutoMarkReadEnabled && !IsFooterVisible;
+
+    partial void OnAutoMarkReadEnabledChanged(bool value)
+        => OnPropertyChanged(nameof(IsManualReadButtonOverlayVisible));
+
+    partial void OnIsFooterVisibleChanged(bool value)
+        => OnPropertyChanged(nameof(IsManualReadButtonOverlayVisible));
+
     private Episode? _episode;
 
     public Action? ScrollToTop { get; set; }
@@ -127,6 +139,9 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         BackgroundThemeIndex = await _settingsRepo.GetIntValueAsync(SettingsKeys.BACKGROUND_THEME, SettingsKeys.DEFAULT_BACKGROUND_THEME);
         LineSpacingIndex = await _settingsRepo.GetIntValueAsync(SettingsKeys.LINE_SPACING, SettingsKeys.DEFAULT_LINE_SPACING);
         var vertical = await _settingsRepo.GetIntValueAsync(SettingsKeys.VERTICAL_WRITING, SettingsKeys.DEFAULT_VERTICAL_WRITING);
+        AutoMarkReadEnabled = await _settingsRepo.GetIntValueAsync(
+            SettingsKeys.AUTO_MARK_READ_ENABLED,
+            SettingsKeys.DEFAULT_AUTO_MARK_READ_ENABLED) == 1;
 
         IsVerticalWriting = vertical == 1;
         IsHorizontal = !IsVerticalWriting;
@@ -267,11 +282,21 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     }
 
     [RelayCommand]
-    private async Task MarkAsReadAsync()
-    {
-        if (_episode is null || _episode.IsRead) return;
+    private Task MarkAsReadAsync() => ApplyMarkAsReadAsync();
 
-        await _episodeRepo.MarkAsReadAsync(_episode.Id);
+    [RelayCommand]
+    private Task MarkAsReadFromAutoAsync()
+    {
+        // 自動経路 (OnScrolled / WebView read-end)。設定 OFF なら no-op。
+        if (!AutoMarkReadEnabled) return Task.CompletedTask;
+        return ApplyMarkAsReadAsync();
+    }
+
+    private async Task ApplyMarkAsReadAsync()
+    {
+        if (_episode is null) return;
+        // N-2 仕様: 既読でも N+1 以降の未読化を走らせるため IsRead チェックは外す。
+        await _episodeRepo.SetReadStateUpToAsync(_novelDbId, _episode.EpisodeNo);
         _episode.IsRead = true;
 
         var allRead = await _episodeRepo.AreAllReadAsync(_novelDbId);

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -179,11 +179,10 @@ public partial class SearchViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanSearch))]
     private Task SearchAsync()
     {
-        var searchTarget = "Both";
         return ExecuteSiteQueryAsync(
             "Search",
-            SearchNarou ? ct => _narou.SearchAsync(SearchKeyword, searchTarget, ct) : null,
-            SearchKakuyomu ? ct => _kakuyomu.SearchAsync(SearchKeyword, searchTarget, ct) : null);
+            SearchNarou    ? ct => _narou.SearchAsync(SearchKeyword, ct)    : null,
+            SearchKakuyomu ? ct => _kakuyomu.SearchAsync(SearchKeyword, ct) : null);
     }
 
     private bool CanSearch() => !string.IsNullOrWhiteSpace(SearchKeyword) && !IsLoading;

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -220,13 +220,16 @@ public partial class SearchViewModel : ObservableObject
     [RelayCommand]
     private Task FetchGenreAsync()
     {
-        int? narouBg = (SearchNarou
-            && SelectedNarouBigGenre is not null
+        // narouBg=null は「すべて」選択時 (Id="" で int.TryParse 失敗) を表す。
+        // 旧コードは narouBg=null だと fetch 自体を呼ばず 0 件になっていた。
+        int? narouBg = (SelectedNarouBigGenre is not null
             && int.TryParse(SelectedNarouBigGenre.Id, out var bg)) ? bg : null;
 
         return ExecuteSiteQueryAsync(
             "Genre fetch",
-            narouBg is int bgv ? ct => _narou.FetchByGenreAsync(bgv, "weeklypoint", 30, ct) : null,
+            SearchNarou
+                ? ct => _narou.FetchByGenreAsync(narouBg, "weeklypoint", 30, ct)
+                : null,
             (SearchKakuyomu && SelectedKakuyomuGenre is not null)
                 ? ct => _kakuyomu.FetchRankingAsync(SelectedKakuyomuGenre.Id, "weekly", ct)
                 : null);

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -220,15 +220,17 @@ public partial class SearchViewModel : ObservableObject
     [RelayCommand]
     private Task FetchGenreAsync()
     {
-        // narouBg=null は「すべて」選択時 (Id="" で int.TryParse 失敗) を表す。
-        // 旧コードは narouBg=null だと fetch 自体を呼ばず 0 件になっていた。
-        int? narouBg = (SelectedNarouBigGenre is not null
-            && int.TryParse(SelectedNarouBigGenre.Id, out var bg)) ? bg : null;
-
         return ExecuteSiteQueryAsync(
             "Genre fetch",
             SearchNarou
-                ? ct => _narou.FetchByGenreAsync(narouBg, "weeklypoint", 30, ct)
+                ? ct =>
+                {
+                    // narouBg=null は「すべて」選択時 (Id="" で int.TryParse 失敗) を表す。
+                    // 旧コードは narouBg=null だと fetch 自体を呼ばず 0 件になっていた。
+                    int? narouBg = (SelectedNarouBigGenre is not null
+                        && int.TryParse(SelectedNarouBigGenre.Id, out var bg)) ? bg : null;
+                    return _narou.FetchByGenreAsync(narouBg, "weeklypoint", 30, ct);
+                }
                 : null,
             (SearchKakuyomu && SelectedKakuyomuGenre is not null)
                 ? ct => _kakuyomu.FetchRankingAsync(SelectedKakuyomuGenre.Id, "weekly", ct)

--- a/_Apps/ViewModels/SettingsViewModel.cs
+++ b/_Apps/ViewModels/SettingsViewModel.cs
@@ -45,6 +45,9 @@ public partial class SettingsViewModel : ObservableObject
     private bool _prefetchEnabled = true;
 
     [ObservableProperty]
+    private bool _autoMarkReadEnabled = true;
+
+    [ObservableProperty]
     private int _requestDelayMs = SettingsKeys.DEFAULT_REQUEST_DELAY_MS;
 
     public async Task InitializeAsync()
@@ -60,6 +63,7 @@ public partial class SettingsViewModel : ObservableObject
             EpisodesPerPage = await _settingsRepo.GetIntValueAsync(SettingsKeys.EPISODES_PER_PAGE, SettingsKeys.DEFAULT_EPISODES_PER_PAGE);
             VerticalWriting = await _settingsRepo.GetIntValueAsync(SettingsKeys.VERTICAL_WRITING, SettingsKeys.DEFAULT_VERTICAL_WRITING) == 1;
             PrefetchEnabled = await _settingsRepo.GetIntValueAsync(SettingsKeys.PREFETCH_ENABLED, SettingsKeys.DEFAULT_PREFETCH_ENABLED) == 1;
+            AutoMarkReadEnabled = await _settingsRepo.GetIntValueAsync(SettingsKeys.AUTO_MARK_READ_ENABLED, SettingsKeys.DEFAULT_AUTO_MARK_READ_ENABLED) == 1;
             RequestDelayMs = await _settingsRepo.GetIntValueAsync(SettingsKeys.REQUEST_DELAY_MS, SettingsKeys.DEFAULT_REQUEST_DELAY_MS);
         }
         finally
@@ -106,6 +110,7 @@ public partial class SettingsViewModel : ObservableObject
 
     partial void OnVerticalWritingChanged(bool value)  => DebounceSave(SettingsKeys.VERTICAL_WRITING, value ? "1" : "0");
     partial void OnPrefetchEnabledChanged(bool value)  => DebounceSave(SettingsKeys.PREFETCH_ENABLED, value ? "1" : "0");
+    partial void OnAutoMarkReadEnabledChanged(bool value) => DebounceSave(SettingsKeys.AUTO_MARK_READ_ENABLED, value ? "1" : "0");
 
     [RelayCommand]
     private async Task ClearCacheAsync()

--- a/_Apps/Views/ReaderPage.xaml
+++ b/_Apps/Views/ReaderPage.xaml
@@ -81,14 +81,23 @@
 
 		<!-- Footer -->
 		<Grid Grid.Row="2" Padding="8" BackgroundColor="{StaticResource Overlay}"
-              ColumnDefinitions="*,*,*"
+              ColumnDefinitions="*,*,*,*"
               IsVisible="{Binding IsFooterVisible}">
 			<Button Grid.Column="0" Text="目次" Command="{Binding NavigateToTocCommand}"
                     Style="{StaticResource OverlayButton}" />
-			<Button Grid.Column="1" Text="◀ 前へ" Command="{Binding PrevEpisodeCommand}"
+			<Button Grid.Column="1" Text="既読" Command="{Binding MarkAsReadCommand}"
                     Style="{StaticResource OverlayButton}" />
-			<Button Grid.Column="2" Text="次へ ▶" Command="{Binding NextEpisodeCommand}"
+			<Button Grid.Column="2" Text="◀ 前へ" Command="{Binding PrevEpisodeCommand}"
+                    Style="{StaticResource OverlayButton}" />
+			<Button Grid.Column="3" Text="次へ ▶" Command="{Binding NextEpisodeCommand}"
                     Style="{StaticResource OverlayButton}" />
 		</Grid>
+
+		<!-- 自動 OFF + フッタ非表示時の救済 Overlay (現状 ToggleHeaderFooter 未 binding のため将来導入時の保険) -->
+		<Button Grid.Row="2" Text="既読" Command="{Binding MarkAsReadCommand}"
+                Style="{StaticResource OverlayButton}"
+                HorizontalOptions="Start" VerticalOptions="End"
+                Margin="8,0,0,8" Padding="12,6"
+                IsVisible="{Binding IsManualReadButtonOverlayVisible}" />
 	</Grid>
 </ContentPage>

--- a/_Apps/Views/ReaderPage.xaml.cs
+++ b/_Apps/Views/ReaderPage.xaml.cs
@@ -27,7 +27,7 @@ public partial class ReaderPage : ContentPage
 
         if (scrollView.ScrollY + scrollView.Height >= scrollView.ContentSize.Height - 10)
         {
-            if (BindingContext is ReaderViewModel vm)
+            if (BindingContext is ReaderViewModel vm && vm.AutoMarkReadEnabled)
             {
                 await vm.MarkAsReadFromAutoCommand.ExecuteAsync(null);
             }
@@ -43,7 +43,8 @@ public partial class ReaderPage : ContentPage
 
         if (e.Url.Contains("read-end", StringComparison.OrdinalIgnoreCase))
         {
-            await vm.MarkAsReadFromAutoCommand.ExecuteAsync(null);
+            if (vm.AutoMarkReadEnabled)
+                await vm.MarkAsReadFromAutoCommand.ExecuteAsync(null);
         }
         else if (e.Url.Contains("next-episode", StringComparison.OrdinalIgnoreCase))
         {

--- a/_Apps/Views/ReaderPage.xaml.cs
+++ b/_Apps/Views/ReaderPage.xaml.cs
@@ -29,7 +29,7 @@ public partial class ReaderPage : ContentPage
         {
             if (BindingContext is ReaderViewModel vm)
             {
-                await vm.MarkAsReadCommand.ExecuteAsync(null);
+                await vm.MarkAsReadFromAutoCommand.ExecuteAsync(null);
             }
         }
     }
@@ -43,7 +43,7 @@ public partial class ReaderPage : ContentPage
 
         if (e.Url.Contains("read-end", StringComparison.OrdinalIgnoreCase))
         {
-            await vm.MarkAsReadCommand.ExecuteAsync(null);
+            await vm.MarkAsReadFromAutoCommand.ExecuteAsync(null);
         }
         else if (e.Url.Contains("next-episode", StringComparison.OrdinalIgnoreCase))
         {

--- a/_Apps/Views/SettingsPage.xaml
+++ b/_Apps/Views/SettingsPage.xaml
@@ -97,6 +97,14 @@
                     <Switch IsToggled="{Binding VerticalWriting}" />
                     <Label Text="縦書き表示" Style="{StaticResource BodyLabel}" VerticalOptions="Center" />
                 </HorizontalStackLayout>
+
+                <!-- Auto mark-as-read -->
+                <HorizontalStackLayout Spacing="8" Margin="0,8,0,0">
+                    <Switch IsToggled="{Binding AutoMarkReadEnabled}" />
+                    <Label Text="スクロール終端で自動的に既読にする" Style="{StaticResource BodyLabel}" VerticalOptions="Center" />
+                </HorizontalStackLayout>
+                <Label Style="{StaticResource SmallMetaLabel}"
+                       Text="OFF にすると手動の「既読」ボタンのみで既読化されます" />
             </VerticalStackLayout>
 
             <BoxView HeightRequest="1" Color="LightGray" />


### PR DESCRIPTION
## Summary

`plan_2026-04-30_review-c1-l11.md` の **PR-7**。ユーザ報告 4 件 (N-1〜N-4) + 検索 dead parameter 削除 (L-3) + 自動既読化トグル (B-4) を統合。

| コミット | 項目 | 内容 |
|---|---|---|
| 1 | L-3 + N-1 | searchTarget dead parameter 削除 + Narou 検索 URL に title=1&wname=1 追加 |
| 2 | N-2 + B-4 | 読了点までの一括既読化 + 自動既読化トグル + 手動既読ボタン UI |
| 3 | N-3 | なろうジャンルブラウズの biggenre パラメータ修正 + 「すべて」対応 |
| 4 | N-4 | カクヨムランキングを widget-work セレクタで取り直し |
| 5 | レビュー反映 | 既定 OFF 化 + Page 側 no-op 抑止 + SearchNarou ガード整理 + Regex import |

## L-3 + N-1 (コミット 1): なろう検索精度

### L-3: dead parameter removal
- `SearchViewModel` が `searchTarget=\"Both\"` 固定で `INovelService.SearchAsync(string, string, ct)` の第 2 引数として渡していた dead code。Kakuyomu 側は未使用、Narou 側の switch も常に \"word\" 分岐に落ちる。
- インターフェースから `searchTarget` を削除し、`NarouApiService` の wordParam switch も削除。

### N-1: search scope narrowing
- なろう novelapi の `word` パラメータはフラグ未指定時にタイトル+あらすじ+キーワード+作者名を全文検索 → 対象語があらすじ/タグに含まれる無関係作品が大量にヒットしていた。
- URL に `title=1&wname=1` を付与し「タイトル or 作者名」マッチに絞り込む（公式仕様 https://dev.syosetu.com/man/api/ で 2026-04-30 確認済み）。
- L-3 と同一の URL 生成箇所への複合修正のため 1 コミットに統合。

## N-2 + B-4 (コミット 2): 既読化仕様変更 + 自動既読化トグル

### N-2: 読了点までの一括既読化
- 旧 `MarkAsReadAsync` は当該 episode 1 件のみ既読化 → ユーザが N 話まで連続して読んでも 1..N-1 が未読のまま残り未読カウントが減らない問題。
- `EpisodeRepository.SetReadStateUpToAsync(novelId, episodeNo)` を新設。1 トランザクション 2 SQL で:
  - `1..N`: `is_read=1`、`read_at=COALESCE(read_at, ?)` で既存読了日時を保持
  - `N+1..max`: `is_read=0`、`read_at=NULL` に巻き戻し
- 過去話を再読した場合に N+1 以降を未読化するのは「読み直したらそれ以降を最後まで読み直したい」というユーザ承認済み仕様。
- 旧 `MarkAsReadAsync` は廃止（`ReaderViewModel` 以外から呼ばれていないことを grep 確認）。

### B-4: 自動既読化トグル + 手動既読ボタン
- 既存の `MarkAsReadCommand` は `OnScrolled` / WebView `read-end` の自動経路のみ。短編作品では画面遷移直後に終端到達して即発火するケースがあり、N-2 の巻き戻し挙動と組み合わさると過去話を確認しただけで巻き戻しが起きる UX 詰みがある。
- `SettingsKeys.AUTO_MARK_READ_ENABLED` 設定キーを追加（**既定 OFF**、`SeedSettingsAsync` にも 1 行追加）。
- `ReaderViewModel` に **3 メソッド構造**を導入:
  - `MarkAsReadAsync` (手動経路、フッタの「既読」ボタンから常に発火)
  - `MarkAsReadFromAutoAsync` (自動経路、`AutoMarkReadEnabled=false` なら no-op)
  - `ApplyMarkAsReadAsync` (private ヘルパー、N-2 の SQL と全話既読時の `HasUnconfirmedUpdate=false` 処理を集約)
- `ReaderPage.xaml.cs` の `OnScrolled` / `OnWebViewNavigating` を `MarkAsReadFromAutoCommand` に切替（コミット 5 で Page 側 `AutoMarkReadEnabled` ガード追加）。
- `ReaderPage.xaml` のフッタを 4 列化（目次/既読/前へ/次へ）。
- `SettingsPage` に「スクロール終端で自動的に既読にする」トグル UI を追加。
- 「自動 OFF + フッタ非表示」時の救済 Overlay (`IsManualReadButtonOverlayVisible`) を**先回り投入**。事前確認 P-8 で `ToggleHeaderFooter` は **XAML/コードビハインドのいずれからも binding されておらず dead code** であることを確認済みのため、現状到達不能なシナリオへの保険。将来 binding 導入時に既読化経路が失われるのを防ぐ。

### v9 注記の解消（コミット 5 で対応）
当初 v9 注記で挙げた「既定 ON + 巻き戻し挙動 = `read_at` が NULL に戻り復元不可」という攻撃的挙動について、レビュー指摘を受けて `DEFAULT_AUTO_MARK_READ_ENABLED` を **0 (OFF)** に変更。設定変更しないユーザはオプトインしない限り従来挙動（手動既読のみ）を維持し、復元不能なデータ喪失リスクを回避する。

## N-3 (コミット 3): なろうジャンルブラウズ修正

- なろう novelapi は `biggenre=` (大ジャンル ID) と `genre=` (サブジャンル ID) を区別するが、旧コードは UI のビッグジャンル ID を `genre=` で渡していたため実質 0 件。
- `NarouApiService.FetchByGenreAsync` のシグネチャを `int? biggenre` に変更し、URL を `biggenre={value}` で組み立てる（null 時は付与しない = 全ジャンル取得）。
- `SearchViewModel.FetchGenreAsync` の `narouBg is int bgv ? ... : null` を `SearchNarou ? ... : null` に変更。「すべて」選択時 (Id=\"\" → narouBg=null) でも fetch を呼ぶ（コミット 5 で `narouBg` 計算を `SearchNarou` ガードの内側に移動）。

## N-4 (コミット 4): カクヨムランキング/ジャンル取り直し

- 旧 `FetchRankingAsync` は `a[href*='/works/']` でリンク総当たりしていたため、ナビゲーション・おすすめ枠の作品リンクまで拾い、順序崩れ・重複・広告混入が発生。
- 事前調査 (Firecrawl で実 HTML を 2026-04-30 確認) の構造に基づき、以下の selector ベースに書き換え:
  - `div.widget-work` でランキング項目を限定列挙
  - 同カード内に `p.widget-work-rank` が無いものは広告/おすすめ枠なのでスキップ
  - title: `a.widget-workCard-titleLabel` / author: `a.widget-workCard-authorLabel`
  - status: `span.widget-workCard-statusLabel` の \"完結\" を `IsCompleted=true` 判定
  - episodes: `span.widget-workCard-episodeCount` の数値部分を `TotalEpisodes` に取得
- DOM 順 = ランキング順 (W3C QuerySelectorAll 仕様) のため OrderBy 不要。
- ジャンルブラウズ (Issue 4) も `SearchViewModel.FetchGenreAsync` から同メソッドを呼ぶため同時解消。

## レビュー反映 (コミット 5)

PR レビューでの指摘 4 件を反映:

- **既定値の変更**: `DEFAULT_AUTO_MARK_READ_ENABLED = 1` → `0`。N-2 の巻き戻し挙動（`read_at = NULL`）は履歴テーブルやバックアップが無く復元手段が無いため、設定変更しないユーザに対する暗黙的なデータ喪失を防ぐ。
- **Page 側 no-op 抑止**: `ReaderPage.xaml.cs` の `OnScrolled` / `OnWebViewNavigating` で `vm.AutoMarkReadEnabled` を見て、自動 OFF 時は `MarkAsReadFromAutoCommand.ExecuteAsync` の dispatch 自体を抑止。スクロールイベントごとの RelayCommand allocation を回避。
- **`SearchNarou` ガード整理**: `SearchViewModel.FetchGenreAsync` の `narouBg` パース処理を `SearchNarou ? ct => {...} : null` ラムダの内側に移動。`SearchNarou=false` 時に `SelectedNarouBigGenre` を読まない構造に。
- **Regex import**: `KakuyomuApiService.cs` でフルパス参照していた `System.Text.RegularExpressions.Regex.Match(...)` を `using` 追加で `Regex.Match(...)` に短縮。

なお、レビューで挙がった「Overlay ボタンは現状到達不能なので先回り投入は YAGNI」の指摘は、将来 `ToggleHeaderFooter` を binding する別 PR で同時に有効化する方針に倒すか、現 PR で削除するかは要相談 (現状は据え置き)。

## 事前確認結果

- **P-5** (SQLite-net で 4 個以上の placeholder 先例): EpisodeRepository では最大 3 個。よって N-2 は **2 文分割案を本実装** (1 トランザクション 2 SQL) として採用。
- **P-6** (read_at 空文字列経路の有無): 旧 `MarkAsReadAsync` のみで NULL or ISO-8601 文字列のみ書き込み。SQL の比較は `IS NULL` のみで足る。
- **P-7** (`IsFooterVisible` が `[ObservableProperty]`): `ReaderViewModel.cs:51-52` で確認 ✓。`OnIsFooterVisibleChanged` partial が利用可能。
- **P-8** (`ToggleHeaderFooter` の binding 状況): ソース上で `ReaderViewModel.cs:253` の定義のみ、XAML/コードビハインドからの binding 0 件。**現状 dead code** で `IsFooterVisible=false` 経路は到達不能。Overlay は将来導入時の保険として先回り投入。

## ⚠ 要件書同期マージブロック (v7 で追加)

PR-7 は `searchTarget=\"Title\"`/`\"Author\"` の単独検索が消える仕様変更を伴うが、要件書 §3.2 F-001 への反映は **PR-5 (L-4) で対応予定**。本 PR ではコードのみ変更し、要件書側は PR-5 でキャッチアップする方針 (v7 (a) の選択)。マージ後 PR-5 の F-001 修正前は仕様食い違い期間が発生するため、PR-5 を遅らせない運用が望ましい。

## ビルド

`dotnet build _Apps/App.sln --no-restore` で **0 Warning / 0 Error**。各コミット時点でも individual ビルドが通ることを確認済み。

## Test plan

- [ ] N-1: 「異世界転生」等で検索 → タイトル/作者名にマッチする作品のみが結果に出る (あらすじだけ一致は出ない)
- [ ] L-3: 検索動作に regression なし
- [ ] N-2: 第 N 話のリーダーで「既読」ボタン → 目次に戻ると 1..N が既読、N+1 以降が未読表示
- [ ] N-2 (巻き戻し): N=10 既読の状態で N=3 を読む → 4..10 が未読化される
- [ ] B-4 (既定 OFF 確認): 初期インストール直後は自動既読化が OFF。スクロール終端では既読化されず、フッタ「既読」ボタンでのみ既読化される
- [ ] B-4 (自動 ON): 設定 ON にしてスクロール終端 → 自動既読化発火
- [ ] B-4 (自動 OFF): 設定 OFF に戻してスクロール終端 → 自動経路は no-op、フッタの「既読」ボタンで手動既読化のみ可能
- [ ] N-3 (すべて): なろうジャンルブラウズで「すべて」選択 → 全ジャンルの結果が表示される
- [ ] N-3 (恋愛): 「恋愛」選択 → 大ジャンル=恋愛の結果が表示される (旧版では 0 件 / 不定)
- [ ] N-4 (ランキング): カクヨムランキングが順位通りに 30 件表示、広告枠の混入なし、TotalEpisodes と IsCompleted も正しく取得
- [ ] N-4 (ジャンル): カクヨムジャンルブラウズが N-4 修正で同時に正しく動作

## 参考

- 計画書: `_Apps/Features/plan_2026-04-30_review-c1-l11.md` (v10)
- 前 PR: #123 (PR-4 / L-1, L-5〜L-10)
- 後続 PR: PR-3 (M-1〜M-5) → PR-6 (L-9) → PR-5 (要件書)
