### PR TITLE
fix(m-1〜m-3, m-5): UX improvements — quarterly notice / prefetch toggle / offline content clear / init order

### DIFF
--- a/_Apps/Features/plan_2026-04-30_review-c1-l11.md
+++ b/_Apps/Features/plan_2026-04-30_review-c1-l11.md
@@ -914,6 +914,7 @@ await _jobQueue.EnqueueAsync(new PrefetchEpisodeJob { /* ... */ }).ConfigureAwai
 - Enqueue 1 件ごとに `GetIntValueAsync` を await するが、`_cache` はメモリ ConcurrentDictionary。**初回の 1 件目のみ** `LoadAllAsync` 経由で DB 初期化と全設定ロードを行うため数百 ms オーダーの遅延が発生し得る。**2 件目以降**は cache hit でマイクロ秒オーダー。`EnqueueAllUnreadAsync` で 200 話を一括投入する場合、初回 1 回 + cache hit 199 回 ≒ 数百 ms の遅延に収まる想定。
 - **race window の完全抑止が成立する根拠**: `GetIntValueAsync`（[AppSettingsRepository.cs:43-47](../Services/Database/AppSettingsRepository.cs#L43-L47)）は内部で `GetValueAsync` を呼び、その冒頭（[:39](../Services/Database/AppSettingsRepository.cs#L39)）で `if (!_loaded) await LoadAllAsync()` を実行する。`LoadAllAsync`（[:22-35](../Services/Database/AppSettingsRepository.cs#L22-L35)）は `_loadGate` SemaphoreSlim でガードされ、二重チェックロックパターンで複数同時呼び出しを 1 回に集約する。さらに `_dbService.EnsureInitializedAsync`（[:29](../Services/Database/AppSettingsRepository.cs#L29)）を内部で呼ぶため DB 初期化前でも安全。よって Worker 早期起動時でも、最初の `EnqueueAsync` が DB 初期化 + 設定ロードを完了させてから判定を返す。
 - **呼び出し側のパフォーマンス**: PrefetchService.EnqueueNovelAsync が直列に await することになるが、これは元から DB クエリを直列実行する設計（line 34, 37, 38）と同質で、新規ボトルネックは生まない。
+- **PR-6 への follow-up**: [SearchViewModel.cs:324](../ViewModels/SearchViewModel.cs#L324) の `_ = _prefetch.EnqueueNovelAsync(dbNovel.Id);` は M-2 以前から fire-and-forget だが、M-2 で `EnqueueAsync` 内に `GetIntValueAsync` の await が入ったため、理論上の例外発生経路が増えた（実際にはキャッシュヒット後 μs オーダーで例外もほぼ起きない）。PR-6 のエラー UI 統一作業時に `_prefetch.EnqueueNovelAsync` 呼び出しを `try/catch + LogHelper.Warn` で wrap することを検討する。本 PR (PR-3) では対応不要 — fire-and-forget の安全性は M-2 単体で変わっていない。
 
 ---
 

--- a/_Apps/Services/Background/BackgroundJobQueue.cs
+++ b/_Apps/Services/Background/BackgroundJobQueue.cs
@@ -52,15 +52,23 @@ public class BackgroundJobQueue
 
     public int PendingCount => _highPriority.Count + _normalPriority.Count;
 
-    public void Enqueue(PrefetchEpisodeJob job)
+    public async Task EnqueueAsync(PrefetchEpisodeJob job)
     {
+        // 設定 OFF なら drop。GetIntValueAsync は内部で LoadAllAsync 完了を保証するため race なし。
+        var enabled = await _settingsRepo.GetIntValueAsync(
+            SettingsKeys.PREFETCH_ENABLED,
+            SettingsKeys.DEFAULT_PREFETCH_ENABLED).ConfigureAwait(false);
+        if (enabled == 0) return;
+
+        // HashSet.Add と Queue.Enqueue を同一 lock 内で完結させる。
+        // 旧 Enqueue は Add 後 lock を抜けてから Enqueue していたため、StopWorker →
+        // SyncEnqueuedIdsFromQueues が割り込むと「HashSet にも Queue にもない job」が発生する race があった。
         lock (_enqueuedEpisodeIds)
         {
             if (!_enqueuedEpisodeIds.Add(job.EpisodeDbId)) return;
+            if (job.Priority > 0) _highPriority.Enqueue(job);
+            else _normalPriority.Enqueue(job);
         }
-
-        if (job.Priority > 0) _highPriority.Enqueue(job);
-        else _normalPriority.Enqueue(job);
 
         EnsureWorkerStarted();
     }
@@ -111,9 +119,10 @@ public class BackgroundJobQueue
 
     private void SyncEnqueuedIdsFromQueues()
     {
-        // ConcurrentQueue.GetEnumerator はスナップショットを返すため列挙中の変更で例外にはならない。
-        // 旧 Enqueue が HashSet.Add 後に lock を抜けてから Queue.Enqueue する race window が
-        // 残るが、PR-3 (M-2) で Enqueue を async 化して同一 lock 内に統合し恒久解消する。
+        // ConcurrentQueue.GetEnumerator はスナップショットを返す。
+        // EnqueueAsync が HashSet.Add と Queue.Enqueue を同一 lock 内で完結させているため、
+        // 本メソッドが lock を取った時点で Queue 列挙の結果は HashSet と整合している
+        // (HashSet に居るが Queue に未追加という中間状態は存在しない)。
         lock (_enqueuedEpisodeIds)
         {
             var live = new HashSet<int>();

--- a/_Apps/Services/Background/PrefetchService.cs
+++ b/_Apps/Services/Background/PrefetchService.cs
@@ -41,7 +41,7 @@ public class PrefetchService
         foreach (var ep in episodes)
         {
             if (cachedIds.Contains(ep.Id)) continue;
-            _queue.Enqueue(new PrefetchEpisodeJob
+            await _queue.EnqueueAsync(new PrefetchEpisodeJob
             {
                 NovelDbId = novel.Id,
                 EpisodeDbId = ep.Id,
@@ -49,7 +49,7 @@ public class PrefetchService
                 SiteType = novel.SiteType,
                 SiteNovelId = novel.NovelId,
                 Priority = (highPriority || novel.IsFavorite) ? 1 : 0,
-            });
+            }).ConfigureAwait(false);
             enqueued++;
         }
         LogHelper.Info(nameof(PrefetchService), $"Enqueued {enqueued} episodes for novel {novelDbId}");
@@ -72,7 +72,7 @@ public class PrefetchService
             foreach (var ep in episodes.Where(e => !e.IsRead))
             {
                 if (cachedIds.Contains(ep.Id)) continue;
-                _queue.Enqueue(new PrefetchEpisodeJob
+                await _queue.EnqueueAsync(new PrefetchEpisodeJob
                 {
                     NovelDbId = novel.Id,
                     EpisodeDbId = ep.Id,
@@ -80,7 +80,7 @@ public class PrefetchService
                     SiteType = novel.SiteType,
                     SiteNovelId = novel.NovelId,
                     Priority = novel.IsFavorite ? 1 : 0,
-                });
+                }).ConfigureAwait(false);
             }
         }
     }

--- a/_Apps/Services/UpdateCheckService.cs
+++ b/_Apps/Services/UpdateCheckService.cs
@@ -86,7 +86,7 @@ public class UpdateCheckService
                                 var inserted = await _episodeRepo.GetByNovelIdAsync(novel.Id).ConfigureAwait(false);
                                 foreach (var ep in inserted.Where(e => e.EpisodeNo > currentMaxEpisode))
                                 {
-                                    _jobQueue.Enqueue(new PrefetchEpisodeJob
+                                    await _jobQueue.EnqueueAsync(new PrefetchEpisodeJob
                                     {
                                         NovelDbId = novel.Id,
                                         EpisodeDbId = ep.Id,
@@ -94,7 +94,7 @@ public class UpdateCheckService
                                         SiteType = novel.SiteType,
                                         SiteNovelId = novel.NovelId,
                                         Priority = novel.IsFavorite ? 1 : 0,
-                                    });
+                                    }).ConfigureAwait(false);
                                 }
                             }
                         }

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -71,15 +71,18 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
 
     private int _episodesPerPage = 50;
     private Novel? _novel;
+    private Task? _initTask;
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
         if (query.TryGetValue("novelId", out var novelIdObj) && int.TryParse(novelIdObj?.ToString(), out var novelId))
         {
             _novelDbId = novelId;
-            _ = InitializeAsync();
+            _initTask = InitializeAsync();
         }
     }
+
+    public Task EnsureInitializedAsync() => _initTask ?? Task.CompletedTask;
 
     public async Task InitializeAsync()
     {

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -185,7 +185,14 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
                 var connectivity = Connectivity.Current.NetworkAccess;
                 if (connectivity != NetworkAccess.Internet)
                 {
-                    await Shell.Current.DisplayAlert("エラー", "オフラインのため表示できません。キャッシュがありません", "OK");
+                    // 前話の残り表示を防ぐためコンテンツをクリア（横書き Label / 縦書き WebView 両方）。
+                    // ユーザは目次/戻るボタンで自分で抜ける（自動遷移は採用しない）。
+                    EpisodeContent = string.Empty;
+                    EpisodeTitle = string.Empty;
+                    EpisodeHtml = string.Empty;
+
+                    await Shell.Current.DisplayAlert("オフライン",
+                        "オフラインのため表示できません。キャッシュもありません。", "OK");
                     return;
                 }
 

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -135,7 +135,8 @@ public partial class SearchViewModel : ObservableObject
     private async Task ExecuteSiteQueryAsync(
         string operationName,
         Func<CancellationToken, Task<List<SearchResult>>>? narouFetch,
-        Func<CancellationToken, Task<List<SearchResult>>>? kakuyomuFetch)
+        Func<CancellationToken, Task<List<SearchResult>>>? kakuyomuFetch,
+        string? prefixMessage = null)
     {
         IsLoading = true;
         HasError = false;
@@ -156,10 +157,16 @@ public partial class SearchViewModel : ObservableObject
 
             var allHits = siteResults.SelectMany(r => r.hits).ToList();
             var errors = siteResults.Select(r => r.error).Where(e => e is not null).ToList();
-            if (errors.Count > 0)
+
+            // prefixMessage はユーザに告知すべき制限（例: Quarterly カクヨム非対応）の専用ルート。
+            // サイト fetch 失敗の errors の前に連結表示する。
+            var combined = new List<string>();
+            if (!string.IsNullOrEmpty(prefixMessage)) combined.Add(prefixMessage);
+            combined.AddRange(errors!);
+            if (combined.Count > 0)
             {
                 HasError = true;
-                ErrorMessage = string.Join("\n", errors);
+                ErrorMessage = string.Join("\n", combined);
             }
 
             await ShowResultsAsync(allHits);
@@ -191,6 +198,15 @@ public partial class SearchViewModel : ObservableObject
     private Task FetchRankingAsync()
     {
         var period = (RankingPeriod)Math.Clamp(RankingPeriodIndex, 0, 3);
+        var kakuyomuSupported = period != RankingPeriod.Quarterly;
+        // カクヨムは四半期ランキング非対応。silently fallback ではなくバナー通知する。
+        // 文言はなろう側の選択状況で出し分け。
+        string? prefixMessage = (!kakuyomuSupported && SearchKakuyomu)
+            ? (SearchNarou
+                ? "カクヨムは四半期ランキング非対応のため、なろうのみ取得します"
+                : "カクヨムは四半期ランキング非対応です。取得対象がありません")
+            : null;
+
         return ExecuteSiteQueryAsync(
             "Ranking fetch",
             SearchNarou
@@ -202,7 +218,7 @@ public partial class SearchViewModel : ObservableObject
                     return _narou.FetchRankingAsync(period, bg, 30, ct);
                 }
                 : null,
-            SearchKakuyomu
+            (SearchKakuyomu && kakuyomuSupported)
                 ? ct =>
                 {
                     var periodSlug = period switch
@@ -210,11 +226,12 @@ public partial class SearchViewModel : ObservableObject
                         RankingPeriod.Daily => "daily",
                         RankingPeriod.Weekly => "weekly",
                         RankingPeriod.Monthly => "monthly",
-                        _ => "weekly",
+                        _ => "weekly", // 到達しない (kakuyomuSupported で gate 済み)
                     };
                     return _kakuyomu.FetchRankingAsync(SelectedKakuyomuGenre?.Id ?? "all", periodSlug, ct);
                 }
-                : null);
+                : null,
+            prefixMessage);
     }
 
     [RelayCommand]

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -162,7 +162,7 @@ public partial class SearchViewModel : ObservableObject
             // サイト fetch 失敗の errors の前に連結表示する。
             var combined = new List<string>();
             if (!string.IsNullOrEmpty(prefixMessage)) combined.Add(prefixMessage);
-            combined.AddRange(errors!);
+            combined.AddRange(errors.Select(e => e!));
             if (combined.Count > 0)
             {
                 HasError = true;

--- a/_Apps/Views/EpisodeListPage.xaml.cs
+++ b/_Apps/Views/EpisodeListPage.xaml.cs
@@ -1,3 +1,4 @@
+using LanobeReader.Helpers;
 using LanobeReader.ViewModels;
 
 namespace LanobeReader.Views;
@@ -26,7 +27,7 @@ public partial class EpisodeListPage : ContentPage
             {
                 // async void の例外は TaskScheduler.UnobservedTaskException で拾えないため、
                 // ここで握り潰してプロセスクラッシュを防ぐ。
-                LanobeReader.Helpers.LogHelper.Warn(nameof(EpisodeListPage),
+                LogHelper.Warn(nameof(EpisodeListPage),
                     $"OnAppearing failed: {ex.Message}");
             }
         }

--- a/_Apps/Views/EpisodeListPage.xaml.cs
+++ b/_Apps/Views/EpisodeListPage.xaml.cs
@@ -10,12 +10,25 @@ public partial class EpisodeListPage : ContentPage
         BindingContext = viewModel;
     }
 
-    protected override void OnAppearing()
+    protected override async void OnAppearing()
     {
         base.OnAppearing();
         if (BindingContext is EpisodeListViewModel vm)
         {
-            _ = vm.RefreshReadStatusAsync();
+            try
+            {
+                // ApplyQueryAttributes が起動した InitializeAsync の完了を待ってから RefreshReadStatusAsync。
+                // 旧実装は両者が並列実行され、初回表示時に DB クエリの二重実行が発生していた。
+                await vm.EnsureInitializedAsync();
+                await vm.RefreshReadStatusAsync();
+            }
+            catch (Exception ex)
+            {
+                // async void の例外は TaskScheduler.UnobservedTaskException で拾えないため、
+                // ここで握り潰してプロセスクラッシュを防ぐ。
+                LanobeReader.Helpers.LogHelper.Warn(nameof(EpisodeListPage),
+                    $"OnAppearing failed: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`plan_2026-04-30_review-c1-l11.md` の **PR-3**。Medium 分類の UX 改善 4 件 (M-1, M-2, M-3, M-5)。

| コミット | 項目 | 内容 |
|---|---|---|
| 1 | M-1 | Quarterly ランキングでカクヨムを silently fallback せずバナー通知 |
| 2 | M-2 | PrefetchEnabled=false でも Enqueue されていた問題を完全抑止 + dedup lock 統合 (H-4 race window 恒久解消) |
| 3 | M-3 | オフライン早期 return 時に前話のコンテンツが残る問題を修正 |
| 4 | M-5 | EpisodeListPage の InitializeAsync / RefreshReadStatusAsync 競合を直列化 |

**M-4 は本 PR 対象外**: plan v10 で「実機未検証の preventive 修正・現行コードが動作しているなら見送り可」と明記されているため、実害が観測されてから別 PR 対応の方針。

## M-1: Quarterly ランキングの silently fallback 解消

旧 `FetchRankingAsync` は `Quarterly` 選択時にカクヨムを `_ => "weekly"` で silently fallback。UI は「四半期」表示のまま結果は週間ランキングになり、ユーザに通知なし。

- `ExecuteSiteQueryAsync` に `string? prefixMessage = null` 引数を追加。`HasError = false; ErrorMessage = string.Empty;` でリセットされる前に呼び出し側で値をセットしても上書きされる問題を構造的に回避。
- `FetchRankingAsync` で Quarterly + SearchKakuyomu 時はカクヨム呼び出し自体を skip し、理由を `prefixMessage` でエラーバナーに流す。なろう側の選択状況で文言を出し分け（なろう ON なら「なろうのみ取得します」、OFF なら「取得対象がありません」）。
- **影響ファイル**: `_Apps/ViewModels/SearchViewModel.cs`

## M-2: PrefetchEnabled=false での完全抑止 + race window 恒久解消

旧 `BackgroundJobQueue.Enqueue` は設定値を見ず、Worker 入口でのみ `PREFETCH_ENABLED=0` を early return していたため、設定 OFF のユーザでも `RegisterAsync` / `DownloadAllAsync` 等からキューが膨張し HashSet と内部キューがプロセス生存期間ずっとメモリに残っていた。

- 旧 `void Enqueue` を削除し、`async Task EnqueueAsync` に置換:
  - 入口で `_settingsRepo.GetIntValueAsync(PREFETCH_ENABLED)` を await 判定し OFF なら drop
  - **HashSet.Add と Queue.Enqueue を同一 lock 内で完結** → H-4 (PR-2) で残っていた race window が恒久解消
- 呼び出し側 3 経路を全て await 化（PrefetchService 2 箇所 + UpdateCheckService 1 箇所）。
- `SyncEnqueuedIdsFromQueues` のコメントを「race window が残るが M-2 で恒久解消する」→「同一 lock 内で完結している」に更新。
- Worker 入口の `PREFETCH_ENABLED` チェックは設定変更タイミングのレース対策として二重ガードを維持。
- `GetIntValueAsync` は内部で `LoadAllAsync` 完了を保証するため race なし。`_cache` ヒット後はマイクロ秒オーダー。
- **影響ファイル**: `_Apps/Services/Background/BackgroundJobQueue.cs`, `_Apps/Services/Background/PrefetchService.cs`, `_Apps/Services/UpdateCheckService.cs`

## M-3: オフライン早期 return 時の前話残り表示

`LoadEpisodeAsync` のオフライン + 未キャッシュ分岐は `DisplayAlert` 後に return するだけで、`EpisodeContent` / `EpisodeTitle` が前話のまま残り「前話が読まれている」と錯覚する問題を修正。

- return 前に `EpisodeContent` / `EpisodeTitle` / `EpisodeHtml` を明示クリア（横書き Label と縦書き WebView の両方をカバー）。
- 自動遷移 (`GoToAsync`) は採用しない。ユーザは目次/戻るボタンで自分で抜ける。
- DisplayAlert の文言を更新: タイトル `"エラー" → "オフライン"`、本文 `"オフラインのため表示できません。キャッシュがありません" → "オフラインのため表示できません。キャッシュもありません。"`（オフライン状況を明示するタイトルと、句点・助詞を整えた本文）。
- **PR-6 (L-9) との関係**: 本 M-3 は「前話の残り表示を消す」最小修正のみ。`DisplayAlert` のままで OK。PR-6 で `ErrorAwareViewModel` 導入と同時に `SetError` バナーに置換予定（基底クラス変更を分散させないため M-3 単体ではバナー化しない）。
- **影響ファイル**: `_Apps/ViewModels/ReaderViewModel.cs`

## M-5: InitializeAsync と OnAppearing の競合直列化

`EpisodeListPage.OnAppearing` は `ApplyQueryAttributes` が起動した `InitializeAsync` の完了を待たずに `RefreshReadStatusAsync` を fire-and-forget で呼んでいた。両者が並列実行され、初回表示時に DB クエリの二重実行が発生していた。

- `EpisodeListViewModel` に `Task? _initTask` フィールドと `EnsureInitializedAsync()` を追加。`ApplyQueryAttributes` は `_initTask = InitializeAsync()` で参照を保持。
- `EpisodeListPage.OnAppearing` を `async void` に変更して `await EnsureInitializedAsync() → await RefreshReadStatusAsync()` の順で直列実行。
- `async void` の例外は `TaskScheduler.UnobservedTaskException` で拾えないため、`OnAppearing` 内に `try/catch + LogHelper.Warn` を追加してプロセスクラッシュを防ぐ（v6 B-2 で議論済み）。
- **H-3 との二重実行リスク**: 初回表示時に `RebuildFilterCache` が 2 回呼ばれる (Initialize 内 + RefreshReadStatus 内) が、観測上の重複であって機能的問題はない。最適化は本 PR スコープ外。
- **影響ファイル**: `_Apps/ViewModels/EpisodeListViewModel.cs`, `_Apps/Views/EpisodeListPage.xaml.cs`

## ビルド

`dotnet build _Apps/App.sln --no-restore` で **0 Warning / 0 Error**。

## Test plan

- [ ] M-1: 検索画面でランキングモード → 「四半期」+ カクヨム ON で実行 → エラーバナーに「カクヨムは四半期ランキング非対応のため、なろうのみ取得します」が表示される
- [ ] M-1: 「四半期」+ なろう OFF + カクヨム ON で実行 → 「カクヨムは四半期ランキング非対応です。取得対象がありません」が表示される
- [ ] M-2: 設定で「Wi-Fi接続時にバックグラウンド先読みする」を OFF → 作品登録や一括 DL でキューが空のまま (HashSet も増えない)
- [ ] M-2: 設定 ON のままで通常動作するか regression check
- [ ] M-3: オフライン状態で未キャッシュ話のリーダーを開く → DisplayAlert 表示 + その後の画面が空白 (前話のタイトル/本文が残らない)
- [ ] M-5: 目次画面を素早く開閉 → DB クエリの二重実行が発生しないこと (ログで確認)
- [ ] PR-1〜PR-7 で導入済みの修正が崩れていないこと (regression)

## 参考

- 計画書: `_Apps/Features/plan_2026-04-30_review-c1-l11.md` (v10)
- 前 PR: #124 (PR-7 / L-3 + N-1〜N-4 + B-4)
- 後続 PR: PR-6 (L-9 エラー UI 統一) → PR-5 (要件書キャッチアップ + plan ファイル整理)