### PR TITLE
refactor(l-9): unify error UI across all viewmodels with ErrorAwareViewModel + red banner

### DIFF
--- a/_Apps/Resources/Styles/Styles.xaml
+++ b/_Apps/Resources/Styles/Styles.xaml
@@ -81,4 +81,15 @@
         <Setter Property="TextColor" Value="White" />
     </Style>
 
+    <!-- Inline error banner (red background, white text). Shown above the page content
+         when HasError=true. Used for transient error notifications only;
+         confirmation dialogs (delete confirmation etc.) keep using DisplayAlert. -->
+    <Style x:Key="ErrorBanner" TargetType="Label">
+        <Setter Property="BackgroundColor" Value="{StaticResource DestructiveRed}" />
+        <Setter Property="TextColor" Value="White" />
+        <Setter Property="Padding" Value="16,12" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="LineBreakMode" Value="WordWrap" />
+    </Style>
+
 </ResourceDictionary>

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -8,7 +8,7 @@ using LanobeReader.Services.Database;
 
 namespace LanobeReader.ViewModels;
 
-public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
+public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributable
 {
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeRepository _episodeRepo;
@@ -87,6 +87,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
     public async Task InitializeAsync()
     {
         IsLoading = true;
+        ClearError();
         try
         {
             _novel = await _novelRepo.GetByIdAsync(_novelDbId);
@@ -112,6 +113,7 @@ public partial class EpisodeListViewModel : ObservableObject, IQueryAttributable
         catch (Exception ex)
         {
             LogHelper.Error(nameof(EpisodeListViewModel), $"InitializeAsync failed: {ex.Message}");
+            SetError($"目次の読み込みに失敗しました: {ex.Message}");
         }
         finally
         {

--- a/_Apps/ViewModels/ErrorAwareViewModel.cs
+++ b/_Apps/ViewModels/ErrorAwareViewModel.cs
@@ -15,13 +15,13 @@ public abstract partial class ErrorAwareViewModel : ObservableObject
     [ObservableProperty]
     private string _errorMessage = string.Empty;
 
-    protected void SetError(string message)
+    protected virtual void SetError(string message)
     {
         ErrorMessage = message;
         HasError = true;
     }
 
-    protected void ClearError()
+    protected virtual void ClearError()
     {
         ErrorMessage = string.Empty;
         HasError = false;

--- a/_Apps/ViewModels/ErrorAwareViewModel.cs
+++ b/_Apps/ViewModels/ErrorAwareViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LanobeReader.ViewModels;
+
+/// <summary>
+/// 全画面共通のエラー状態を持つ基底 ViewModel。
+/// HasError=true のとき ErrorMessage を赤バナーで表示する規約。
+/// 確認ダイアログ（削除確認等）には使わず、エラー通知のみに用いる。
+/// </summary>
+public abstract partial class ErrorAwareViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _hasError;
+
+    [ObservableProperty]
+    private string _errorMessage = string.Empty;
+
+    protected void SetError(string message)
+    {
+        ErrorMessage = message;
+        HasError = true;
+    }
+
+    protected void ClearError()
+    {
+        ErrorMessage = string.Empty;
+        HasError = false;
+    }
+}

--- a/_Apps/ViewModels/NovelListViewModel.cs
+++ b/_Apps/ViewModels/NovelListViewModel.cs
@@ -7,7 +7,7 @@ using LanobeReader.Services.Database;
 
 namespace LanobeReader.ViewModels;
 
-public partial class NovelListViewModel : ObservableObject
+public partial class NovelListViewModel : ErrorAwareViewModel
 {
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeCacheRepository _cacheRepo;
@@ -35,9 +35,6 @@ public partial class NovelListViewModel : ObservableObject
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
     private bool _isLoading;
-
-    [ObservableProperty]
-    private bool _hasCheckError;
 
     [ObservableProperty]
     private string _sortKey = "updated_desc";
@@ -72,11 +69,15 @@ public partial class NovelListViewModel : ObservableObject
             var rows = await _novelRepo.GetAllWithUnreadCountAsync(SortKey);
             Novels = new ObservableCollection<NovelCardViewModel>(
                 rows.Select(r => NovelCardViewModel.FromModel(r.Novel, r.UnreadCount)));
-            HasCheckError = rows.Any(r => r.Novel.HasCheckError);
+            if (rows.Any(r => r.Novel.HasCheckError))
+                SetError("一部のタイトルで更新チェックに失敗しました");
+            else
+                ClearError();
         }
         catch (Exception ex)
         {
             LogHelper.Error(nameof(NovelListViewModel), $"LoadNovelsAsync failed: {ex.Message}");
+            SetError("一覧の読み込みに失敗しました");
         }
     }
 
@@ -130,7 +131,7 @@ public partial class NovelListViewModel : ObservableObject
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             LogHelper.Warn(nameof(NovelListViewModel), $"Refresh failed: {ex.Message}");
-            HasCheckError = true;
+            SetError("更新チェックに失敗しました");
         }
         finally
         {

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -7,7 +7,7 @@ using LanobeReader.Services.Database;
 
 namespace LanobeReader.ViewModels;
 
-public partial class ReaderViewModel : ObservableObject, IQueryAttributable
+public partial class ReaderViewModel : ErrorAwareViewModel, IQueryAttributable
 {
     private readonly EpisodeRepository _episodeRepo;
     private readonly EpisodeCacheRepository _cacheRepo;
@@ -166,6 +166,7 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
     private async Task LoadEpisodeAsync(int episodeId)
     {
         IsLoading = true;
+        ClearError();
         try
         {
             _episode = await _episodeRepo.GetByIdAsync(episodeId);
@@ -191,8 +192,7 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
                     EpisodeTitle = string.Empty;
                     EpisodeHtml = string.Empty;
 
-                    await Shell.Current.DisplayAlert("オフライン",
-                        "オフラインのため表示できません。キャッシュもありません。", "OK");
+                    SetError("オフラインのため表示できません。キャッシュもありません");
                     return;
                 }
 
@@ -221,15 +221,15 @@ public partial class ReaderViewModel : ObservableObject, IQueryAttributable
         }
         catch (TaskCanceledException)
         {
-            await Shell.Current.DisplayAlert("エラー", "タイムアウトしました", "OK");
+            SetError("タイムアウトしました");
         }
         catch (HttpRequestException ex)
         {
-            await Shell.Current.DisplayAlert("エラー", $"本文の取得に失敗しました（HTTPエラー: {ex.Message}）", "OK");
+            SetError($"本文の取得に失敗しました（HTTPエラー: {ex.Message}）");
         }
         catch (Exception ex)
         {
-            await Shell.Current.DisplayAlert("エラー", $"本文の取得に失敗しました（{ex.Message}）", "OK");
+            SetError($"本文の取得に失敗しました（{ex.Message}）");
         }
         finally
         {

--- a/_Apps/ViewModels/ReaderViewModel.cs
+++ b/_Apps/ViewModels/ReaderViewModel.cs
@@ -167,6 +167,11 @@ public partial class ReaderViewModel : ErrorAwareViewModel, IQueryAttributable
     {
         IsLoading = true;
         ClearError();
+        // 失敗時に前話の本文・タイトルが残るのを防ぐためここで一括クリアする。
+        // 成功時は下で上書きされる。
+        EpisodeContent = string.Empty;
+        EpisodeTitle = string.Empty;
+        EpisodeHtml = string.Empty;
         try
         {
             _episode = await _episodeRepo.GetByIdAsync(episodeId);
@@ -186,12 +191,7 @@ public partial class ReaderViewModel : ErrorAwareViewModel, IQueryAttributable
                 var connectivity = Connectivity.Current.NetworkAccess;
                 if (connectivity != NetworkAccess.Internet)
                 {
-                    // 前話の残り表示を防ぐためコンテンツをクリア（横書き Label / 縦書き WebView 両方）。
                     // ユーザは目次/戻るボタンで自分で抜ける（自動遷移は採用しない）。
-                    EpisodeContent = string.Empty;
-                    EpisodeTitle = string.Empty;
-                    EpisodeHtml = string.Empty;
-
                     SetError("オフラインのため表示できません。キャッシュもありません");
                     return;
                 }

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -245,6 +245,19 @@ public partial class SearchViewModel : ErrorAwareViewModel
                 : null);
     }
 
+    private async Task TryEnqueuePrefetchAsync(int novelId)
+    {
+        try
+        {
+            await _prefetch.EnqueueNovelAsync(novelId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn(nameof(SearchViewModel),
+                $"Prefetch enqueue failed for novelId={novelId}: {ex.Message}");
+        }
+    }
+
     private async Task ShowResultsAsync(List<SearchResult> results)
     {
         var existingIds = await _novelRepo.GetExistingSiteNovelIdsAsync();
@@ -313,18 +326,8 @@ public partial class SearchViewModel : ErrorAwareViewModel
 
             // Auto-enqueue prefetch for newly registered novel (Wi-Fi only)。
             // M-2 で BackgroundJobQueue.EnqueueAsync 内に GetIntValueAsync の await が入ったため
-            // 例外発生面が広がった (キャッシュヒット後はマイクロ秒オーダーで実害は限定的だが) ため、
-            // fire-and-forget は続行しつつ try/catch + LogHelper.Warn でクラッシュ耐性を確保する。
-            var enqueueNovelId = dbNovel.Id;
-            _ = Task.Run(async () =>
-            {
-                try { await _prefetch.EnqueueNovelAsync(enqueueNovelId).ConfigureAwait(false); }
-                catch (Exception prefetchEx)
-                {
-                    LogHelper.Warn(nameof(SearchViewModel),
-                        $"Prefetch enqueue failed for novelId={enqueueNovelId}: {prefetchEx.Message}");
-                }
-            });
+            // 例外発生面が広がった点に対し try/catch + LogHelper.Warn でクラッシュ耐性を確保する。
+            _ = TryEnqueuePrefetchAsync(dbNovel.Id);
 
             result.IsRegistered = true;
             result.TotalEpisodes = episodes.Count;

--- a/_Apps/ViewModels/SearchViewModel.cs
+++ b/_Apps/ViewModels/SearchViewModel.cs
@@ -11,7 +11,7 @@ using LanobeReader.Services.Narou;
 
 namespace LanobeReader.ViewModels;
 
-public partial class SearchViewModel : ObservableObject
+public partial class SearchViewModel : ErrorAwareViewModel
 {
     private readonly INovelServiceFactory _serviceFactory;
     private readonly NovelRepository _novelRepo;
@@ -79,12 +79,6 @@ public partial class SearchViewModel : ObservableObject
     [ObservableProperty]
     private bool _hasSearched;
 
-    [ObservableProperty]
-    private bool _hasError;
-
-    [ObservableProperty]
-    private string _errorMessage = string.Empty;
-
     // Ranking/Genre browse
     public ObservableCollection<GenreInfo> NarouBigGenres { get; }
     public ObservableCollection<GenreInfo> KakuyomuGenreList { get; }
@@ -139,8 +133,7 @@ public partial class SearchViewModel : ObservableObject
         string? prefixMessage = null)
     {
         IsLoading = true;
-        HasError = false;
-        ErrorMessage = string.Empty;
+        ClearError();
         try
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -165,8 +158,7 @@ public partial class SearchViewModel : ObservableObject
             combined.AddRange(errors.Select(e => e!));
             if (combined.Count > 0)
             {
-                HasError = true;
-                ErrorMessage = string.Join("\n", combined);
+                SetError(string.Join("\n", combined));
             }
 
             await ShowResultsAsync(allHits);
@@ -174,8 +166,7 @@ public partial class SearchViewModel : ObservableObject
         catch (Exception ex)
         {
             LogHelper.Error(nameof(SearchViewModel), $"{operationName} failed: {ex.Message}");
-            HasError = true;
-            ErrorMessage = "通信エラーが発生しました";
+            SetError("通信エラーが発生しました");
         }
         finally
         {
@@ -320,8 +311,20 @@ public partial class SearchViewModel : ObservableObject
 
             await _novelRepo.UpdateAsync(dbNovel);
 
-            // Auto-enqueue prefetch for newly registered novel (Wi-Fi only)
-            _ = _prefetch.EnqueueNovelAsync(dbNovel.Id);
+            // Auto-enqueue prefetch for newly registered novel (Wi-Fi only)。
+            // M-2 で BackgroundJobQueue.EnqueueAsync 内に GetIntValueAsync の await が入ったため
+            // 例外発生面が広がった (キャッシュヒット後はマイクロ秒オーダーで実害は限定的だが) ため、
+            // fire-and-forget は続行しつつ try/catch + LogHelper.Warn でクラッシュ耐性を確保する。
+            var enqueueNovelId = dbNovel.Id;
+            _ = Task.Run(async () =>
+            {
+                try { await _prefetch.EnqueueNovelAsync(enqueueNovelId).ConfigureAwait(false); }
+                catch (Exception prefetchEx)
+                {
+                    LogHelper.Warn(nameof(SearchViewModel),
+                        $"Prefetch enqueue failed for novelId={enqueueNovelId}: {prefetchEx.Message}");
+                }
+            });
 
             result.IsRegistered = true;
             result.TotalEpisodes = episodes.Count;
@@ -345,7 +348,7 @@ public partial class SearchViewModel : ObservableObject
                         $"Rollback delete failed for ({result.SiteType}, {result.NovelId}): {rbEx.Message}");
                 }
             }
-            await Shell.Current.DisplayAlert("エラー", $"登録に失敗しました: {ex.Message}", "OK");
+            SetError($"登録に失敗しました: {ex.Message}");
         }
         finally
         {

--- a/_Apps/ViewModels/SettingsViewModel.cs
+++ b/_Apps/ViewModels/SettingsViewModel.cs
@@ -93,7 +93,13 @@ public partial class SettingsViewModel : ErrorAwareViewModel
                 await _settingsRepo.SetValueAsync(key, value).ConfigureAwait(false);
             }
             catch (TaskCanceledException) { /* 新しい変更が来た */ }
-            catch (Exception ex) { LogHelper.Warn(nameof(SettingsViewModel), $"DebounceSave failed: {ex.Message}"); }
+            catch (Exception ex)
+            {
+                LogHelper.Warn(nameof(SettingsViewModel), $"DebounceSave failed: {ex.Message}");
+                // Task.Run 経由のためバインディング更新は UI スレッドへ戻す
+                MainThread.BeginInvokeOnMainThread(() =>
+                    SetError($"設定の保存に失敗しました: {ex.Message}"));
+            }
         });
     }
 
@@ -118,11 +124,19 @@ public partial class SettingsViewModel : ErrorAwareViewModel
         bool confirm = await Shell.Current.DisplayAlert(
             "確認", "すべてのキャッシュを削除しますか？", "OK", "キャンセル");
 
-        if (confirm)
+        if (!confirm) return;
+
+        ClearError();
+        try
         {
             await _cacheRepo.DeleteAllAsync();
             // Snackbar-like notification
             await Shell.Current.DisplayAlert("完了", "クリアしました", "OK");
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Error(nameof(SettingsViewModel), $"ClearCacheAsync failed: {ex.Message}");
+            SetError($"キャッシュの削除に失敗しました: {ex.Message}");
         }
     }
 }

--- a/_Apps/ViewModels/SettingsViewModel.cs
+++ b/_Apps/ViewModels/SettingsViewModel.cs
@@ -5,7 +5,7 @@ using LanobeReader.Services.Database;
 
 namespace LanobeReader.ViewModels;
 
-public partial class SettingsViewModel : ObservableObject
+public partial class SettingsViewModel : ErrorAwareViewModel
 {
     private readonly AppSettingsRepository _settingsRepo;
     private readonly EpisodeCacheRepository _cacheRepo;

--- a/_Apps/Views/EpisodeListPage.xaml
+++ b/_Apps/Views/EpisodeListPage.xaml
@@ -7,9 +7,13 @@
              Title="{Binding NovelTitle}"
              Shell.TabBarIsVisible="False">
 
-	<Grid RowDefinitions="Auto,*,Auto">
-		<!-- Row 0: Filter + Action row -->
-		<HorizontalStackLayout Grid.Row="0" Padding="8,4" Spacing="8">
+	<Grid RowDefinitions="Auto,Auto,*,Auto">
+		<!-- Error banner (Auto row collapses when HasError=false) -->
+		<Label Grid.Row="0" Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
+		       Style="{StaticResource ErrorBanner}" />
+
+		<!-- Filter + Action row -->
+		<HorizontalStackLayout Grid.Row="1" Padding="8,4" Spacing="8">
 			<HorizontalStackLayout Spacing="4">
 				<CheckBox IsChecked="{Binding ShowUnreadOnly}" />
 				<Label Text="未読のみ" VerticalOptions="Center" />
@@ -25,11 +29,11 @@
 		</HorizontalStackLayout>
 
 		<!-- Loading -->
-		<ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
+		<ActivityIndicator Grid.Row="2" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
 		<!-- Episode list -->
-		<CollectionView Grid.Row="1" ItemsSource="{Binding Episodes}" SelectionMode="None"
+		<CollectionView Grid.Row="2" ItemsSource="{Binding Episodes}" SelectionMode="None"
                          IsGrouped="False">
 			<CollectionView.ItemTemplate>
 				<DataTemplate x:DataType="vm:EpisodeViewModel">
@@ -73,7 +77,7 @@
 		</CollectionView>
 
 		<!-- Footer: Continue + Paging -->
-		<Grid Grid.Row="2" RowDefinitions="Auto,Auto" Padding="8,4">
+		<Grid Grid.Row="3" RowDefinitions="Auto,Auto" Padding="8,4">
 			<!-- Continue reading -->
 			<Button Grid.Row="0" Text="続きから読む" Command="{Binding ReadContinueCommand}"
 			        HorizontalOptions="Fill" Margin="0,0,0,4" />

--- a/_Apps/Views/NovelListPage.xaml
+++ b/_Apps/Views/NovelListPage.xaml
@@ -9,16 +9,20 @@
 	<ContentPage.ToolbarItems>
 		<ToolbarItem Text="並び替え" Command="{Binding ChangeSortCommand}" />
 		<ToolbarItem Text="更新" Command="{Binding RefreshCommand}"
-                     IsEnabled="{Binding HasCheckError}" />
+                     IsEnabled="{Binding HasError}" />
 	</ContentPage.ToolbarItems>
 
-	<Grid>
+	<Grid RowDefinitions="Auto,*">
+		<!-- Error banner (Auto row collapses when HasError=false) -->
+		<Label Grid.Row="0" Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
+		       Style="{StaticResource ErrorBanner}" />
+
 		<!-- Loading indicator -->
-		<ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
+		<ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
 		<!-- Novel list -->
-		<CollectionView ItemsSource="{Binding Novels}" SelectionMode="None">
+		<CollectionView Grid.Row="1" ItemsSource="{Binding Novels}" SelectionMode="None">
 			<CollectionView.ItemTemplate>
 				<DataTemplate x:DataType="vm:NovelCardViewModel">
 					<SwipeView Margin="8,4">

--- a/_Apps/Views/NovelListPage.xaml
+++ b/_Apps/Views/NovelListPage.xaml
@@ -8,6 +8,9 @@
 
 	<ContentPage.ToolbarItems>
 		<ToolbarItem Text="並び替え" Command="{Binding ChangeSortCommand}" />
+		<!-- 旧 HasCheckError 連動から HasError 連動に変更。
+		     個別タイトルの check error に加え LoadNovelsAsync 自体の失敗時も retry 可能となる
+		     (= 活性スコープが広がる方向の意図的な仕様変更)。 -->
 		<ToolbarItem Text="更新" Command="{Binding RefreshCommand}"
                      IsEnabled="{Binding HasError}" />
 	</ContentPage.ToolbarItems>

--- a/_Apps/Views/ReaderPage.xaml
+++ b/_Apps/Views/ReaderPage.xaml
@@ -21,10 +21,14 @@
         </DataTrigger>
     </ContentPage.Triggers>
 
-	<Grid RowDefinitions="Auto,*,Auto">
+	<Grid RowDefinitions="Auto,Auto,*,Auto">
+
+		<!-- Error banner (Auto row collapses when HasError=false) -->
+		<Label Grid.Row="0" Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
+		       Style="{StaticResource ErrorBanner}" />
 
 		<!-- Header -->
-		<Grid Grid.Row="0" Padding="8" BackgroundColor="{StaticResource Overlay}"
+		<Grid Grid.Row="1" Padding="8" BackgroundColor="{StaticResource Overlay}"
               ColumnDefinitions="*,Auto"
               IsVisible="{Binding IsHeaderVisible}">
 			<Label Grid.Column="0" Text="{Binding EpisodeTitle}" TextColor="White"
@@ -36,11 +40,11 @@
 		</Grid>
 
 		<!-- Loading -->
-		<ActivityIndicator Grid.Row="1" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
+		<ActivityIndicator Grid.Row="2" IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
 		<!-- Content (horizontal - Label) -->
-		<ScrollView Grid.Row="1" x:Name="ContentScrollView" Scrolled="OnScrolled"
+		<ScrollView Grid.Row="2" x:Name="ContentScrollView" Scrolled="OnScrolled"
                     IsVisible="{Binding IsHorizontal}">
 			<Label Text="{Binding EpisodeContent}" Padding="16"
                    FontSize="{Binding FontSize}" FontFamily="serif">
@@ -73,14 +77,14 @@
 		</ScrollView>
 
 		<!-- Content (vertical writing - WebView) -->
-		<controls:ReaderWebView Grid.Row="1"
+		<controls:ReaderWebView Grid.Row="2"
                                 IsVisible="{Binding IsVerticalWriting}"
                                 HtmlSource="{Binding EpisodeHtml}"
                                 CssVariables="{Binding ReaderCss}"
                                 Navigating="OnWebViewNavigating" />
 
 		<!-- Footer -->
-		<Grid Grid.Row="2" Padding="8" BackgroundColor="{StaticResource Overlay}"
+		<Grid Grid.Row="3" Padding="8" BackgroundColor="{StaticResource Overlay}"
               ColumnDefinitions="*,*,*,*"
               IsVisible="{Binding IsFooterVisible}">
 			<Button Grid.Column="0" Text="目次" Command="{Binding NavigateToTocCommand}"
@@ -94,7 +98,7 @@
 		</Grid>
 
 		<!-- 自動 OFF + フッタ非表示時の救済 Overlay (現状 ToggleHeaderFooter 未 binding のため将来導入時の保険) -->
-		<Button Grid.Row="2" Text="既読" Command="{Binding MarkAsReadCommand}"
+		<Button Grid.Row="3" Text="既読" Command="{Binding MarkAsReadCommand}"
                 Style="{StaticResource OverlayButton}"
                 HorizontalOptions="Start" VerticalOptions="End"
                 Margin="8,0,0,8" Padding="12,6"

--- a/_Apps/Views/SearchPage.xaml
+++ b/_Apps/Views/SearchPage.xaml
@@ -7,16 +7,20 @@
              x:DataType="vm:SearchViewModel"
              Title="検索">
 
-	<Grid RowDefinitions="Auto,Auto,Auto,*">
+	<Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+		<!-- Error banner (Auto row collapses when HasError=false) -->
+		<Label Grid.Row="0" Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
+		       Style="{StaticResource ErrorBanner}" />
+
 		<!-- Mode tabs -->
-		<HorizontalStackLayout Grid.Row="0" Padding="8,4" Spacing="6">
+		<HorizontalStackLayout Grid.Row="1" Padding="8,4" Spacing="6">
 			<Button Text="検索" Command="{Binding SetModeKeywordCommand}" FontSize="12" HeightRequest="36" />
 			<Button Text="ランキング" Command="{Binding SetModeRankingCommand}" FontSize="12" HeightRequest="36" />
 			<Button Text="ジャンル" Command="{Binding SetModeGenreCommand}" FontSize="12" HeightRequest="36" />
 		</HorizontalStackLayout>
 
 		<!-- Mode-specific inputs -->
-		<Grid Grid.Row="1" Padding="8,0">
+		<Grid Grid.Row="2" Padding="8,0">
 			<!-- Keyword mode -->
 			<Grid IsVisible="{Binding IsKeywordMode}" ColumnDefinitions="*,Auto">
 				<Entry Grid.Column="0" Placeholder="タイトル・作者名で検索"
@@ -67,7 +71,7 @@
 		</Grid>
 
 		<!-- Site filters -->
-		<HorizontalStackLayout Grid.Row="2" Padding="8,0" Spacing="16">
+		<HorizontalStackLayout Grid.Row="3" Padding="8,0" Spacing="16">
 			<HorizontalStackLayout Spacing="4">
 				<CheckBox IsChecked="{Binding SearchNarou}" />
 				<Label Text="なろう" VerticalOptions="Center" />
@@ -78,12 +82,9 @@
 			</HorizontalStackLayout>
 		</HorizontalStackLayout>
 
-		<Grid Grid.Row="3">
+		<Grid Grid.Row="4">
 			<ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                                HorizontalOptions="Center" VerticalOptions="Center" />
-
-			<Label Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
-                   TextColor="Red" Padding="16" FontSize="14" />
 
 			<CollectionView ItemsSource="{Binding SearchResults}" SelectionMode="None">
 				<CollectionView.ItemTemplate>

--- a/_Apps/Views/SettingsPage.xaml
+++ b/_Apps/Views/SettingsPage.xaml
@@ -6,8 +6,12 @@
              x:DataType="vm:SettingsViewModel"
              Title="設定">
 
-    <ScrollView>
-        <VerticalStackLayout Padding="16" Spacing="24">
+    <Grid RowDefinitions="Auto,*">
+        <Label Grid.Row="0" Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
+               Style="{StaticResource ErrorBanner}" />
+
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout Padding="16" Spacing="24">
 
             <!-- Cache settings -->
             <VerticalStackLayout Spacing="8">
@@ -144,6 +148,7 @@
                         Style="{StaticResource ThemedSlider}" />
             </VerticalStackLayout>
 
-        </VerticalStackLayout>
-    </ScrollView>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
 </ContentPage>


### PR DESCRIPTION
## Summary

`plan_2026-04-30_review-c1-l11.md` の **PR-6**。各 ViewModel に分散していたエラー UI 4 通りのパターンを共通基底クラス + 赤バナーで完全統一する大規模リファクタ (12 ファイル / ~150 行)。

| 種類 | Before | After |
|---|---|---|
| `NovelListViewModel` | `HasCheckError` フラグだけ (テキストなし) | `ErrorAwareViewModel` + 赤バナー |
| `SearchViewModel` | `HasError` + `ErrorMessage` 赤バナー (Row 3 内に独自配置) | `ErrorAwareViewModel` + ルート行赤バナー |
| `EpisodeListViewModel` | ログのみ UI 無 | `ErrorAwareViewModel` + 赤バナー |
| `ReaderViewModel` | `DisplayAlert` (モーダル) | `ErrorAwareViewModel` + 赤バナー (DisplayAlert 廃止) |
| `SettingsViewModel` | `DisplayAlert` (確認ダイアログのみ) | `ErrorAwareViewModel` (確認ダイアログは据え置き) |

## 変更内容

### 共通基底クラス (新規 1 ファイル)
- `_Apps/ViewModels/ErrorAwareViewModel.cs`: `[ObservableProperty]` 経由で `HasError` / `ErrorMessage` を保持し、`protected SetError(message)` / `ClearError()` を提供。`CommunityToolkit.Mvvm` 8.x の継承対応 source generator を活用。

### 共通 Style (1 ファイル)
- `_Apps/Resources/Styles/Styles.xaml` に `ErrorBanner` Style を追加 (`DestructiveRed` 背景 / 白文字 / `Padding=16,12` / `LineBreakMode=WordWrap`)。

### 5 ViewModel の継承先 + エラー処理を統一
- `NovelListViewModel`: 旧 `_hasCheckError` を削除。`LoadNovelsAsync` で「一部のタイトルで更新チェックに失敗しました」「一覧の読み込みに失敗しました」、`RefreshAsync` の catch で「更新チェックに失敗しました」を `SetError` で出す。
- `SearchViewModel`: 旧 `_hasError` / `_errorMessage` を削除し全て `SetError` / `ClearError` 経由に。`RegisterAsync` の `DisplayAlert("登録に失敗しました…")` も `SetError` に置換。
- `EpisodeListViewModel`: `InitializeAsync` の catch で `SetError($"目次の読み込みに失敗しました: {ex.Message}")`。
- `ReaderViewModel`: `LoadEpisodeAsync` 内の DisplayAlert (タイムアウト / HTTP エラー / 一般例外 / オフライン) を全て `SetError` に置換。**M-3 (PR-3) で投入済みのコンテンツクリア 3 行 (`EpisodeContent` / `EpisodeTitle` / `EpisodeHtml`) はそのまま維持し、DisplayAlert 1 行のみを置換** (二重実装防止、plan v7 注記参照)。
- `SettingsViewModel`: 継承先のみ変更。`ClearCacheAsync` の確認 DisplayAlert は据え置き。

### follow-up: RegisterAsync の prefetch fire-and-forget をガード
レビューフィードバック (`9b0b2ea`) で指摘された M-2 由来のリスクに対応:
- `_ = _prefetch.EnqueueNovelAsync(dbNovel.Id);` を `Task.Run` + try/catch + `LogHelper.Warn` でラップ。BackgroundJobQueue.EnqueueAsync 内に GetIntValueAsync の await が増えた件で発生面が広がった例外をクラッシュさせず握り潰す。

### 5 XAML にエラーバナー Label + Grid.Row リナンバリング
plan §4-1 〜 §4-5 の手順通り:
- **NovelListPage.xaml**: 単行 Grid → `RowDefinitions=\"Auto,*\"`、子要素 (`ActivityIndicator` / `CollectionView`) に `Grid.Row=\"1\"` 付与。`ToolbarItem` の `IsEnabled` を `HasCheckError` → `HasError` 連動に変更。
- **SearchPage.xaml**: `Auto,Auto,Auto,*` → `Auto,Auto,Auto,Auto,*`、子要素 4 個 `Grid.Row` +1。**既存負債**だった Row 3 内の `TextColor=\"Red\"` Label は削除。
- **EpisodeListPage.xaml**: `Auto,*,Auto` → `Auto,Auto,*,Auto`、子要素 3 個 `Grid.Row` +1。
- **ReaderPage.xaml**: `Auto,*,Auto` → `Auto,Auto,*,Auto`、**子要素 6 個** `Grid.Row` +1 (ヘッダ Grid / ActivityIndicator / ScrollView / ReaderWebView / フッタ Grid / 救済 Overlay Button)。Overlay Button のリナンバリング漏れは本文行と重なる重大バグになるため特に注意 (plan v10 注記)。
- **SettingsPage.xaml**: 全体を `<Grid RowDefinitions=\"Auto,*\">` でラップ。

## ⚠ 後方互換 / DB スキーマ
- `Novel.HasCheckError` カラムは DB に残るが、ViewModel 側は `SetError` の判定材料として使うのみ → スキーマ変更なし、後方互換破壊なし。

## 事前確認 / マージ順序

- **rebase**: 推奨順 `PR-1 → PR-2 → PR-4 → PR-7 → PR-3 → PR-6` に従い、PR-2 (H-3) / PR-3 (M-3 / M-5) / PR-7 (B-4 / N-2) の ViewModel 改修が全て base に取り込まれている前提。本ブランチは最新 `app-novelviewer` から作成済み。
- **DisplayAlert 廃止の UX 影響**: ReaderViewModel のモーダル待機がなくなる。インライン赤バナーで継続視認 + 戻る/目次ボタンが操作可能になり UX 改善方向。要件書 §6.3 への追記は PR-5 で対応。

## ビルド

`dotnet build _Apps/App.sln --no-restore` で **0 Warning / 0 Error**。

## Test plan

- [ ] **NovelListPage**: 更新チェック失敗時に赤バナー「一部のタイトルで更新チェックに失敗しました」+ ToolbarItem「更新」が活性
- [ ] **SearchPage**: 通信エラー時に赤バナーに「なろうの通信エラー…」が表示。Quarterly + カクヨム選択で M-1 の prefix もバナー表示
- [ ] **SearchPage**: 登録失敗時 (TLS エラー等) に赤バナーに「登録に失敗しました: …」が表示 (DisplayAlert は出ない)
- [ ] **EpisodeListPage**: 初回読込失敗時に赤バナー「目次の読み込みに失敗しました: …」
- [ ] **ReaderPage**: 本文取得失敗時に赤バナー (タイムアウト / HTTP エラー / 一般例外)、目次/戻るで手動退出可能
- [ ] **ReaderPage**: オフライン + 未キャッシュ時に赤バナー「オフラインのため表示できません。キャッシュもありません」+ 前話のコンテンツがクリアされている
- [ ] **SettingsPage**: 通常動作に regression なし、`ClearCacheAsync` の確認ダイアログは従来どおりモーダル表示
- [ ] **HasError=false 時**: 全 5 ページで Auto 行が `IsVisible=false` で潰れて空白行が残らない
- [ ] **ReaderPage**: 「自動 OFF + フッタ非表示」状態で Overlay Button が左下に正しく表示され、本文行 (新 Grid.Row=2) と重ならない (PR-7 で追加した救済 Overlay の `Grid.Row=3` リナンバリング検証)
- [ ] **SearchPage**: 旧 `TextColor=\"Red\"` Label が削除されレイアウト崩れがない

## 参考

- 計画書: `_Apps/Features/plan_2026-04-30_review-c1-l11.md` (v10) §L-9
- 前 PR: #125 (PR-3 / M-1〜M-5)
- 後続 PR: PR-5 (要件書キャッチアップ + plan ファイル整理) — DisplayAlert 廃止に伴う §6.3 例外・エラーハンドリングの追記を含む