### PR TITLE
fix(reader): remove unrecognized -webkit-writing-mode prefix

### DIFF
--- a/_Apps/Resources/Html/ReaderTemplate.html
+++ b/_Apps/Resources/Html/ReaderTemplate.html
@@ -20,7 +20,7 @@ html,body{margin:0;padding:0;height:100%;overflow-y:hidden;}
 body{
   background:var(--reader-bg);color:var(--reader-fg);
   font-family:serif;
-  writing-mode:vertical-rl;-webkit-writing-mode:vertical-rl;
+  writing-mode:vertical-rl;
   font-size:var(--reader-fs);line-height:var(--reader-lh);
   padding:16px;box-sizing:border-box;
   overflow-x:auto;overflow-y:hidden;touch-action:pan-x;overscroll-behavior-y:none;


### PR DESCRIPTION
## 概要

`_Apps/Resources/Html/ReaderTemplate.html` から `-webkit-writing-mode:vertical-rl;` を削除し、CSS リンター警告 (`-webkit-writing-mode は認識できる CSS プロパティ名ではありません`) を解消する。

## 調査と判断

- `-webkit-writing-mode` は **iOS Safari (<= 13) 向けのレガシーベンダープレフィックス**。
- このテンプレートが描画される環境（Chromium ベースの WebView2 / 最新 WebKit / Android WebView）は、すべて unprefixed の `writing-mode` を完全サポート済み。
- プレフィックスを残しても害はないが、エディタ/リンターで「未知のプロパティ」警告の原因となるため削除。
- 標準の `writing-mode:vertical-rl;` は維持しているため、縦書き表示の動作には一切影響しない。

## 変更内容

- [_Apps/Resources/Html/ReaderTemplate.html:23](_Apps/Resources/Html/ReaderTemplate.html#L23): `-webkit-writing-mode:vertical-rl;` を削除

## テスト計画

- [ ] `ReaderPage` を起動し、縦書き表示が従来どおりレンダリングされることを確認
- [ ] 横スクロール / `read-end` / `next-episode` / `prev-episode` のナビゲーションが動作することを確認