### PR TITLE
feat(episode-list): scroll to last-read episode on initial display

### DIFF
--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -108,6 +108,31 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
             IsNovelFavorite = _novel.IsFavorite;
 
             RecalcPaging();
+
+            // anchor: 直前まで読んだ話 (= firstUnread の 1 つ前) を優先、無ければ最新既読話 (= 全話既読時の最終話)。
+            // 個別話 IsRead を flip する経路が無い前提で firstUnread の 1 つ前 == MAX(EpisodeNo WHERE IsRead) と一致する。
+            Episode? anchor = null;
+            var firstUnread = _allEpisodes.FirstOrDefault(e => !e.IsRead);
+            if (firstUnread is not null)
+            {
+                var idx = _allEpisodes.IndexOf(firstUnread);
+                if (idx > 0) anchor = _allEpisodes[idx - 1];
+            }
+            else
+            {
+                anchor = _allEpisodes.LastOrDefault(e => e.IsRead);
+            }
+
+            if (anchor is not null)
+            {
+                var idxInFiltered = _filteredCache.FindIndex(e => e.Id == anchor.Id);
+                if (idxInFiltered >= 0)
+                {
+                    CurrentPage = (idxInFiltered / _episodesPerPage) + 1;
+                    PendingInitialScrollIndex = idxInFiltered % _episodesPerPage;
+                }
+            }
+
             await LoadPageAsync();
         }
         catch (Exception ex)
@@ -119,6 +144,24 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
         {
             IsLoading = false;
         }
+    }
+
+    /// <summary>
+    /// 初期スクロール対象 (anchor) のページ内インデックス。
+    /// anchor は「直前まで読んだ話 = firstUnread の 1 つ前」、無ければ「最新既読話」。
+    /// InitializeAsync が anchor を見つけた場合に設定され、View 側の OnAppearing で
+    /// TakePendingInitialScrollIndex() により 1 回だけ消費される。null = スクロール不要。
+    /// </summary>
+    public int? PendingInitialScrollIndex { get; private set; }
+
+    /// <summary>
+    /// PendingInitialScrollIndex を読み取って null クリアする。1 回限り消費を保証。
+    /// </summary>
+    public int? TakePendingInitialScrollIndex()
+    {
+        var v = PendingInitialScrollIndex;
+        PendingInitialScrollIndex = null;
+        return v;
     }
 
     private void RebuildFilterCache()

--- a/_Apps/Views/EpisodeListPage.xaml
+++ b/_Apps/Views/EpisodeListPage.xaml
@@ -33,8 +33,10 @@
                            HorizontalOptions="Center" VerticalOptions="Center" />
 
 		<!-- Episode list -->
-		<CollectionView Grid.Row="2" ItemsSource="{Binding Episodes}" SelectionMode="None"
-                         IsGrouped="False">
+		<CollectionView Grid.Row="2" x:Name="EpisodesView"
+		                ItemsSource="{Binding Episodes}" SelectionMode="None"
+		                IsGrouped="False"
+		                SizeChanged="OnEpisodesViewSizeChanged">
 			<CollectionView.ItemTemplate>
 				<DataTemplate x:DataType="vm:EpisodeViewModel">
 					<Grid Padding="16,10" ColumnDefinitions="Auto,*,Auto,Auto">

--- a/_Apps/Views/EpisodeListPage.xaml.cs
+++ b/_Apps/Views/EpisodeListPage.xaml.cs
@@ -5,6 +5,8 @@ namespace LanobeReader.Views;
 
 public partial class EpisodeListPage : ContentPage
 {
+    private int? _pendingScrollIndex;
+
     public EpisodeListPage(EpisodeListViewModel viewModel)
     {
         InitializeComponent();
@@ -22,6 +24,35 @@ public partial class EpisodeListPage : ContentPage
                 // 旧実装は両者が並列実行され、初回表示時に DB クエリの二重実行が発生していた。
                 await vm.EnsureInitializedAsync();
                 await vm.RefreshReadStatusAsync();
+
+                // 初回 OnAppearing で 1 回だけスクロール。Take... が null クリアするので
+                // Reader から戻った再表示時には再スクロールしない。
+                var idx = vm.TakePendingInitialScrollIndex();
+                if (idx is int i)
+                {
+                    // SizeChanged フォールバック用にもインデックスを保持。
+                    // TryScrollToPending() の成功時に null クリアすることで二重実行を防ぐ。
+                    _pendingScrollIndex = i;
+
+                    // OnAppearing 時点でページは visible だが、ItemsSource 差し替え直後で
+                    // CollectionView の measure/layout 未完だと ScrollTo が空振りする。
+                    // DispatchDelayed で 150ms 待ち、Android の最初の layout サイクル完了を確実にする。
+                    // それでも空振りする場合は OnEpisodesViewSizeChanged が初回 size 確定時に再 ScrollTo する。
+                    Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(150), () =>
+                    {
+                        // このデリゲートは外側 try/catch の保護対象外。OnAppearing → 即 OnDisappearing の
+                        // 遷移直後に走った場合 ObjectDisposed で例外する可能性があるため明示的に握り潰す。
+                        try
+                        {
+                            TryScrollToPending();
+                        }
+                        catch (Exception ex)
+                        {
+                            LogHelper.Warn(nameof(EpisodeListPage),
+                                $"Delayed ScrollTo failed: {ex.Message}");
+                        }
+                    });
+                }
             }
             catch (Exception ex)
             {
@@ -30,6 +61,39 @@ public partial class EpisodeListPage : ContentPage
                 LogHelper.Warn(nameof(EpisodeListPage),
                     $"OnAppearing failed: {ex.Message}");
             }
+        }
+    }
+
+    /// <summary>
+    /// _pendingScrollIndex が指す行へ ScrollTo を試みる。Center / animate=false で画面中央に置く。
+    /// 成功時に _pendingScrollIndex を null クリアして 1 回限り消費を保証する。
+    /// DispatchDelayed と SizeChanged の両経路から呼ばれるため、必ずここで null 化する。
+    /// </summary>
+    private void TryScrollToPending()
+    {
+        if (_pendingScrollIndex is not int i) return;
+        if (BindingContext is not EpisodeListViewModel vm) return;
+        if (i < 0 || i >= vm.Episodes.Count) return;
+
+        EpisodesView.ScrollTo(i, position: ScrollToPosition.Center, animate: false);
+        _pendingScrollIndex = null;
+    }
+
+    /// <summary>
+    /// CollectionView の measure/layout 確定時に発火。DispatchDelayed(150ms) が
+    /// 遅い実機で空振りしたケースを救うフォールバック経路。
+    /// _pendingScrollIndex が null (= 既に消費済 or 不要) なら何もしない。
+    /// </summary>
+    private void OnEpisodesViewSizeChanged(object? sender, EventArgs e)
+    {
+        try
+        {
+            TryScrollToPending();
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn(nameof(EpisodeListPage),
+                $"SizeChanged ScrollTo failed: {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
プラン §1 (UX-1) の実装。目次ページを開いたとき、自動で「直前まで読んだ話」を画面中央に表示する。

## 実装概要

### anchor 選定 (§1.2)
1. `firstUnread = _allEpisodes.FirstOrDefault(e => !e.IsRead)` を取得
2. firstUnread が存在 → anchor = `_allEpisodes[indexOf(firstUnread) - 1]` (= 直前まで読んだ話)
3. firstUnread が無い (全話既読) → anchor = `_allEpisodes.LastOrDefault(e => e.IsRead)` (= 最終話)
4. 既読も未読も無ければ anchor 無し (= 1 ページ目先頭表示)

### 変更ファイル
- `EpisodeListViewModel.cs`: anchor 算出後 `PendingInitialScrollIndex` を公開、`TakePendingInitialScrollIndex()` で 1 回限り消費を保証 (pull 型設計)
- `EpisodeListPage.xaml`: CollectionView に `x:Name="EpisodesView"` + `SizeChanged` 配線
- `EpisodeListPage.xaml.cs`: `OnAppearing` で `DispatchDelayed(150ms)` ScrollTo (Center / animate=false)、`SizeChanged` をフォールバック経路として追加

### ScrollTo 空振り対策 (二重防御)
- pull 型: `await EnsureInitializedAsync()` 完了後 = ページ visible 化 + layout 完了タイミングで ScrollTo
- 150ms `DispatchDelayed`: Pixel 系実機の初回 layout (~80-120ms) を待つ
- `SizeChanged` フォールバック: 上記が空振りした実機を救済
- `_pendingScrollIndex` の null クリアで二重実行を防止

### 例外安全性
- `OnAppearing` 全体を try/catch で包囲 (async void のクラッシュ防止)
- `DispatchDelayed` クロージャ内に**個別の try/catch** (外側 try/catch の保護対象外、OnAppearing→OnDisappearing 高速遷移時の ObjectDisposed を握り潰す)
- `SizeChanged` ハンドラにも try/catch

## 動作確認 (プラン §1.4)

実機確認は未実施 (Android エミュレータ/実機での確認をお願いします)。

- [ ] 既読 0 件 (= 先頭話が未読) → anchor 無し、ページ 1 / スクロールなし
- [ ] 既読 1 話、未読 99 話 → anchor = 1 話目、ページ 1 で 1 話目を画面中央付近にスクロール
- [ ] 既読 86 話、未読あり (50/page、firstUnread = 87 話) → anchor = 86 話、ページ 2 で 86 話を画面中央
- [ ] 全 100 話既読 (firstUnread = null) → anchor = 100 話、最終ページ末尾付近にスクロール
- [ ] 0 話登録のみ → anchor 無し、ページ 1
- [ ] フィルタ ON 切替 → ページ 1 リセット (現行どおり)
- [ ] Reader 画面から戻る → 再 OnAppearing で再スクロールしないこと
- [ ] OnAppearing 直後に高速戻る (~150ms 以内) → クラッシュしないこと
- [ ] 画面回転で SizeChanged が再発火 → 再スクロールしないこと

## 仕様の前提

`firstUnread` の 1 つ前を「直前まで読んだ話」とみなすのは、`SetReadStateUpToAsync` が「読了点までを既読化、それ以降を未読化」する仕様で既読/未読の境界が常に連続している前提に依存。将来 `EpisodeRepository.UpdateAsync` 経由で個別話 IsRead を flip する経路ができた場合は `LastOrDefault(e => e.IsRead)` 単独に切り替える必要がある。