### PR TITLE
feat(novel-list): show read progress (read/total) on bookshelf cards

### DIFF
--- a/_Apps/Services/Database/DatabaseService.cs
+++ b/_Apps/Services/Database/DatabaseService.cs
@@ -6,7 +6,7 @@ namespace LanobeReader.Services.Database;
 
 public class DatabaseService
 {
-    private const int CURRENT_SCHEMA_VERSION = 2;
+    private const int CURRENT_SCHEMA_VERSION = 3;
 
     private readonly SQLiteAsyncConnection _connection;
     private Task? _initTask;
@@ -168,8 +168,10 @@ public class DatabaseService
         {
             await MigrateToV2Async().ConfigureAwait(false);
         }
-        // 今後のバージョンは↓に追加
-        // if (fromVersion < 3) await MigrateToV3Async().ConfigureAwait(false);
+        if (fromVersion < 3)
+        {
+            await MigrateToV3Async().ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -226,6 +228,29 @@ public class DatabaseService
         {
             LogHelper.Warn(nameof(DatabaseService), $"[MigrateToV2] Failed: {ex.Message}");
             throw; // 上位 (InitializeInternalAsync) で SetSchemaVersion を skip させるため再送出
+        }
+    }
+
+    /// <summary>
+    /// v2 → v3: episodes(novel_id, is_read) に複合インデックスを追加。
+    /// NovelRepository.GetAllWithUnreadCountAsync の集計サブクエリ
+    /// (episode_count / read_count / unread_count を 1 パスで GROUP BY) の
+    /// covering index として機能する。
+    /// </summary>
+    private async Task MigrateToV3Async()
+    {
+        try
+        {
+            await _connection.ExecuteAsync(
+                "CREATE INDEX IF NOT EXISTS idx_episodes_novel_isread " +
+                "ON episodes (novel_id, is_read)"
+            ).ConfigureAwait(false);
+            LogHelper.Info(nameof(DatabaseService), "[MigrateToV3] Done.");
+        }
+        catch (Exception ex)
+        {
+            LogHelper.Warn(nameof(DatabaseService), $"[MigrateToV3] Failed: {ex.Message}");
+            throw;
         }
     }
 }

--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -3,7 +3,11 @@ using SQLite;
 
 namespace LanobeReader.Services.Database;
 
-public sealed record NovelWithUnread(Novel Novel, int UnreadCount);
+public sealed record NovelWithUnread(
+    Novel Novel,
+    int UnreadCount,
+    int ReadCount,
+    int EpisodeCount);
 
 public class NovelRepository
 {
@@ -11,6 +15,12 @@ public class NovelRepository
     {
         [SQLite.Column("unread_count")]
         public int UnreadCount { get; set; }
+
+        [SQLite.Column("read_count")]
+        public int ReadCount { get; set; }
+
+        [SQLite.Column("episode_count")]
+        public int EpisodeCount { get; set; }
     }
 
     private readonly SQLiteAsyncConnection _db;
@@ -62,6 +72,9 @@ public class NovelRepository
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
 
+        // episodes 1 パス GROUP BY で episode_count / read_count / unread_count を一括集計。
+        // (novel_id, is_read) 複合インデックス (idx_episodes_novel_isread, schema v3) が covering index となる。
+        // 全 3 値を episodes から派生させることで「既読+未読=総話数」の不変条件を保証する。
         const string baseSql =
             "SELECT " +
             "  n.id, " +
@@ -77,14 +90,19 @@ public class NovelRepository
             "  n.has_check_error, " +
             "  n.is_favorite, " +
             "  n.favorited_at, " +
-            "  COALESCE(u.cnt, 0) AS unread_count " +
+            "  COALESCE(e.unread_count, 0) AS unread_count, " +
+            "  COALESCE(e.read_count, 0) AS read_count, " +
+            "  COALESCE(e.episode_count, 0) AS episode_count " +
             "FROM novels n " +
             "LEFT JOIN (" +
-            "    SELECT novel_id, COUNT(*) AS cnt " +
+            "    SELECT " +
+            "      novel_id, " +
+            "      COUNT(*) AS episode_count, " +
+            "      SUM(CASE WHEN is_read = 1 THEN 1 ELSE 0 END) AS read_count, " +
+            "      SUM(CASE WHEN is_read = 0 THEN 1 ELSE 0 END) AS unread_count " +
             "    FROM episodes " +
-            "    WHERE is_read = 0 " +
             "    GROUP BY novel_id" +
-            ") u ON u.novel_id = n.id ";
+            ") e ON e.novel_id = n.id ";
 
         string orderBy = sortKey switch
         {
@@ -120,7 +138,7 @@ public class NovelRepository
                 IsFavorite = r.IsFavorite,
                 FavoritedAt = r.FavoritedAt,
             };
-            result.Add(new NovelWithUnread(novel, r.UnreadCount));
+            result.Add(new NovelWithUnread(novel, r.UnreadCount, r.ReadCount, r.EpisodeCount));
         }
         return result;
     }

--- a/_Apps/ViewModels/NovelCardViewModel.cs
+++ b/_Apps/ViewModels/NovelCardViewModel.cs
@@ -21,6 +21,18 @@ public partial class NovelCardViewModel : ObservableObject
     private int _unreadCount;
 
     [ObservableProperty]
+    private int _readCount;
+
+    [ObservableProperty]
+    private int _episodeCount;
+
+    // ReadCount ≤ EpisodeCount は SQL の構造上保証される (両方とも同じ episodes 集計から派生)。
+    public string ReadProgressLabel => $"{ReadCount}/{EpisodeCount}";
+
+    partial void OnReadCountChanged(int value) => OnPropertyChanged(nameof(ReadProgressLabel));
+    partial void OnEpisodeCountChanged(int value) => OnPropertyChanged(nameof(ReadProgressLabel));
+
+    [ObservableProperty]
     private string _lastUpdatedAt = string.Empty;
 
     [ObservableProperty]
@@ -38,7 +50,7 @@ public partial class NovelCardViewModel : ObservableObject
     [ObservableProperty]
     private bool _isFavorite;
 
-    public static NovelCardViewModel FromModel(Novel novel, int unreadCount)
+    public static NovelCardViewModel FromModel(Novel novel, int unreadCount, int readCount, int episodeCount)
     {
         return new NovelCardViewModel
         {
@@ -49,6 +61,8 @@ public partial class NovelCardViewModel : ObservableObject
             SiteType = (SiteType)novel.SiteType,
             NovelId = novel.NovelId,
             UnreadCount = unreadCount,
+            ReadCount = readCount,
+            EpisodeCount = episodeCount,
             LastUpdatedAt = DateTime.TryParse(novel.LastUpdatedAt, null,
                 System.Globalization.DateTimeStyles.RoundtripKind, out var dt)
                 ? dt.ToLocalTime().ToString("yyyy/MM/dd HH:mm:ss")

--- a/_Apps/ViewModels/NovelListViewModel.cs
+++ b/_Apps/ViewModels/NovelListViewModel.cs
@@ -68,7 +68,7 @@ public partial class NovelListViewModel : ErrorAwareViewModel
         {
             var rows = await _novelRepo.GetAllWithUnreadCountAsync(SortKey);
             Novels = new ObservableCollection<NovelCardViewModel>(
-                rows.Select(r => NovelCardViewModel.FromModel(r.Novel, r.UnreadCount)));
+                rows.Select(r => NovelCardViewModel.FromModel(r.Novel, r.UnreadCount, r.ReadCount, r.EpisodeCount)));
             if (rows.Any(r => r.Novel.HasCheckError))
                 SetError("一部のタイトルで更新チェックに失敗しました");
             else

--- a/_Apps/Views/NovelListPage.xaml
+++ b/_Apps/Views/NovelListPage.xaml
@@ -77,19 +77,25 @@
                                            IsVisible="{Binding IsCompleted, Converter={StaticResource InverseBool}}" />
 								</HorizontalStackLayout>
 
-								<!-- Unread + Updated -->
-								<HorizontalStackLayout Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Spacing="12">
-									<Border Padding="6,2" BackgroundColor="{StaticResource UnreadBadge}"
-                                           IsVisible="{Binding UnreadCount, Converter={StaticResource IntToBool}}">
+								<!-- Row 2: 更新日時 (左端) | 未読 (中右) | 既読数/総話数 (右端) -->
+								<Grid Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
+								      ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+									<Label Grid.Column="0" Text="{Binding LastUpdatedAt}"
+									       Style="{StaticResource SmallMetaLabel}" VerticalOptions="Center"
+									       LineBreakMode="TailTruncation" />
+									<Border Grid.Column="1" Padding="6,2" BackgroundColor="{StaticResource UnreadBadge}"
+									        VerticalOptions="Center"
+									        IsVisible="{Binding UnreadCount, Converter={StaticResource IntToBool}}">
 										<Border.StrokeShape>
 											<RoundRectangle CornerRadius="10" />
 										</Border.StrokeShape>
 										<Label Text="{Binding UnreadCount, StringFormat='{0}話未読'}"
-                                               Style="{StaticResource BadgeLabel}" />
+										       Style="{StaticResource BadgeLabel}" />
 									</Border>
-									<Label Text="{Binding LastUpdatedAt}" Style="{StaticResource SmallMetaLabel}"
-                                           VerticalOptions="Center" />
-								</HorizontalStackLayout>
+									<Label Grid.Column="2" Text="{Binding ReadProgressLabel}"
+									       Style="{StaticResource SmallMetaLabel}" VerticalOptions="Center"
+									       IsVisible="{Binding EpisodeCount, Converter={StaticResource IntToBool}}" />
+								</Grid>
 							</Grid>
 						</Border>
 					</SwipeView>


### PR DESCRIPTION
プラン §2 (UX-2) の実装。本棚カード行を「更新日時 | 未読 | 既読数/総話数」の 3 情報配置に再構成する。

## 実装概要

### 表示の整合性方針 (§2.2)

`EpisodeCount` / `ReadCount` / `UnreadCount` の 3 値はすべて同じ `episodes` テーブルから 1 パス GROUP BY で派生させる。これにより「既読数 + 未読数 = 総話数」の不変条件が常に成立する。

旧仕様では `Novel.TotalEpisodes` と `COUNT(WHERE is_read=0)` を別ソースから引いていたため、`UpdateCheckService` (サイト fetch 値) と `SearchViewModel.RegisterAsync` (登録時 episodes.Count) で意味が混在し、incremental fetch 失敗時に「100/300 既読、未読 0 話」のような表示崩れが起きうる構造だった。

### 変更ファイル

- **`DatabaseService.cs`**: `CURRENT_SCHEMA_VERSION` 2→3、`MigrateToV3Async` 追加 (`idx_episodes_novel_isread` 複合インデックス)
- **`NovelRepository.cs`**: `NovelWithUnread` record に `ReadCount` / `EpisodeCount` を追加、SQL を `SUM(CASE WHEN is_read=1)` で 1 パス GROUP BY 化
- **`NovelCardViewModel.cs`**: `ReadCount` / `EpisodeCount` / `ReadProgressLabel` プロパティ追加、`FromModel` シグネチャ拡張
- **`NovelListViewModel.cs`**: `FromModel` 呼び出し更新
- **`NovelListPage.xaml`**: Row 2 を 3 列 Grid (`*,Auto,Auto`) に再構成、`LineBreakMode=\"TailTruncation\"` 付与

## 既存ユーザへの影響 (重要)

**v2→v3 マイグレーションで一度きりのレイテンシ**: 既存ユーザの初回起動で `CREATE INDEX` が走る。10 万行規模 (1k タイトル × 100 話) で実機 (Pixel クラス) **約 1-2 秒の追加レイテンシ** が `DatabaseService.EnsureInitializedAsync` に発生する。バックグラウンド化や進捗 UI は今回実装しない方針 (一度きりの体感劣化、複雑性に見合わない)。新規インストール環境では即時完了。

## 動作確認 (プラン §2.4)

実機確認は未実施。

- [ ] 既読 0 / 全 100 話 → \`0/100\` + 「100話未読」
- [ ] 既読 25 / 全 100 話 → \`25/100\` + 「75話未読」
- [ ] 全 100 話既読 → \`100/100\`、未読バッジ非表示
- [ ] 0 話登録のみ (EpisodeCount=0) → 右端ラベル非表示
- [ ] \`Novel.TotalEpisodes=300\` だが episodes 行が 100 件のみ → \`X/100\` で整合
- [ ] episode_no に gap (例: [1,2,3,5,6,7] 全既読) → \`6/6\`
- [ ] 各種ソート (`unread_desc` 等) で正しく描画
- [ ] 狭画面 (360dp) で更新日時が TailTruncation
- [ ] 既存 v2 ユーザの初回起動で IsLoading が ~1-2s 余分に表示