### PR TITLE
feat(search): equal-width mode tabs and per-mode site filter placement

### DIFF
--- a/_Apps/Converters/BoolToOpacityConverter.cs
+++ b/_Apps/Converters/BoolToOpacityConverter.cs
@@ -1,0 +1,15 @@
+using System.Globalization;
+
+namespace LanobeReader.Converters;
+
+public sealed class BoolToOpacityConverter : IValueConverter
+{
+    public double TrueOpacity { get; set; } = 1.0;
+    public double FalseOpacity { get; set; } = 0.4;
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => (value is bool b && b) ? TrueOpacity : FalseOpacity;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/_Apps/Converters/BoolToOpacityConverter.cs
+++ b/_Apps/Converters/BoolToOpacityConverter.cs
@@ -2,13 +2,28 @@ using System.Globalization;
 
 namespace LanobeReader.Converters;
 
-public sealed class BoolToOpacityConverter : IValueConverter
+public class BoolToOpacityConverter : BindableObject, IValueConverter
 {
-    public double TrueOpacity { get; set; } = 1.0;
-    public double FalseOpacity { get; set; } = 0.4;
+    public static readonly BindableProperty TrueOpacityProperty =
+        BindableProperty.Create(nameof(TrueOpacity), typeof(double), typeof(BoolToOpacityConverter), 1.0);
+
+    public static readonly BindableProperty FalseOpacityProperty =
+        BindableProperty.Create(nameof(FalseOpacity), typeof(double), typeof(BoolToOpacityConverter), 0.4);
+
+    public double TrueOpacity
+    {
+        get => (double)GetValue(TrueOpacityProperty);
+        set => SetValue(TrueOpacityProperty, value);
+    }
+
+    public double FalseOpacity
+    {
+        get => (double)GetValue(FalseOpacityProperty);
+        set => SetValue(FalseOpacityProperty, value);
+    }
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => (value is bool b && b) ? TrueOpacity : FalseOpacity;
+        => value is true ? TrueOpacity : FalseOpacity;
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/_Apps/Resources/Styles/Converters.xaml
+++ b/_Apps/Resources/Styles/Converters.xaml
@@ -12,5 +12,6 @@
     <converters:BoolToColorConverter x:Key="BoolToGoldConverter"
         TrueColor="{StaticResource FavoriteGold}" FalseColor="{StaticResource Gray200}" />
     <converters:IntToBoolConverter x:Key="IntToBool" />
+    <converters:BoolToOpacityConverter x:Key="BoolToOpacity" />
 
 </ResourceDictionary>

--- a/_Apps/Views/SearchPage.xaml
+++ b/_Apps/Views/SearchPage.xaml
@@ -7,26 +7,41 @@
              x:DataType="vm:SearchViewModel"
              Title="検索">
 
-	<Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+	<Grid RowDefinitions="Auto,Auto,Auto,*">
 		<!-- Error banner (Auto row collapses when HasError=false) -->
 		<Label Grid.Row="0" Text="{Binding ErrorMessage}" IsVisible="{Binding HasError}"
 		       Style="{StaticResource ErrorBanner}" />
 
-		<!-- Mode tabs -->
-		<HorizontalStackLayout Grid.Row="1" Padding="8,4" Spacing="6">
-			<Button Text="検索" Command="{Binding SetModeKeywordCommand}" FontSize="12" HeightRequest="36" />
-			<Button Text="ランキング" Command="{Binding SetModeRankingCommand}" FontSize="12" HeightRequest="36" />
-			<Button Text="ジャンル" Command="{Binding SetModeGenreCommand}" FontSize="12" HeightRequest="36" />
-		</HorizontalStackLayout>
+		<!-- Mode tabs (3 等分) -->
+		<Grid Grid.Row="1" Padding="8,4" ColumnDefinitions="*,*,*" ColumnSpacing="6">
+			<Button Grid.Column="0" Text="検索"
+			        Command="{Binding SetModeKeywordCommand}" FontSize="12" HeightRequest="36" />
+			<Button Grid.Column="1" Text="ランキング"
+			        Command="{Binding SetModeRankingCommand}" FontSize="12" HeightRequest="36" />
+			<Button Grid.Column="2" Text="ジャンル"
+			        Command="{Binding SetModeGenreCommand}" FontSize="12" HeightRequest="36" />
+		</Grid>
 
 		<!-- Mode-specific inputs -->
 		<Grid Grid.Row="2" Padding="8,0">
 			<!-- Keyword mode -->
-			<Grid IsVisible="{Binding IsKeywordMode}" ColumnDefinitions="*,Auto">
-				<Entry Grid.Column="0" Placeholder="タイトル・作者名で検索"
-                       Text="{Binding SearchKeyword}" ReturnCommand="{Binding SearchCommand}" />
-				<Button Grid.Column="1" Text="検索" Command="{Binding SearchCommand}" Margin="4,0,0,0" />
-			</Grid>
+			<VerticalStackLayout IsVisible="{Binding IsKeywordMode}" Spacing="6">
+				<HorizontalStackLayout Spacing="16">
+					<HorizontalStackLayout Spacing="4">
+						<Switch IsToggled="{Binding SearchNarou}" VerticalOptions="Center" />
+						<Label Text="なろう" VerticalOptions="Center" />
+					</HorizontalStackLayout>
+					<HorizontalStackLayout Spacing="4">
+						<Switch IsToggled="{Binding SearchKakuyomu}" VerticalOptions="Center" />
+						<Label Text="カクヨム" VerticalOptions="Center" />
+					</HorizontalStackLayout>
+				</HorizontalStackLayout>
+				<Grid ColumnDefinitions="*,Auto">
+					<Entry Grid.Column="0" Placeholder="タイトル・作者名で検索"
+					       Text="{Binding SearchKeyword}" ReturnCommand="{Binding SearchCommand}" />
+					<Button Grid.Column="1" Text="検索" Command="{Binding SearchCommand}" Margin="4,0,0,0" />
+				</Grid>
+			</VerticalStackLayout>
 
 			<!-- Ranking mode -->
 			<VerticalStackLayout IsVisible="{Binding IsRankingMode}" Spacing="6">
@@ -41,48 +56,56 @@
 						</Picker.Items>
 					</Picker>
 				</HorizontalStackLayout>
-				<HorizontalStackLayout Spacing="8">
-					<Label Text="なろう大ジャンル:" VerticalOptions="Center" />
-					<Picker ItemsSource="{Binding NarouBigGenres, x:DataType=vm:SearchViewModel}" ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
-                            SelectedItem="{Binding SelectedNarouBigGenre}" />
-				</HorizontalStackLayout>
-				<HorizontalStackLayout Spacing="8">
-					<Label Text="カクヨムジャンル:" VerticalOptions="Center" />
-					<Picker ItemsSource="{Binding KakuyomuGenreList}" ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
-                            SelectedItem="{Binding SelectedKakuyomuGenre}" />
-				</HorizontalStackLayout>
+				<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+					<Label Grid.Column="0" Text="なろう大ジャンル:" VerticalOptions="Center"
+					       Opacity="{Binding SearchNarou, Converter={StaticResource BoolToOpacity}}" />
+					<Picker Grid.Column="1"
+					        ItemsSource="{Binding NarouBigGenres, x:DataType=vm:SearchViewModel}"
+					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
+					        SelectedItem="{Binding SelectedNarouBigGenre}"
+					        IsEnabled="{Binding SearchNarou}" />
+					<Switch Grid.Column="2" IsToggled="{Binding SearchNarou}" VerticalOptions="Center" />
+				</Grid>
+				<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+					<Label Grid.Column="0" Text="カクヨムジャンル:" VerticalOptions="Center"
+					       Opacity="{Binding SearchKakuyomu, Converter={StaticResource BoolToOpacity}}" />
+					<Picker Grid.Column="1"
+					        ItemsSource="{Binding KakuyomuGenreList}"
+					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
+					        SelectedItem="{Binding SelectedKakuyomuGenre}"
+					        IsEnabled="{Binding SearchKakuyomu}" />
+					<Switch Grid.Column="2" IsToggled="{Binding SearchKakuyomu}" VerticalOptions="Center" />
+				</Grid>
 				<Button Text="ランキング取得" Command="{Binding FetchRankingCommand}" />
 			</VerticalStackLayout>
 
 			<!-- Genre mode -->
 			<VerticalStackLayout IsVisible="{Binding IsGenreMode}" Spacing="6">
-				<HorizontalStackLayout Spacing="8">
-					<Label Text="なろう大ジャンル:" VerticalOptions="Center" />
-					<Picker ItemsSource="{Binding NarouBigGenres}" ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
-                            SelectedItem="{Binding SelectedNarouBigGenre}" />
-				</HorizontalStackLayout>
-				<HorizontalStackLayout Spacing="8">
-					<Label Text="カクヨムジャンル:" VerticalOptions="Center" />
-					<Picker ItemsSource="{Binding KakuyomuGenreList}" ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
-                            SelectedItem="{Binding SelectedKakuyomuGenre}" />
-				</HorizontalStackLayout>
+				<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+					<Label Grid.Column="0" Text="なろう大ジャンル:" VerticalOptions="Center"
+					       Opacity="{Binding SearchNarou, Converter={StaticResource BoolToOpacity}}" />
+					<Picker Grid.Column="1"
+					        ItemsSource="{Binding NarouBigGenres}"
+					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
+					        SelectedItem="{Binding SelectedNarouBigGenre}"
+					        IsEnabled="{Binding SearchNarou}" />
+					<Switch Grid.Column="2" IsToggled="{Binding SearchNarou}" VerticalOptions="Center" />
+				</Grid>
+				<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+					<Label Grid.Column="0" Text="カクヨムジャンル:" VerticalOptions="Center"
+					       Opacity="{Binding SearchKakuyomu, Converter={StaticResource BoolToOpacity}}" />
+					<Picker Grid.Column="1"
+					        ItemsSource="{Binding KakuyomuGenreList}"
+					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
+					        SelectedItem="{Binding SelectedKakuyomuGenre}"
+					        IsEnabled="{Binding SearchKakuyomu}" />
+					<Switch Grid.Column="2" IsToggled="{Binding SearchKakuyomu}" VerticalOptions="Center" />
+				</Grid>
 				<Button Text="ジャンル別取得" Command="{Binding FetchGenreCommand}" />
 			</VerticalStackLayout>
 		</Grid>
 
-		<!-- Site filters -->
-		<HorizontalStackLayout Grid.Row="3" Padding="8,0" Spacing="16">
-			<HorizontalStackLayout Spacing="4">
-				<CheckBox IsChecked="{Binding SearchNarou}" />
-				<Label Text="なろう" VerticalOptions="Center" />
-			</HorizontalStackLayout>
-			<HorizontalStackLayout Spacing="4">
-				<CheckBox IsChecked="{Binding SearchKakuyomu}" />
-				<Label Text="カクヨム" VerticalOptions="Center" />
-			</HorizontalStackLayout>
-		</HorizontalStackLayout>
-
-		<Grid Grid.Row="4">
+		<Grid Grid.Row="3">
 			<ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}"
                                HorizontalOptions="Center" VerticalOptions="Center" />
 

--- a/_Apps/Views/SearchPage.xaml
+++ b/_Apps/Views/SearchPage.xaml
@@ -29,11 +29,13 @@
 				<HorizontalStackLayout Spacing="16">
 					<HorizontalStackLayout Spacing="4">
 						<Switch IsToggled="{Binding SearchNarou}" VerticalOptions="Center" />
-						<Label Text="なろう" VerticalOptions="Center" />
+						<Label Text="なろう" VerticalOptions="Center"
+						       Opacity="{Binding SearchNarou, Converter={StaticResource BoolToOpacity}}" />
 					</HorizontalStackLayout>
 					<HorizontalStackLayout Spacing="4">
 						<Switch IsToggled="{Binding SearchKakuyomu}" VerticalOptions="Center" />
-						<Label Text="カクヨム" VerticalOptions="Center" />
+						<Label Text="カクヨム" VerticalOptions="Center"
+						       Opacity="{Binding SearchKakuyomu, Converter={StaticResource BoolToOpacity}}" />
 					</HorizontalStackLayout>
 				</HorizontalStackLayout>
 				<Grid ColumnDefinitions="*,Auto">
@@ -63,7 +65,8 @@
 					        ItemsSource="{Binding NarouBigGenres, x:DataType=vm:SearchViewModel}"
 					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
 					        SelectedItem="{Binding SelectedNarouBigGenre}"
-					        IsEnabled="{Binding SearchNarou}" />
+					        IsEnabled="{Binding SearchNarou}"
+					        Opacity="{Binding SearchNarou, Converter={StaticResource BoolToOpacity}}" />
 					<Switch Grid.Column="2" IsToggled="{Binding SearchNarou}" VerticalOptions="Center" />
 				</Grid>
 				<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
@@ -73,7 +76,8 @@
 					        ItemsSource="{Binding KakuyomuGenreList}"
 					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
 					        SelectedItem="{Binding SelectedKakuyomuGenre}"
-					        IsEnabled="{Binding SearchKakuyomu}" />
+					        IsEnabled="{Binding SearchKakuyomu}"
+					        Opacity="{Binding SearchKakuyomu, Converter={StaticResource BoolToOpacity}}" />
 					<Switch Grid.Column="2" IsToggled="{Binding SearchKakuyomu}" VerticalOptions="Center" />
 				</Grid>
 				<Button Text="ランキング取得" Command="{Binding FetchRankingCommand}" />
@@ -88,7 +92,8 @@
 					        ItemsSource="{Binding NarouBigGenres}"
 					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
 					        SelectedItem="{Binding SelectedNarouBigGenre}"
-					        IsEnabled="{Binding SearchNarou}" />
+					        IsEnabled="{Binding SearchNarou}"
+					        Opacity="{Binding SearchNarou, Converter={StaticResource BoolToOpacity}}" />
 					<Switch Grid.Column="2" IsToggled="{Binding SearchNarou}" VerticalOptions="Center" />
 				</Grid>
 				<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
@@ -98,7 +103,8 @@
 					        ItemsSource="{Binding KakuyomuGenreList}"
 					        ItemDisplayBinding="{Binding Name, x:DataType=mo:GenreInfo}"
 					        SelectedItem="{Binding SelectedKakuyomuGenre}"
-					        IsEnabled="{Binding SearchKakuyomu}" />
+					        IsEnabled="{Binding SearchKakuyomu}"
+					        Opacity="{Binding SearchKakuyomu, Converter={StaticResource BoolToOpacity}}" />
 					<Switch Grid.Column="2" IsToggled="{Binding SearchKakuyomu}" VerticalOptions="Center" />
 				</Grid>
 				<Button Text="ジャンル別取得" Command="{Binding FetchGenreCommand}" />


### PR DESCRIPTION
プラン §3 (UX-3) の実装。検索ページのレイアウトを再構成する。

## 実装概要

### Row 1: 3 等分モードタブ
横幅を `*,*,*` の Grid に変更し、3 ボタンを均等幅化。

### Row 2: モード固有入力 + サイト Switch 再配置
- **Keyword モード**: なろう/カクヨム Switch を検索 Entry の**上**に横並び配置
- **Ranking モード**: 期間 Picker、なろう Picker + Switch、カクヨム Picker + Switch (各 Picker 行末尾に Switch)
- **Genre モード**: なろう Picker + Switch、カクヨム Picker + Switch
- 全モードで Switch に統一 (旧 CheckBox 廃止)
- Picker 行は `Grid ColumnDefinitions=\"Auto,*,Auto\"` で Label/Picker/Switch を配置し、Picker を `*` 列で expand

### 旧 Row 3 を削除
共通サイトフィルタ行を削除し、Grid を `Auto,Auto,Auto,*` の 4 行に変更。

### Switch OFF 時の視覚表現 (新規 Converter)
- Picker は `IsEnabled=\"{Binding SearchNarou/Kakuyomu}\"` でタップ不能化 + システム既定のグレー描画
- Label は `BoolToOpacity` Converter (true → 1.0 / false → 0.4) で薄く表示
- モード横断で Switch 状態が共有される現行仕様の認知齟齬 (別モードに切り替えた直後に Picker が触れるのに OFF 状態) を緩和

### 追加ファイル
- `_Apps/Converters/BoolToOpacityConverter.cs` (新規)
- `_Apps/Resources/Styles/Converters.xaml` に `BoolToOpacity` 登録

## 動作確認 (プラン §3.4)

実機確認は未実施。

- [x] 「検索」モード: なろう/カクヨム Switch が Entry の上に出る、検索動作 OK
- [x] 「ランキング」モード: 期間/なろう/カクヨムの行構成、Switch 片方 OFF で当該サイトのみ取得
- [x] 「ジャンル」モード: 同様
- [x] モード横断で Switch 状態が保持されること (意図された挙動)
- [x] Switch OFF で Picker が IsEnabled=false かつ Label が Opacity=0.4 になること
- [x] 既存の四半期非対応バナー (\`prefixMessage\`) が変わらず動作