### PR TITLE
fix(episode-list): gate SizeChanged scroll fallback behind delay completion

### DIFF
--- a/_Apps/Views/EpisodeListPage.xaml.cs
+++ b/_Apps/Views/EpisodeListPage.xaml.cs
@@ -6,6 +6,7 @@ namespace LanobeReader.Views;
 public partial class EpisodeListPage : ContentPage
 {
     private int? _pendingScrollIndex;
+    private bool _delayedRan;
 
     public EpisodeListPage(EpisodeListViewModel viewModel)
     {
@@ -33,6 +34,7 @@ public partial class EpisodeListPage : ContentPage
                     // SizeChanged フォールバック用にもインデックスを保持。
                     // TryScrollToPending() の成功時に null クリアすることで二重実行を防ぐ。
                     _pendingScrollIndex = i;
+                    _delayedRan = false;
 
                     // OnAppearing 時点でページは visible だが、ItemsSource 差し替え直後で
                     // CollectionView の measure/layout 未完だと ScrollTo が空振りする。
@@ -50,6 +52,13 @@ public partial class EpisodeListPage : ContentPage
                         {
                             LogHelper.Warn(nameof(EpisodeListPage),
                                 $"Delayed ScrollTo failed: {ex.Message}");
+                        }
+                        finally
+                        {
+                            // 成否に関わらず delay 経過を記録。これ以降の SizeChanged が
+                            // フォールバックとして動けるようになる (ScrollTo が silent no-op
+                            // だった場合も、次の SizeChanged で再試行される)。
+                            _delayedRan = true;
                         }
                     });
                 }
@@ -83,9 +92,13 @@ public partial class EpisodeListPage : ContentPage
     /// CollectionView の measure/layout 確定時に発火。DispatchDelayed(150ms) が
     /// 遅い実機で空振りしたケースを救うフォールバック経路。
     /// _pendingScrollIndex が null (= 既に消費済 or 不要) なら何もしない。
+    /// _delayedRan が false の間 (= DispatchDelayed が未到達) は何もしない。
+    /// 早期に発火した SizeChanged で消費 → ScrollTo silent no-op → 後続の delay 空振り、
+    /// という詰みパターンを避けるため、SizeChanged は必ず delay 経過後だけ動くよう順序保証する。
     /// </summary>
     private void OnEpisodesViewSizeChanged(object? sender, EventArgs e)
     {
+        if (!_delayedRan) return;
         try
         {
             TryScrollToPending();


### PR DESCRIPTION
PR #130 のレビューで指摘した SizeChanged / DispatchDelayed の順序問題への follow-up fix。

## 背景

PR #130 では初期スクロールに二重防御 (DispatchDelayed 150ms + SizeChanged フォールバック) を入れたが、SizeChanged が DispatchDelayed より先に発火するケースで以下の詰みパターンがあった:

1. SizeChanged が早期発火 (CollectionView の途中 layout)
2. \`TryScrollToPending\` が \`_pendingScrollIndex\` を消費して null クリア
3. ScrollTo は layout 未完で silent no-op (戻り値も例外も無い)
4. 150ms 後の DispatchDelayed が走るが \`_pendingScrollIndex == null\` で素通り
5. **ユーザはスクロールされないまま**

## 修正内容

- \`_delayedRan\` フィールドを追加。SizeChanged は \`_delayedRan == true\` の時だけ動かす
- DispatchDelayed の \`finally\` で \`_delayedRan = true\`。ScrollTo が例外した場合でもフォールバック経路は活きる
- \`OnAppearing\` 毎に \`_delayedRan = false\` でリセット

これにより「DispatchDelayed が必ず最初の試行を担当 → 空振りしたケースだけ SizeChanged が後追いで救う」というプラン §1.3 の意図通りの順序が保証される。

## 動作確認

- [x] dotnet build (0 warning, 0 error)
- [ ] 実機: 既読 86 話 → 86 話目が中央表示
- [ ] 実機: 全話既読 → 最終話付近表示
- [ ] 実機: Reader から戻った時に再スクロールしない
- [ ] 実機: OnAppearing → 即 OnDisappearing 高速遷移でクラッシュしない