### PR TITLE
refactor(novel-repo): remove dead GetAllAsync(string) overload

### DIFF
--- a/_Apps/Services/Database/NovelRepository.cs
+++ b/_Apps/Services/Database/NovelRepository.cs
@@ -24,38 +24,12 @@ public class NovelRepository
         _cacheRepo = cacheRepo;
     }
 
-    public Task<List<Novel>> GetAllAsync()
-    {
-        return GetAllAsync("updated_desc");
-    }
-
-    public async Task<List<Novel>> GetAllAsync(string sortKey)
+    public async Task<List<Novel>> GetAllAsync()
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
-        return sortKey switch
-        {
-            "updated_asc" => await _db.Table<Novel>().OrderBy(n => n.LastUpdatedAt).ToListAsync().ConfigureAwait(false),
-            "title_asc" => await _db.Table<Novel>().OrderBy(n => n.Title).ToListAsync().ConfigureAwait(false),
-            "title_desc" => await _db.Table<Novel>().OrderByDescending(n => n.Title).ToListAsync().ConfigureAwait(false),
-            "author_asc" => await _db.Table<Novel>().OrderBy(n => n.Author).ToListAsync().ConfigureAwait(false),
-            "registered_desc" => await _db.Table<Novel>().OrderByDescending(n => n.RegisteredAt).ToListAsync().ConfigureAwait(false),
-            "unread_desc" => await _db.QueryAsync<Novel>(
-                "SELECT n.id, n.site_type, n.novel_id, n.title, n.author, " +
-                "n.total_episodes, n.is_completed, n.last_updated_at, " +
-                "n.registered_at, n.has_unconfirmed_update, n.has_check_error, " +
-                "n.is_favorite, n.favorited_at " +
-                "FROM novels n " +
-                "ORDER BY (SELECT COUNT(*) FROM episodes e WHERE e.novel_id = n.id AND e.is_read = 0) DESC, n.last_updated_at DESC"
-            ).ConfigureAwait(false),
-            "favorite_first" => await _db.QueryAsync<Novel>(
-                "SELECT id, site_type, novel_id, title, author, " +
-                "total_episodes, is_completed, last_updated_at, " +
-                "registered_at, has_unconfirmed_update, has_check_error, " +
-                "is_favorite, favorited_at " +
-                "FROM novels ORDER BY is_favorite DESC, last_updated_at DESC"
-            ).ConfigureAwait(false),
-            _ => await _db.Table<Novel>().OrderByDescending(n => n.LastUpdatedAt).ToListAsync().ConfigureAwait(false),
-        };
+        return await _db.Table<Novel>()
+            .OrderByDescending(n => n.LastUpdatedAt)
+            .ToListAsync().ConfigureAwait(false);
     }
 
     public async Task<List<NovelWithUnread>> GetAllWithUnreadCountAsync(string sortKey)


### PR DESCRIPTION
PR #131 のレビューで判明した、`NovelRepository.GetAllAsync(string sortKey)` がほぼ全分岐到達不能なデッドコードである件の整理。

## 調査結果

`GetAllAsync(string sortKey)` の呼び出し元は以下のみ:

- [UpdateCheckService.cs:39](../blob/app-novelviewer/_Apps/Services/UpdateCheckService.cs#L39) — 引数なし `GetAllAsync()`
- [PrefetchService.cs:64](../blob/app-novelviewer/_Apps/Services/Background/PrefetchService.cs#L64) — 引数なし `GetAllAsync()`
- 引数なし版が内部で `GetAllAsync(\"updated_desc\")` を呼んでいるだけ

つまり switch の `\"updated_desc\"` (default) 分岐以外 (`updated_asc` / `title_asc` / `title_desc` / `author_asc` / `registered_desc` / `unread_desc` / `favorite_first`) は全て到達不能。一覧画面のソートは [NovelListViewModel.cs:69](../blob/app-novelviewer/_Apps/ViewModels/NovelListViewModel.cs#L69) の `GetAllWithUnreadCountAsync(SortKey)` 経由で処理されている。

## 変更内容

`GetAllAsync(string sortKey)` オーバーロードを削除し、`updated_desc` 相当のクエリ (`OrderByDescending(LastUpdatedAt)`) を引数なし版にインライン化。

```csharp
public async Task<List<Novel>> GetAllAsync()
{
    await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
    return await _db.Table<Novel>()
        .OrderByDescending(n => n.LastUpdatedAt)
        .ToListAsync().ConfigureAwait(false);
}
```

## 副次的なメリット

- `unread_desc` 分岐内のインライン相関サブクエリ (`SELECT COUNT(*) FROM episodes WHERE is_read=0`) が消滅。PR #131 で追加される `idx_episodes_novel_isread` の恩恵を受けられない旧式クエリの撤去となる。
- API 表面積縮小 (将来 sortKey が必要になっても再追加は容易)。

## PR #131 との関係

PR #131 (`feature/novel-card-read-progress`) が変更する `GetAllWithUnreadCountAsync` とは独立した変更であり、コンフリクトなし。先行マージ・後続マージのどちらでも問題ない。

## 動作確認

- `dotnet build _Apps/App.sln --no-restore` 成功 (エラー 0 / ワーニング 0)
- 影響を受ける呼び出し元 (`UpdateCheckService` / `PrefetchService`) はいずれも引数なし `GetAllAsync()` を使用しており、シグネチャ変更なし