### PR TITLE
perf(episode-list): 初回表示とページ切替の UI 詰まりを解消

### DIFF
--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LanobeReader.Helpers;
@@ -38,8 +37,11 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
     [ObservableProperty]
     private string _novelTitle = string.Empty;
 
+    // ItemsSource を List で渡し、ページ切替時はリスト全体を差し替える。
+    // ObservableCollection 経由よりも CollectionView の view 再構築コストが軽い
+    // (NotifyCollectionChanged のバーストを避け、PropertyChanged 1 発に集約)。
     [ObservableProperty]
-    private ObservableCollection<EpisodeViewModel> _episodes = [];
+    private List<EpisodeViewModel> _episodes = new();
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(PrevPageCommand))]
@@ -72,6 +74,11 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
     private int _episodesPerPage = 50;
     private Novel? _novel;
     private Task? _initTask;
+
+    // InitializeAsync 完了直後の OnAppearing で RefreshReadStatusAsync をスキップするためのフラグ。
+    // Init で既に最新の IsRead を取得済みのため、初回 Refresh は不要 (DB の二重 fetch を回避)。
+    // Reader 画面から戻った 2 回目以降の OnAppearing では実 fetch する。
+    private bool _hasFreshData;
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
@@ -134,6 +141,9 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
             }
 
             await LoadPageAsync();
+
+            // _allEpisodes は最新なので次の OnAppearing.Refresh は不要 (Reader 復帰時のみ実 fetch)。
+            _hasFreshData = true;
         }
         catch (Exception ex)
         {
@@ -181,18 +191,25 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
 
     private Task LoadPageAsync()
     {
-        var list = _filteredCache
+        Episodes = _filteredCache
             .Skip((CurrentPage - 1) * _episodesPerPage)
             .Take(_episodesPerPage)
             .Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)))
             .ToList();
-        Episodes = new ObservableCollection<EpisodeViewModel>(list);
         return Task.CompletedTask;
     }
 
     public async Task RefreshReadStatusAsync()
     {
         if (_allEpisodes.Count == 0) return;
+
+        // Init 直後の最初の OnAppearing では _allEpisodes が最新なのでスキップ。
+        // フラグを倒して、次回 (Reader 復帰時等) の OnAppearing からは実 fetch する。
+        if (_hasFreshData)
+        {
+            _hasFreshData = false;
+            return;
+        }
 
         var freshEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
         var readMap = freshEpisodes.ToDictionary(e => e.Id, e => e.IsRead);

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -78,7 +78,7 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
     // InitializeAsync 完了直後の OnAppearing で RefreshReadStatusAsync をスキップするためのフラグ。
     // Init で既に最新の IsRead を取得済みのため、初回 Refresh は不要 (DB の二重 fetch を回避)。
     // Reader 画面から戻った 2 回目以降の OnAppearing では実 fetch する。
-    private bool _hasFreshData;
+    private bool _skipNextRefresh;
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
@@ -143,7 +143,7 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
             await LoadPageAsync();
 
             // _allEpisodes は最新なので次の OnAppearing.Refresh は不要 (Reader 復帰時のみ実 fetch)。
-            _hasFreshData = true;
+            _skipNextRefresh = true;
         }
         catch (Exception ex)
         {
@@ -205,9 +205,9 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
 
         // Init 直後の最初の OnAppearing では _allEpisodes が最新なのでスキップ。
         // フラグを倒して、次回 (Reader 復帰時等) の OnAppearing からは実 fetch する。
-        if (_hasFreshData)
+        if (_skipNextRefresh)
         {
-            _hasFreshData = false;
+            _skipNextRefresh = false;
             return;
         }
 


### PR DESCRIPTION
## 概要

実機 (1591 話) で目次画面の初回表示が遅く (2 秒)、ページ切替後に UI スレッドが 1.5 秒詰まる (Davey! / Skipped 80 frames) 問題を解消する。`adb logcat` の Stopwatch 計測で 2 つのボトルネックを特定。

## 計測ログ (Before)

```
初回表示:
  Init.GetAllEpisodes: 142ms (1591件)
  Refresh.GetAll:      737-1497ms (同じクエリの 2 回目で 7-8 倍に膨張)
  OnAppearing.TOTAL:   1047-2054ms

ページ切替:
  NextPage.TOTAL: 15-72ms
    ↓ 直後に Davey! duration=1504ms / Skipped 80 frames
```

## ボトルネック分析

### 1. 初回 OnAppearing で `GetByNovelIdAsync` が 2 回実行されていた
`InitializeAsync` で全話 fetch (1 回目) → CollectionView が DataTemplate を組み立てる最中 (UI スレッド占有) に `RefreshReadStatusAsync` の同クエリ (2 回目) が継続できず詰まる、というメインスレッド競合パターン。

### 2. ページ切替で `Episodes = new ObservableCollection(...)` 全置換
50 個の view を毎回 dispose / measure / layout し直すため `PerformTraversalsStart → DrawStart` で 1.4 秒消費。

## 修正内容

| # | 修正 | 効果 |
|---|------|------|
| 1 | `_hasFreshData` フラグで Init 直後の Refresh をスキップ。Reader 復帰時の OnAppearing からのみ実 fetch | 初回 OnAppearing **2054ms → 248ms** (約 8 倍速) |
| 2 | `Episodes` を `ObservableCollection<EpisodeViewModel>` → `List<EpisodeViewModel>` に変更 | ページ切替後の **Davey! / Skipped frames が消滅** |

## 計測ログ (After)

```
初回表示:
  Init.GetAllEpisodes:    142ms
  Refresh.SKIP            (fresh data from Init)
  OnAppearing.TOTAL:      248ms

ページ切替:
  NextPage.TOTAL:         34-44ms
  (Davey! / Skipped frames は観測されず)

2 回目以降の OnAppearing (Reader 復帰想定):
  Refresh は実 fetch される設計 (本 PR では未計測)
```

## 動作確認

- ✅ ビルド成功 (0 warning / 0 error)
- ✅ 実機 (Pixel 7 emulator / API 35) で 1591 話の小説を開いて初回表示・ページ切替を計測
- ⚠️ Reader 画面で既読化 → 戻った際の Refresh 実 fetch は未検証 (ロジック的には `_hasFreshData = false` で実 fetch されるはず)

## 影響範囲

- `EpisodeListViewModel.cs` のみ。21 行追加 / 4 行削除。
- `Episodes` プロパティの型変更は外部から見て `IEnumerable<EpisodeViewModel>` として動作するため、XAML の `ItemsSource="{Binding Episodes}"` は無変更で動作。
- `RefreshReadStatusAsync` の内部 `foreach (var vm in Episodes)` も List で動作。