### PR TITLE
perf(episode-list): スクロールイベント統合と per-cell コスト削減 (#139 取り込み)

### DIFF
--- a/_Apps/Features/requirements_lanovereader.md
+++ b/_Apps/Features/requirements_lanovereader.md
@@ -739,18 +739,23 @@ graph TD
    最終話付近を提示する目的。
 3. 0 話登録（`_allEpisodes.Count == 0`） → anchor 無し。
 
-anchor が決まったら、それを含むページを `CurrentPage` として `LoadPageAsync` 実行。OnAppearing 完了後に
-CollectionView の対象行へ `ScrollToPosition.Center, animate=false` でスクロールし、画面中央に配置する。
-anchor 無しのときは 1 ページ目・スクロールなし。
+anchor が決まったら、それを含むページを `CurrentPage` として `LoadPageAsync` 実行。`LoadPageAsync` 完了と
+同じ UI tick で `PageContentReset` イベントを発火し、View 側で `ScrollTo(idx, ScrollToPosition.Center,
+animate=false)` を同期呼び出しすることで対象行を画面中央に配置する（同一レイアウトパスでアイテム配置と
+スクロール target の両方が処理され、ユーザーには「先頭→アンカー」の中間スクロールが見えない）。
+anchor 無しのときは 1 ページ目で `PageContentReset(ScrollIndex=0, ToCenter=false)` を発火し、
+`ScrollToPosition.Start` で先頭リセットする。
 
 > **anchor が「直前まで読んだ話 = firstUnread の 1 つ前」と一致する根拠**: `EpisodeRepository.SetReadStateUpToAsync` は
 > 「読了点までを既読化、それ以降を未読化」する仕様のため、既読/未読の境界は常に連続している（飛ばし読みによる穴は
 > 発生しない）。よって `firstUnread の前` = `MAX(episode_no WHERE is_read=1)` と一致する。将来 `UpdateAsync` 経由で
 > 個別話 IsRead=true を許す経路ができた場合、anchor 選定を `LastOrDefault(IsRead == true)` 単独に変更する。
 
-> 初期スクロールはフィルタ ON/OFF (`ShowUnreadOnly`/`ShowFavoritesOnly`) の再ロードや、ページ手動切替
-> (`PrevPageAsync`/`NextPageAsync`) では適用しない（現行どおり `CurrentPage=1` リセット）。
-> Reader 画面から戻った再 `OnAppearing` でも再スクロールしない（`PendingInitialScrollIndex` は 1 回限り消費）。
+> フィルタ ON/OFF (`ShowUnreadOnly`/`ShowFavoritesOnly`) の再ロードや、ページ手動切替
+> (`PrevPageAsync`/`NextPageAsync`) では anchor スクロールではなく先頭リセット
+> (`PageContentReset(ScrollIndex=0, ToCenter=false)`) を発火する。
+> Reader 画面から戻った再 `OnAppearing` では `PageContentReset` を発火しないため再スクロールしない
+> （`RefreshReadStatusAsync` は `Episodes` への in-place 更新のみで完結する）。
 
 **UIコントロール一覧:**
 | コントロール | 種別 | バインディング先 | 備考 |
@@ -772,7 +777,11 @@ anchor 無しのときは 1 ページ目・スクロールなし。
 | CurrentPage | int | 1 | 現在ページ番号 |
 | MaxPage | int | 0 | 最大ページ数 |
 | HasChapters | bool | false | 章情報ありフラグ |
-| PendingInitialScrollIndex | int? | null | 初期スクロール対象 (anchor) のページ内インデックス。`InitializeAsync` が anchor を見つけた場合のみ設定。View 側 (`OnAppearing`) で `TakePendingInitialScrollIndex()` により 1 回だけ消費される pull 型設計 |
+
+**ViewModelイベント:**
+| イベント名 | ペイロード | 発火タイミング |
+|---|---|---|
+| PageContentReset | `(ScrollIndex: int, ToCenter: bool)` | `InitializeAsync` 完了時（初回 anchor スクロール、`ToCenter=true`）/ `PrevPageAsync` / `NextPageAsync` / フィルタ切替による `ReloadListAsync`（先頭リセット、`ToCenter=false`）。`RefreshReadStatusAsync` の in-place 更新では発火しない。View 側はコンストラクタで購読し、`ScrollTo` を同期呼び出しする push 型設計 |
 
 **ViewModelコマンド:**
 | コマンド名 | CanExecute条件 | Execute処理 |

--- a/_Apps/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/ViewModels/EpisodeListViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LanobeReader.Helpers;
@@ -37,11 +38,18 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
     [ObservableProperty]
     private string _novelTitle = string.Empty;
 
-    // ItemsSource を List で渡し、ページ切替時はリスト全体を差し替える。
-    // ObservableCollection 経由よりも CollectionView の view 再構築コストが軽い
-    // (NotifyCollectionChanged のバーストを避け、PropertyChanged 1 発に集約)。
-    [ObservableProperty]
-    private List<EpisodeViewModel> _episodes = new();
+    // ItemsSource は ObservableCollection の同一インスタンスを保持し、ページ切替時は
+    // Clear + Add で内容のみ差し替える。List 再代入だと CollectionView がアダプタを
+    // 全リセットしてコンテナ再利用 (RecyclerView のプール) が効かず、ページ切替が体感重くなる。
+    // 単発 Reset (notifyDataSetChanged 相当) は Android で逆に全アイテム invalidate が走り
+    // 遅いことが多いため、incremental な Clear + Add の方が体感が速い。
+    public ObservableCollection<EpisodeViewModel> Episodes { get; } = new();
+
+    // 「ページが切り替わった」セマンティクスを View へ通知する。Episodes 更新と同一 UI tick で
+    // 発火することで、View 側で ScrollTo を呼んでもユーザーには「先頭で表示されてからスクロール」
+    // の途中過程が見えない (RecyclerView が同じレイアウトパスでアイテム配置とスクロール target を
+    // 両方処理する)。RefreshReadStatusAsync 等のインプレース更新では発火させない。
+    public event EventHandler<PageContentResetArgs>? PageContentReset;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(PrevPageCommand))]
@@ -133,17 +141,29 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
                 anchor = _allEpisodes.LastOrDefault(e => e.IsRead);
             }
 
+            int? anchorIdxInPage = null;
             if (anchor is not null)
             {
                 var idxInFiltered = _filteredCache.FindIndex(e => e.Id == anchor.Id);
                 if (idxInFiltered >= 0)
                 {
                     CurrentPage = (idxInFiltered / _episodesPerPage) + 1;
-                    PendingInitialScrollIndex = idxInFiltered % _episodesPerPage;
+                    anchorIdxInPage = idxInFiltered % _episodesPerPage;
                 }
             }
 
+            // Shell のスライドアニメ (~250ms) と 50 アイテム追加が UI スレッドで競合すると
+            // 遷移が中途半端な位置で詰まって見えるため、アニメ完了を待ってからリスト構築する。
+            // Dispatcher.Dispatch (1 tick) では不足、Task.Delay(200) が必要 (実機検証済)。
+            await Task.Delay(200);
             await LoadPageAsync();
+
+            // LoadPageAsync 完了と同じ UI tick でスクロール target を渡すことで、
+            // ユーザーには「先頭→アンカー」の中間スクロールが見えないようにする。
+            // anchor が無い場合は先頭リセット (ScrollIndex=0, ToCenter=false)。
+            PageContentReset?.Invoke(this, new PageContentResetArgs(
+                ScrollIndex: anchorIdxInPage ?? 0,
+                ToCenter: anchorIdxInPage.HasValue));
 
             // _allEpisodes は最新なので次の OnAppearing.Refresh は不要 (Reader 復帰時のみ実 fetch)。
             _skipNextRefresh = true;
@@ -157,24 +177,6 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
         {
             IsLoading = false;
         }
-    }
-
-    /// <summary>
-    /// 初期スクロール対象 (anchor) のページ内インデックス。
-    /// anchor は「直前まで読んだ話 = firstUnread の 1 つ前」、無ければ「最新既読話」。
-    /// InitializeAsync が anchor を見つけた場合に設定され、View 側の OnAppearing で
-    /// TakePendingInitialScrollIndex() により 1 回だけ消費される。null = スクロール不要。
-    /// </summary>
-    public int? PendingInitialScrollIndex { get; private set; }
-
-    /// <summary>
-    /// PendingInitialScrollIndex を読み取って null クリアする。1 回限り消費を保証。
-    /// </summary>
-    public int? TakePendingInitialScrollIndex()
-    {
-        var v = PendingInitialScrollIndex;
-        PendingInitialScrollIndex = null;
-        return v;
     }
 
     private void RebuildFilterCache()
@@ -194,11 +196,11 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
 
     private Task LoadPageAsync()
     {
-        Episodes = _filteredCache
-            .Skip((CurrentPage - 1) * _episodesPerPage)
-            .Take(_episodesPerPage)
-            .Select(e => EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)))
-            .ToList();
+        Episodes.Clear();
+        foreach (var e in _filteredCache.Skip((CurrentPage - 1) * _episodesPerPage).Take(_episodesPerPage))
+        {
+            Episodes.Add(EpisodeViewModel.FromModel(e, _cachedIds.Contains(e.Id)));
+        }
         return Task.CompletedTask;
     }
 
@@ -213,6 +215,11 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
             _skipNextRefresh = false;
             return;
         }
+
+        // Reader→目次の戻り遷移ではここで Shell のスライドアニメが進行中。DB クエリ + IsRead 更新が
+        // 重なるとアニメが詰まって見えるため、アニメ完了を待ってから fetch & update する。
+        // Dispatcher.Dispatch (1 tick) では不足、Task.Delay(200) が必要 (実機検証済)。
+        await Task.Delay(200);
 
         var freshEpisodes = await _episodeRepo.GetByNovelIdAsync(_novelDbId);
         var readMap = freshEpisodes.ToDictionary(e => e.Id, e => e.IsRead);
@@ -250,6 +257,7 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
         CurrentPage = 1;
         RecalcPaging();
         await LoadPageAsync();
+        PageContentReset?.Invoke(this, new PageContentResetArgs(ScrollIndex: 0, ToCenter: false));
     }
 
     [RelayCommand]
@@ -319,6 +327,7 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
     {
         CurrentPage--;
         await LoadPageAsync();
+        PageContentReset?.Invoke(this, new PageContentResetArgs(ScrollIndex: 0, ToCenter: false));
     }
 
     private bool CanGoPrev() => CurrentPage > 1;
@@ -328,7 +337,14 @@ public partial class EpisodeListViewModel : ErrorAwareViewModel, IQueryAttributa
     {
         CurrentPage++;
         await LoadPageAsync();
+        PageContentReset?.Invoke(this, new PageContentResetArgs(ScrollIndex: 0, ToCenter: false));
     }
 
     private bool CanGoNext() => CurrentPage < MaxPage;
 }
+
+/// <summary>
+/// PageContentReset イベントのペイロード。スクロール先のインデックスと位置 (先頭 / 中央) を渡す。
+/// ToCenter=true は初回アンカースクロール (前回読んだ話を中央表示)、false はページ切替時の先頭リセット。
+/// </summary>
+public sealed record PageContentResetArgs(int ScrollIndex, bool ToCenter);

--- a/_Apps/Views/EpisodeListPage.xaml
+++ b/_Apps/Views/EpisodeListPage.xaml
@@ -2,7 +2,9 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:LanobeReader.ViewModels"
+             xmlns:views="clr-namespace:LanobeReader.Views"
              x:Class="LanobeReader.Views.EpisodeListPage"
+             x:Name="ThisPage"
              x:DataType="vm:EpisodeListViewModel"
              Title="{Binding NovelTitle}"
              Shell.TabBarIsVisible="False">
@@ -36,13 +38,14 @@
 		<CollectionView Grid.Row="2" x:Name="EpisodesView"
 		                ItemsSource="{Binding Episodes}" SelectionMode="None"
 		                IsGrouped="False"
+		                ItemSizingStrategy="MeasureFirstItem"
 		                SizeChanged="OnEpisodesViewSizeChanged">
 			<CollectionView.ItemTemplate>
 				<DataTemplate x:DataType="vm:EpisodeViewModel">
 					<Grid Padding="16,10" ColumnDefinitions="Auto,*,Auto,Auto">
 						<Grid.GestureRecognizers>
 							<TapGestureRecognizer
-									Command="{Binding Source={RelativeSource AncestorType={x:Type vm:EpisodeListViewModel}}, Path=NavigateToEpisodeCommand, x:DataType=vm:EpisodeListViewModel}"
+									Command="{Binding ViewModel.NavigateToEpisodeCommand, Source={x:Reference ThisPage}, x:DataType=views:EpisodeListPage}"
 									CommandParameter="{Binding}" />
 						</Grid.GestureRecognizers>
 
@@ -56,7 +59,8 @@
 							<Label Text="{Binding ChapterName}" FontSize="10" TextColor="Gray"
                                    IsVisible="{Binding ChapterName, Converter={StaticResource HasValue}}" />
 							<Label Text="{Binding Title}" Style="{StaticResource BodyLabel}"
-                                   TextColor="{Binding IsRead, Converter={StaticResource BoolToGrayConverter}}" />
+                                   TextColor="{Binding IsRead, Converter={StaticResource BoolToGrayConverter}}"
+                                   LineBreakMode="TailTruncation" MaxLines="1" />
 						</VerticalStackLayout>
 
 						<!-- Cached indicator -->
@@ -69,7 +73,7 @@
                                TextColor="{Binding IsFavorite, Converter={StaticResource BoolToGoldConverter}}">
 							<Label.GestureRecognizers>
 								<TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:EpisodeListViewModel}}, Path=ToggleEpisodeFavoriteCommand, x:DataType=vm:EpisodeListViewModel}"
+                                    Command="{Binding ViewModel.ToggleEpisodeFavoriteCommand, Source={x:Reference ThisPage}, x:DataType=views:EpisodeListPage}"
                                     CommandParameter="{Binding}" />
 							</Label.GestureRecognizers>
 						</Label>

--- a/_Apps/Views/EpisodeListPage.xaml.cs
+++ b/_Apps/Views/EpisodeListPage.xaml.cs
@@ -6,13 +6,22 @@ namespace LanobeReader.Views;
 public partial class EpisodeListPage : ContentPage
 {
     private int? _pendingScrollIndex;
-    private bool _delayedRan;
+    private bool _pendingToCenter;
 
     public EpisodeListPage(EpisodeListViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
+
+        // VM の PageContentReset は InitializeAsync (ApplyQueryAttributes 経由) からも発火するため、
+        // OnAppearing より前のコンストラクタ時点で購読しないと初回イベントを取りこぼす。
+        // Page と VM は共に Transient (MauiProgram.cs) で寿命が一致するため購読解除は不要。
+        viewModel.PageContentReset += OnPageContentReset;
     }
+
+    // XAML の DataTemplate 内から x:Reference 経由でアクセスするための型付きプロパティ。
+    // BindingContext を直接参照すると object 扱いになりコンパイル済みバインディングが効かない。
+    public EpisodeListViewModel ViewModel => (EpisodeListViewModel)BindingContext;
 
     protected override async void OnAppearing()
     {
@@ -25,45 +34,6 @@ public partial class EpisodeListPage : ContentPage
                 // 旧実装は両者が並列実行され、初回表示時に DB クエリの二重実行が発生していた。
                 await vm.EnsureInitializedAsync();
                 await vm.RefreshReadStatusAsync();
-
-                // 初回 OnAppearing で 1 回だけスクロール。Take... が null クリアするので
-                // Reader から戻った再表示時には再スクロールしない。
-                var idx = vm.TakePendingInitialScrollIndex();
-                if (idx is int i)
-                {
-                    // SizeChanged フォールバック用にもインデックスを保持。
-                    // TryScrollToPending() の成功時に null クリアすることで二重実行を防ぐ。
-                    _pendingScrollIndex = i;
-                    _delayedRan = false;
-
-                    // OnAppearing 時点でページは visible だが、ItemsSource 差し替え直後で
-                    // CollectionView の measure/layout 未完だと ScrollTo が空振りする。
-                    // DispatchDelayed で短時間待って Android の最初の layout サイクル完了を期待する。
-                    // 旧 150ms は Pixel 系実機の最遅ケースに合わせていたが、Init.TOTAL に既に
-                    // 100〜200ms 消費していて layout 完了している可能性が高いため 50ms に短縮。
-                    // 空振りした場合は OnEpisodesViewSizeChanged のフォールバックが救う。
-                    Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(50), () =>
-                    {
-                        // このデリゲートは外側 try/catch の保護対象外。OnAppearing → 即 OnDisappearing の
-                        // 遷移直後に走った場合 ObjectDisposed で例外する可能性があるため明示的に握り潰す。
-                        try
-                        {
-                            TryScrollToPending();
-                        }
-                        catch (Exception ex)
-                        {
-                            LogHelper.Warn(nameof(EpisodeListPage),
-                                $"Delayed ScrollTo failed: {ex.Message}");
-                        }
-                        finally
-                        {
-                            // 成否に関わらず delay 経過を記録。これ以降の SizeChanged が
-                            // フォールバックとして動けるようになる (ScrollTo が silent no-op
-                            // だった場合も、次の SizeChanged で再試行される)。
-                            _delayedRan = true;
-                        }
-                    });
-                }
             }
             catch (Exception ex)
             {
@@ -76,9 +46,22 @@ public partial class EpisodeListPage : ContentPage
     }
 
     /// <summary>
-    /// _pendingScrollIndex が指す行へ ScrollTo を試みる。Center / animate=false で画面中央に置く。
-    /// 成功時に _pendingScrollIndex を null クリアして 1 回限り消費を保証する。
-    /// DispatchDelayed と SizeChanged の両経路から呼ばれるため、必ずここで null 化する。
+    /// VM からのスクロール指示。LoadPageAsync 完了と同じ UI tick で発火されるため、ここで同期的に
+    /// ScrollTo を呼べば RecyclerView は「アイテム配置 + スクロール target」を 1 回のレイアウト
+    /// パスで処理する。ユーザーには中間スクロールが見えない。
+    /// それでも空振りした場合 (measure 未完等) のため _pendingScrollIndex に target を残し、
+    /// 後続の OnEpisodesViewSizeChanged で再試行する。
+    /// </summary>
+    private void OnPageContentReset(object? sender, PageContentResetArgs e)
+    {
+        _pendingScrollIndex = e.ScrollIndex;
+        _pendingToCenter = e.ToCenter;
+        TryScrollToPending();
+    }
+
+    /// <summary>
+    /// _pendingScrollIndex が指す行へ ScrollTo を試みる。ToCenter フラグで Center / Start を選択。
+    /// 成功時に _pendingScrollIndex を null クリアして二重実行を防ぐ。
     /// </summary>
     private void TryScrollToPending()
     {
@@ -86,21 +69,17 @@ public partial class EpisodeListPage : ContentPage
         if (BindingContext is not EpisodeListViewModel vm) return;
         if (i < 0 || i >= vm.Episodes.Count) return;
 
-        EpisodesView.ScrollTo(i, position: ScrollToPosition.Center, animate: false);
+        var position = _pendingToCenter ? ScrollToPosition.Center : ScrollToPosition.Start;
+        EpisodesView.ScrollTo(i, position: position, animate: false);
         _pendingScrollIndex = null;
     }
 
     /// <summary>
-    /// CollectionView の measure/layout 確定時に発火。DispatchDelayed(150ms) が
-    /// 遅い実機で空振りしたケースを救うフォールバック経路。
-    /// _pendingScrollIndex が null (= 既に消費済 or 不要) なら何もしない。
-    /// _delayedRan が false の間 (= DispatchDelayed が未到達) は何もしない。
-    /// 早期に発火した SizeChanged で消費 → ScrollTo silent no-op → 後続の delay 空振り、
-    /// という詰みパターンを避けるため、SizeChanged は必ず delay 経過後だけ動くよう順序保証する。
+    /// CollectionView の measure/layout 確定時に発火。同期 ScrollTo が silent no-op だった場合の
+    /// フォールバック。_pendingScrollIndex が消費済なら何もしない。
     /// </summary>
     private void OnEpisodesViewSizeChanged(object? sender, EventArgs e)
     {
-        if (!_delayedRan) return;
         try
         {
             TryScrollToPending();


### PR DESCRIPTION
## Summary
- PR #139 (`perf/episode-list-render-flow` → `perf/episode-list-recheck`) を `app-novelviewer` に取り込む
- `Episodes` を `ObservableCollection` 化 + `PageContentReset` イベント駆動で、ページ切替・初回 anchor スクロール・Reader 復帰時の UI 詰まりを解消
- per-cell バインディングを `RelativeSource AncestorType` から `x:Reference ThisPage` に置換、Title `MaxLines=1`、`ItemSizingStrategy=MeasureFirstItem` を追加して per-cell コストを削減
- Shell スライドアニメ (~250ms) との競合を回避するため `Task.Delay(200)` を `InitializeAsync` 直前と `RefreshReadStatusAsync` 冒頭に追加
- `requirements_lanovereader.md` (SCR-003) を新設計 (push 型 `PageContentReset` イベント) に追従

詳細は #139 の説明を参照。

## 取り込みコミット
- `95760d2` perf(episode-list): スクロールイベント統合と per-cell コスト削減
- `699de75` docs(episode-list): requirements を PageContentReset イベント設計に追従
- `d984f82` Merge pull request #139 from twinbird827/perf/episode-list-render-flow

## Test plan
- [ ] 一覧 → 目次の遷移で Shell スライドが詰まらず、anchor 位置 (前回読んだ話) で表示される
- [ ] Reader → 目次の戻りで詰まらず、スクロール位置が維持される
- [ ] Prev/Next ページ切替が先頭表示でスムーズに切替わる
- [ ] フィルタ切替 (未読のみ / ★のみ) でページ 1 の先頭表示になる
- [ ] アイテムタップで Reader 遷移、★アイコンタップでお気に入りトグル (x:Reference 経由のコマンド動作確認)
- [ ] 長いタイトルが末尾省略 "…" で 1 行に収まる
- [ ] 章名なしのページ・章境界混在ページ (ChapterName=null と章ありが同一ページ) のいずれもレイアウトが崩れない