### PR TITLE
fix(kakuyomu): ランキング取得失敗と検索結果の話数欠落を修正

### DIFF
--- a/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/Services/Kakuyomu/KakuyomuApiService.cs
@@ -58,18 +58,61 @@ public class KakuyomuApiService : INovelService
 
             var title = link.GetAttribute("title")?.Trim() ?? link.TextContent.Trim();
 
-            // 作者名抽出: 親要素から /users/ アンカーを探す
-            var author = "";
-            var parentEl = link.ParentElement;
-            for (int i = 0; i < 4 && parentEl is not null; i++)
+            // 検索ページは CSS Modules（ハッシュ付クラス名）で組まれており、カードコンテナの
+            // class はビルドごとに変わる。安定して取れる identifying signal は「カード内に
+            // /users/ リンクと Meta_metaItem__* が両方ある」ことなので、両方を含む最近接の
+            // 共通祖先を「カード」とみなす。
+            AngleSharp.Dom.IElement? cardEl = null;
+            var ancestor = link.ParentElement;
+            for (int i = 0; i < 10 && ancestor is not null; i++)
             {
-                var userLink = parentEl.QuerySelector("a[href*='/users/']");
-                if (userLink is not null)
+                if (ancestor.QuerySelector("a[href*='/users/']") is not null
+                    && ancestor.QuerySelector("[class*='Meta_metaItem__']") is not null)
                 {
-                    author = userLink.TextContent.Trim();
+                    cardEl = ancestor;
                     break;
                 }
-                parentEl = parentEl.ParentElement;
+                ancestor = ancestor.ParentElement;
+            }
+
+            var author = "";
+            int totalEpisodes = 0;
+            bool isCompleted = false;
+
+            if (cardEl is not null)
+            {
+                var userLink = cardEl.QuerySelector("a[href*='/users/']");
+                author = userLink?.TextContent.Trim() ?? "";
+
+                // 「連載中 NN話」「完結済 NN話」テキストを持つ Meta_metaItem__* を探す。
+                // CSS Modules のハッシュ部分はビルドごとに変わるため substring 一致で抽出。
+                foreach (var meta in cardEl.QuerySelectorAll("[class*='Meta_metaItem__']"))
+                {
+                    var text = meta.TextContent.Trim();
+                    var m = Regex.Match(text, @"^(連載中|完結済)\s*(\d+)話$");
+                    if (m.Success)
+                    {
+                        isCompleted = m.Groups[1].Value == "完結済";
+                        int.TryParse(m.Groups[2].Value, out totalEpisodes);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                // カード特定失敗時のフォールバック: 旧実装の 4 段親辿りで author だけ取得。
+                // CSS Modules のクラスプレフィックス自体が将来変わった場合の保険。
+                var parentEl = link.ParentElement;
+                for (int i = 0; i < 4 && parentEl is not null; i++)
+                {
+                    var userLink = parentEl.QuerySelector("a[href*='/users/']");
+                    if (userLink is not null)
+                    {
+                        author = userLink.TextContent.Trim();
+                        break;
+                    }
+                    parentEl = parentEl.ParentElement;
+                }
             }
 
             results.Add(new SearchResult
@@ -78,8 +121,8 @@ public class KakuyomuApiService : INovelService
                 NovelId = workId,
                 Title = title,
                 Author = author,
-                TotalEpisodes = 0,
-                IsCompleted = false,
+                TotalEpisodes = totalEpisodes,
+                IsCompleted = isCompleted,
             });
 
             if (results.Count >= 20) break;
@@ -311,7 +354,12 @@ public class KakuyomuApiService : INovelService
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(20));
 
-        var url = $"{BASE_URL}/rankings/{genreSlug}/{periodSlug}";
+        // `?work_variation=long` を必ず付ける。省略するとオリジン nginx が
+        // `Location: http://kakuyomu.jp/...?work_variation=long` の 302 を返し（HTTPS→HTTP）、
+        // Android の Network Security Config（cleartextTrafficPermitted=false）が 2 段目で
+        // 接続を拒否して HttpRequestException "Connection failure" になる。
+        // CloudFront が後段で 301 https に戻すためブラウザは通るが AndroidMessageHandler は通らない。
+        var url = $"{BASE_URL}/rankings/{genreSlug}/{periodSlug}?work_variation=long";
         var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
 
         var config = Configuration.Default;

--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using LanobeReader.Helpers;
 using LanobeReader.Models;
 using LanobeReader.Services.Database;
@@ -91,14 +92,51 @@ public class NetworkPolicyService
         try
         {
             await EnforceDelayAsync(site, ct).ConfigureAwait(false);
-            var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
-            _lastRequestAt[site] = DateTime.UtcNow;
-            return result;
+            try
+            {
+                var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+                _lastRequestAt[site] = DateTime.UtcNow;
+                return result;
+            }
+            catch (Exception ex)
+            {
+                LogRequestFailure(site, url, ex);
+                throw;
+            }
         }
         finally
         {
             gate.Release();
         }
+    }
+
+    // HttpRequestException.Message が "Connection failure" 等の抽象的な文字列だけだと
+    // Android 側の真の原因 (UnknownHostException / SSLHandshakeException / EOFException 等) が見えない。
+    // InnerException チェーンを最大 5 段まで logcat に吐いて切り分けを可能にする。
+    private static void LogRequestFailure(SiteType site, string url, Exception ex)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Request failed [").Append(site).Append("] ").AppendLine(url);
+        var cur = ex;
+        int depth = 0;
+        while (cur is not null && depth < 5)
+        {
+            sb.Append("  [").Append(depth).Append("] ")
+              .Append(cur.GetType().FullName).Append(": ").AppendLine(cur.Message);
+            cur = cur.InnerException;
+            depth++;
+        }
+        var st = ex.StackTrace;
+        if (!string.IsNullOrEmpty(st))
+        {
+            sb.AppendLine("  Stack (top 3):");
+            var lines = st.Split('\n');
+            for (int i = 0; i < Math.Min(3, lines.Length); i++)
+            {
+                sb.Append("    ").AppendLine(lines[i].TrimEnd());
+            }
+        }
+        LogHelper.Error(nameof(NetworkPolicyService), sb.ToString());
     }
 
     private async Task EnforceDelayAsync(SiteType site, CancellationToken ct)


### PR DESCRIPTION
## 概要

報告された 2 つの不具合を修正:
- **ランキング/ジャンル取得が即時 Connection failure で失敗する**
- **カクヨムの検索結果が必ず 0 話 / 連載中固定で表示される**

副産物として、通信失敗の原因切り分け用に InnerException チェーンを logcat に吐く診断ログも追加（今後の通信障害解析で再利用予定）。

## 調査と判明した根本原因

### ランキング/ジャンル取得失敗（即時 Connection failure）

logcat に InnerException を出して切り分けたところ:

```
[0] System.Net.Http.HttpRequestException: Connection failure
[1] Java.IO.IOException: Cleartext HTTP traffic to kakuyomu.jp not permitted
```

つまり HTTPS でリクエストしているのに途中で平文 HTTP に落ちている。curl で挙動を確認:

```
GET https://kakuyomu.jp/rankings/all/daily
 → 302 Location: http://kakuyomu.jp/rankings/all/daily?work_variation=long  ← HTTPS→HTTP
 → 301 Location: https://kakuyomu.jp/rankings/all/daily?work_variation=long
 → 200 OK
```

オリジン nginx が `Location: http://...` の 302 を返し、CloudFront が更に 301 で HTTPS に戻すリダイレクトチェーン。ブラウザは通るが、AndroidMessageHandler は Android 9+ のデフォルト Network Security Config（cleartextTrafficPermitted=false）により 2 段目の HTTP リダイレクト時点で接続を拒否する。

`?work_variation=long` を最初から付ければ 302 が出ず即 200 が返ることを確認したので、これを永続的 workaround とする。

### 検索結果の話数 0 固定

`KakuyomuApiService.SearchAsync` が `TotalEpisodes = 0` / `IsCompleted = false` をハードコードしていた。検索ページは `__APOLLO_STATE__` / `__NEXT_DATA__` を持たず、CSS Modules（ハッシュ付クラス名）の HTML SSR のみ。

現行 HTML を Firecrawl で確認したところ:
- 作品カードのクラス名（`NewBox_box__45ont` 等）はビルド毎に変わる
- 各カード内の `[class*='Meta_metaItem__']` の textContent に「連載中 NN話」「完結済 NN話」が単一文字列で入っている

これを正規表現 `^(連載中|完結済)\s*(\d+)話$` で抽出する。

## 実装

### chore(network): 通信失敗時の InnerException チェーンを logcat に出力

[`_Apps/Services/Network/NetworkPolicyService.cs`](_Apps/Services/Network/NetworkPolicyService.cs)

`GetStringAsync` の `_httpClient.GetStringAsync` 呼び出しを try/catch で囲み、`LogRequestFailure` で URL / 例外型 FullName / Message を InnerException 最大 5 段まで出力。例外は素通し再 throw で呼び出し側挙動は無変更。

### fix(kakuyomu): URL に `?work_variation=long` 付与

[`_Apps/Services/Kakuyomu/KakuyomuApiService.cs`](_Apps/Services/Kakuyomu/KakuyomuApiService.cs) `FetchRankingAsync`

URL 構築に `?work_variation=long` を必ず付ける。`FetchGenreAsync` は内部で `FetchRankingAsync` を呼ぶため同時に修正される。

### fix(kakuyomu): 検索結果カードからメタ情報抽出

[`_Apps/Services/Kakuyomu/KakuyomuApiService.cs`](_Apps/Services/Kakuyomu/KakuyomuApiService.cs) `SearchAsync`

- カード identifying signal を「`/users/` リンクと `Meta_metaItem__*` の両方を含む最近接共通祖先」と定義し、その共通祖先 element をカード境界とみなす
- カード内の `Meta_metaItem__*` の textContent に対し `^(連載中|完結済)\s*(\d+)話$` でマッチ → `TotalEpisodes` / `IsCompleted` 設定
- カード特定失敗時は旧実装の 4 段親辿りに fallback し、author だけ取得（CSS Modules プレフィックス自体が将来変わった場合の保険）

## デメリット / リスク

- `?work_variation=long` パラメータが将来 Kakuyomu 側で廃止された場合、別の workaround が必要になる。ただし「サーバー側の 302 リダイレクト先がこのパラメータを指している」ので、パラメータが廃止される時はリダイレクト挙動も同時に直る可能性が高い
- 検索結果のカード判定が CSS Modules ハッシュ部分のみ変動する前提に依存。プレフィックス（`Meta_metaItem__`, `/users/`）自体が変わると fallback で author だけ取れる挙動になる

## Test plan

- [x] エミュレータ/実機で「ランキング → 取得」を実行し、各ジャンル × 各期間（日間/週間/月間）で結果が表示される
- [x] 「ジャンル → ジャンル別取得」で異世界ファンタジー等を選び結果が表示される
- [x] 「検索」でタイトルキーワード検索を実行し、結果カードに正しい話数と「連載中/完結済」が表示される
- [x] logcat に `[NetworkPolicyService] ERROR:` が出ないこと（成功時）