### PR TITLE
fix(network): transient な HttpRequestException を最大2回リトライ

### DIFF
--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -84,30 +84,61 @@ public class NetworkPolicyService
 
     /// <summary>
     /// 指定サイトに対して HTTP GET（文字列）を発行。直列化＋ディレイが自動で適用される。
+    /// transient な HttpRequestException（SSL ストリーム破損 / 5xx / 408 / 429 等）は
+    /// 最大 2 回リトライする（合計 3 回試行・500ms バックオフ）。
+    /// 4xx クライアントエラー、TaskCanceledException、外部 ct のキャンセル要求はリトライしない。
     /// </summary>
     public async Task<string> GetStringAsync(SiteType site, string url, CancellationToken ct = default)
     {
+        const int maxAttempts = 3;
+        const int retryDelayMs = 500;
+
         var gate = _siteGates[site];
         await gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await EnforceDelayAsync(site, ct).ConfigureAwait(false);
-            try
+            for (int attempt = 1; ; attempt++)
             {
-                var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
-                _lastRequestAt[site] = DateTime.UtcNow;
-                return result;
-            }
-            catch (Exception ex)
-            {
-                LogRequestFailure(site, url, ex);
-                throw;
+                await EnforceDelayAsync(site, ct).ConfigureAwait(false);
+                try
+                {
+                    var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+                    _lastRequestAt[site] = DateTime.UtcNow;
+                    return result;
+                }
+                catch (HttpRequestException ex) when (attempt < maxAttempts && IsTransient(ex) && !ct.IsCancellationRequested)
+                {
+                    // リトライ予定の失敗も「サーバへ実際に投げた」扱いにし、次の試行まで
+                    // request_delay_ms を尊重する（礼儀+連続失敗時の負荷抑制）。
+                    _lastRequestAt[site] = DateTime.UtcNow;
+                    LogHelper.Warn(nameof(NetworkPolicyService),
+                        $"Transient failure [{site}] {url} (attempt {attempt}/{maxAttempts}): {ex.Message}");
+                    await Task.Delay(retryDelayMs, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _lastRequestAt[site] = DateTime.UtcNow;
+                    LogRequestFailure(site, url, ex);
+                    throw;
+                }
             }
         }
         finally
         {
             gate.Release();
         }
+    }
+
+    // 4xx クライアントエラーは恒久的なので再試行不要。
+    // ステータスなし（DNS/SSL/ソケット層の失敗）と 5xx/408/429 は transient とみなす。
+    private static bool IsTransient(HttpRequestException ex)
+    {
+        if (ex.StatusCode is { } code)
+        {
+            var n = (int)code;
+            return n >= 500 || n == 408 || n == 429;
+        }
+        return true;
     }
 
     // HttpRequestException.Message が "Connection failure" 等の抽象的な文字列だけだと

--- a/_Apps/Services/Network/NetworkPolicyService.cs
+++ b/_Apps/Services/Network/NetworkPolicyService.cs
@@ -15,6 +15,9 @@ namespace LanobeReader.Services.Network;
 /// </summary>
 public class NetworkPolicyService
 {
+    private const int MaxAttempts = 3;
+    private const int RetryDelayMs = 500;
+
     private readonly HttpClient _httpClient;
     private readonly AppSettingsRepository _settingsRepo;
 
@@ -85,14 +88,12 @@ public class NetworkPolicyService
     /// <summary>
     /// 指定サイトに対して HTTP GET（文字列）を発行。直列化＋ディレイが自動で適用される。
     /// transient な HttpRequestException（SSL ストリーム破損 / 5xx / 408 / 429 等）は
-    /// 最大 2 回リトライする（合計 3 回試行・500ms バックオフ）。
+    /// 最大 2 回リトライする（合計 3 回試行）。試行間は最小 500ms 待機し、さらに
+    /// サイト別 request_delay_ms を尊重するため実効的な間隔はそれより長くなることがある。
     /// 4xx クライアントエラー、TaskCanceledException、外部 ct のキャンセル要求はリトライしない。
     /// </summary>
     public async Task<string> GetStringAsync(SiteType site, string url, CancellationToken ct = default)
     {
-        const int maxAttempts = 3;
-        const int retryDelayMs = 500;
-
         var gate = _siteGates[site];
         await gate.WaitAsync(ct).ConfigureAwait(false);
         try
@@ -106,14 +107,19 @@ public class NetworkPolicyService
                     _lastRequestAt[site] = DateTime.UtcNow;
                     return result;
                 }
-                catch (HttpRequestException ex) when (attempt < maxAttempts && IsTransient(ex) && !ct.IsCancellationRequested)
+                catch (HttpRequestException ex) when (attempt < MaxAttempts && IsTransient(ex) && !ct.IsCancellationRequested)
                 {
                     // リトライ予定の失敗も「サーバへ実際に投げた」扱いにし、次の試行まで
                     // request_delay_ms を尊重する（礼儀+連続失敗時の負荷抑制）。
                     _lastRequestAt[site] = DateTime.UtcNow;
                     LogHelper.Warn(nameof(NetworkPolicyService),
-                        $"Transient failure [{site}] {url} (attempt {attempt}/{maxAttempts}): {ex.Message}");
-                    await Task.Delay(retryDelayMs, ct).ConfigureAwait(false);
+                        $"Transient failure [{site}] {url} (attempt {attempt}/{MaxAttempts}): {ex.Message}");
+                    await Task.Delay(RetryDelayMs, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // ユーザ操作等によるキャンセルは異常ではないのでスタック付き ERROR を出さない。
+                    throw;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## 背景

更新ボタン押下時に「一部のタイトルで更新チェックに失敗しました」が表示された。logcat を確認したところ、なろう「ティアムーン帝国物語」の TOC ページネーション中 (`https://ncode.syosetu.com/n8920ex/?p=11`) でレスポンス本文の読み取り中に SSL レコード復号失敗が発生していた:

```
[NetworkPolicyService] ERROR: Request failed [Narou] https://ncode.syosetu.com/n8920ex/?p=11
[0] System.Net.Http.HttpRequestException: Error while copying content to a stream.
[1] System.IO.IOException: Read error: ssl=...: Failure in SSL library, usually a protocol error
    error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT
    error:1000008b:SSL routines:OPENSSL_internal:DECRYPTION_FAILED_OR_BAD_RECORD_MAC
[2] Javax.Net.Ssl.SSLProtocolException: ...
[UpdateCheckService] WARN: Failed to check ティアムーン帝国物語: Error while copying content to a stream.
```

1593 話を約 16 ページに分割して取得する途中で 1 回 SSL ストリームが壊れただけで、`UpdateCheckService` の catch (`HttpRequestException or TaskCanceledException`) に拾われて `HasCheckError = true` になり、タイトル丸ごと失敗扱いになっていた。`NetworkPolicyService.GetStringAsync` にリトライが入っていないのが本質原因。

## 変更内容

[_Apps/Services/Network/NetworkPolicyService.cs](_Apps/Services/Network/NetworkPolicyService.cs) の `GetStringAsync` を for ループ化:

- transient な `HttpRequestException` を最大 2 回リトライ（合計 3 回試行・500ms バックオフ）
- transient の判定:
  - `StatusCode` 無し（DNS / SSL / ソケット層失敗）→ transient
  - 5xx / 408 / 429 → transient
  - 4xx クライアントエラー → 非 transient（恒久エラー、即失敗）
- `TaskCanceledException` および外部 `ct.IsCancellationRequested` はリトライしない
- リトライ間でも `_lastRequestAt` を更新し、サイト別 `request_delay_ms` を維持（サーバ礼儀 + 連続失敗時の負荷抑制）
- 中間失敗は 1 行 WARN、最終失敗は従来通り `LogRequestFailure` で詳細スタック付き ERROR

影響範囲: `NetworkPolicyService.GetStringAsync` を経由する全パス（更新チェック / Prefetch / 検索 / ランキング / 本文取得）。

## 試験計画

- [x] `dotnet build _Apps/App.sln` 成功（0 errors / 0 warnings）
- [x] エミュレータで「更新」を押し、両タイトル成功 → 警告バナーが消えること
- [ ] 試行中に意図的にネットを切ってリトライ WARN ログが出ることを確認
- [ ] 復旧後の試行で正常完了すること
- [ ] 4xx を返すケース（存在しない novelId 等）で即失敗してリトライしないこと