### PR TITLE
feat: Android MAUI 共通基盤ライブラリ TBird.Maui.* を追加

### DIFF
--- a/TBird.Maui.Background/BackgroundJobBase.cs
+++ b/TBird.Maui.Background/BackgroundJobBase.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace TBird.Maui.Background;
+
+/// <summary>
+/// バックグラウンドジョブ基底。ジョブ種別ごとに派生する。
+/// 優先度は <see cref="PriorityJobQueue{TJob, TKey}.EnqueueAsync"/> の第二引数で渡す設計のため、
+/// このクラス自体は Priority プロパティを持たない（二重管理を避けるため）。
+/// </summary>
+public abstract class BackgroundJobBase
+{
+    public DateTime EnqueuedAt { get; } = DateTime.UtcNow;
+    public abstract string Description { get; }
+}

--- a/TBird.Maui.Background/INetworkPolicy.cs
+++ b/TBird.Maui.Background/INetworkPolicy.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace TBird.Maui.Background;
+
+/// <summary>
+/// ネットワーク接続ポリシーの抽象。
+/// <see cref="PriorityJobQueue{TJob, TKey}"/> 内部の WiFi ゲート判定とイベント購読に使う。
+///
+/// 【境界規約】当面は PriorityJobQueue 内部の DI 接合専用とし、アプリ層 (Repository /
+/// Service / ViewModel) が INetworkPolicy を直接コンストラクタ DI で受け取ることは禁止
+/// （具象 NetworkPolicyService 経由のみ）。
+/// </summary>
+public interface INetworkPolicy
+{
+    bool IsOnline { get; }
+    bool IsWifiConnected { get; }
+
+    event EventHandler? WifiConnected;
+    event EventHandler? WifiDisconnected;
+}

--- a/TBird.Maui.Background/JobPriority.cs
+++ b/TBird.Maui.Background/JobPriority.cs
@@ -1,0 +1,11 @@
+namespace TBird.Maui.Background;
+
+/// <summary>
+/// <see cref="PriorityJobQueue{TJob, TKey}"/> でジョブの優先度を指定する。
+/// 段階は High / Normal の 2 つのみ（現行 BackgroundJobQueue 仕様の踏襲）。
+/// </summary>
+public enum JobPriority
+{
+    Normal = 0,
+    High = 1,
+}

--- a/TBird.Maui.Background/MauiNetworkPolicy.cs
+++ b/TBird.Maui.Background/MauiNetworkPolicy.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.Maui.Networking;
+using TBird.Core;
+
+namespace TBird.Maui.Background;
+
+// [DI-LIFETIME: SINGLETON]
+// AddTransient/AddScoped causes ConnectivityChanged handler leak because
+// this class subscribes in the ctor without unsubscribe (no IDisposable).
+/// <summary>
+/// <see cref="INetworkPolicy"/> を Microsoft.Maui.Networking.Connectivity で実装する。
+///
+/// 【ライフタイム】Singleton 前提。コンストラクタで Connectivity.ConnectivityChanged を
+/// 購読し、解除コードは持たない（プロセス終了時の GC に委ねる）。
+/// AddTransient / AddScoped 登録は禁止（ハンドラリーク）。
+///
+/// 例外ガードを維持: MAUI Essentials が MainActivity 初期化前に呼ばれるケースや一部 Android
+/// 端末で Connectivity.Current が例外を投げる事象への防御として、購読・getter を try-catch
+/// で囲む。リファクタの「クリーンアップ」名目で削ってはならない（起動時クラッシュ防止）。
+/// </summary>
+public class MauiNetworkPolicy : INetworkPolicy
+{
+    public MauiNetworkPolicy()
+    {
+        try
+        {
+            Connectivity.ConnectivityChanged += OnConnectivityChanged;
+        }
+        catch (Exception ex)
+        {
+            MessageService.Warn($"Failed to hook ConnectivityChanged: {ex.Message}");
+        }
+    }
+
+    public event EventHandler? WifiConnected;
+    public event EventHandler? WifiDisconnected;
+
+    public bool IsOnline
+    {
+        get
+        {
+            try { return Connectivity.Current.NetworkAccess == NetworkAccess.Internet; }
+            catch (Exception ex)
+            {
+                MessageService.Warn($"IsOnline check failed: {ex.Message}");
+                return false;
+            }
+        }
+    }
+
+    public bool IsWifiConnected
+    {
+        get
+        {
+            try
+            {
+                return Connectivity.Current.NetworkAccess == NetworkAccess.Internet
+                    && Connectivity.Current.ConnectionProfiles.Contains(ConnectionProfile.WiFi);
+            }
+            catch { return false; }
+        }
+    }
+
+    private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
+    {
+        var isWifi = e.NetworkAccess == NetworkAccess.Internet
+            && e.ConnectionProfiles.Contains(ConnectionProfile.WiFi);
+        if (isWifi) WifiConnected?.Invoke(this, EventArgs.Empty);
+        else WifiDisconnected?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/TBird.Maui.Background/PriorityJobQueue.cs
+++ b/TBird.Maui.Background/PriorityJobQueue.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TBird.Core;
+
+namespace TBird.Maui.Background;
+
+// [DI-LIFETIME: SINGLETON]
+// AddTransient/AddScoped causes WiFi handler leak because
+// this class subscribes to INetworkPolicy in the ctor without unsubscribe (no IDisposable).
+/// <summary>
+/// インプロセスの優先度付きバックグラウンドジョブキュー。
+///
+/// - Wi-Fi 接続時のみ稼働、切断で自動停止、再接続でレジューム
+/// - <c>isEnabled</c> delegate による設定 OFF 時の drop
+/// - High / Normal の 2 本キューで優先度を扱う（priority aging はしない）
+/// - 同一 <typeparamref name="TKey"/> の重複 enqueue を dedup
+/// - 連続失敗で同セッションのワーカーをブレーカー停止
+/// - バッチクールダウン（一定数処理ごとに sleep）
+///
+/// dedup HashSet と 2 本キューの Enqueue は同一 lock 内で完結させ、
+/// StopWorker / SyncEnqueuedIdsFromQueues との race を避ける設計。
+/// </summary>
+/// <typeparam name="TJob">ジョブ型（<see cref="BackgroundJobBase"/> 派生）</typeparam>
+/// <typeparam name="TKey">dedup キー型（例: int の episode id）</typeparam>
+public class PriorityJobQueue<TJob, TKey>
+    where TJob : BackgroundJobBase
+    where TKey : notnull
+{
+    private readonly ConcurrentQueue<TJob> _highPriority = new();
+    private readonly ConcurrentQueue<TJob> _normalPriority = new();
+    private readonly HashSet<TKey> _dedupSet;
+    private readonly INetworkPolicy _networkPolicy;
+    private readonly Func<TJob, TKey> _keySelector;
+    private readonly Func<TJob, CancellationToken, Task> _processor;
+    private readonly Func<Task<bool>> _isEnabled;
+    private readonly int _batchCooldownThreshold;
+    private readonly int _cooldownDelayMs;
+    private readonly int _maxConsecutiveFailures;
+
+    private readonly object _startLock = new();
+    private CancellationTokenSource? _workerCts;
+    private Task? _workerTask;
+    private int _consecutiveFailures;
+
+    public PriorityJobQueue(
+        INetworkPolicy networkPolicy,
+        Func<TJob, TKey> keySelector,
+        Func<TJob, CancellationToken, Task> processor,
+        Func<Task<bool>> isEnabled,
+        IEqualityComparer<TKey>? keyComparer = null,
+        int batchCooldownThreshold = 200,
+        int cooldownDelayMs = 5000,
+        int maxConsecutiveFailures = 5)
+    {
+        _networkPolicy = networkPolicy;
+        _keySelector = keySelector;
+        _processor = processor;
+        _isEnabled = isEnabled;
+        _dedupSet = keyComparer is null ? new HashSet<TKey>() : new HashSet<TKey>(keyComparer);
+        _batchCooldownThreshold = batchCooldownThreshold;
+        _cooldownDelayMs = cooldownDelayMs;
+        _maxConsecutiveFailures = maxConsecutiveFailures;
+
+        _networkPolicy.WifiConnected += (_, _) => EnsureWorkerStarted();
+        _networkPolicy.WifiDisconnected += (_, _) => StopWorker();
+    }
+
+    public int PendingCount => _highPriority.Count + _normalPriority.Count;
+
+    /// <summary>
+    /// 戻り値:
+    ///   - false: isEnabled=false で drop
+    ///   - false: dedup HashSet 重複で drop
+    ///   - true:  実際にキューに積まれた
+    /// </summary>
+    public async Task<bool> EnqueueAsync(TJob job, JobPriority priority = JobPriority.Normal)
+    {
+        // 設定 OFF なら drop（HashSet には触れない）
+        var enabled = await _isEnabled().ConfigureAwait(false);
+        if (!enabled) return false;
+
+        // dedup Add と Enqueue を同一 lock 内で完結させる（race-free 規約）
+        lock (_dedupSet)
+        {
+            if (!_dedupSet.Add(_keySelector(job))) return false;
+            var queue = priority == JobPriority.High ? _highPriority : _normalPriority;
+            queue.Enqueue(job);
+        }
+
+        // EnsureWorkerStarted は別 lock (_startLock) を取るため、_dedupSet lock を抜けてから呼ぶ。
+        EnsureWorkerStarted();
+        return true;
+    }
+
+    public void EnsureWorkerStarted()
+    {
+        lock (_startLock)
+        {
+            if (_workerTask is not null && !_workerTask.IsCompleted) return;
+            if (!_networkPolicy.IsWifiConnected) return;
+            if (PendingCount == 0) return;
+
+            _workerCts?.Dispose();
+            _workerCts = new CancellationTokenSource();
+            var ct = _workerCts.Token;
+            _workerTask = Task.Run(() => WorkerLoopAsync(ct));
+        }
+    }
+
+    public void StopWorker()
+    {
+        CancellationTokenSource? oldCts;
+        Task? oldTask;
+        lock (_startLock)
+        {
+            oldCts = _workerCts;
+            oldTask = _workerTask;
+            _workerCts = null;
+            _workerTask = null;
+        }
+        if (oldCts is null) return;
+        try { oldCts.Cancel(); }
+        catch (ObjectDisposedException) { return; }
+
+        // キューに残っている job の dedup HashSet を再開可能な状態に戻す。
+        // キュー本体は消さない（Wi-Fi 復帰時にそのまま再消費される）。
+        SyncEnqueuedIdsFromQueues();
+
+        if (oldTask is not null)
+        {
+            // ワーカー完了を待ってから Dispose（Cancel 直後の ObjectDisposedException 回避）
+            _ = oldTask.ContinueWith(_ => oldCts.Dispose(), TaskScheduler.Default);
+        }
+        else
+        {
+            oldCts.Dispose();
+        }
+    }
+
+    private void SyncEnqueuedIdsFromQueues()
+    {
+        // ConcurrentQueue.GetEnumerator はスナップショット。
+        // EnqueueAsync が _dedupSet.Add と Queue.Enqueue を同一 lock 内で完結させているため、
+        // 本メソッドが lock を取った時点で Queue 列挙の結果は HashSet と整合している
+        // (HashSet に居るが Queue に未追加という中間状態は存在しない)。
+        lock (_dedupSet)
+        {
+            var live = _dedupSet.Comparer is null
+                ? new HashSet<TKey>()
+                : new HashSet<TKey>(_dedupSet.Comparer);
+            foreach (var j in _highPriority) live.Add(_keySelector(j));
+            foreach (var j in _normalPriority) live.Add(_keySelector(j));
+            _dedupSet.Clear();
+            foreach (var id in live) _dedupSet.Add(id);
+        }
+    }
+
+    private async Task WorkerLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            // 二重ゲート (1): ループ開始時に isEnabled を再評価
+            // （EnqueueAsync 時点では enabled だったが、ワーカー実行待ちのうちに設定 OFF に
+            //   変更された場合に、キューに残った job が消化されないようにする）
+            var enabled = await _isEnabled().ConfigureAwait(false);
+            if (!enabled)
+            {
+                MessageService.Info("Job processing disabled by setting");
+                return;
+            }
+
+            _consecutiveFailures = 0;
+            int batchCount = 0;
+
+            while (!ct.IsCancellationRequested)
+            {
+                // 二重ゲート (2): 各イテレーション冒頭で WiFi 接続を check
+                // （ConnectivityChanged イベント遅延発火への防御）
+                if (!_networkPolicy.IsWifiConnected)
+                {
+                    MessageService.Info("Wi-Fi disconnected, stopping");
+                    break;
+                }
+
+                if (!TryDequeue(out var job))
+                {
+                    break;
+                }
+
+                try
+                {
+                    await ProcessJobAsync(job!, ct).ConfigureAwait(false);
+                    _consecutiveFailures = 0;
+                    batchCount++;
+
+                    if (batchCount % _batchCooldownThreshold == 0)
+                    {
+                        await Task.Delay(_cooldownDelayMs, ct).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // 正常なキャンセル経路。連続失敗カウントを上げずに break。
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _consecutiveFailures++;
+                    MessageService.Warn($"Job failed ({_consecutiveFailures}): {ex.Message}");
+                    if (_consecutiveFailures >= _maxConsecutiveFailures)
+                    {
+                        MessageService.Warn("Too many consecutive failures, aborting");
+                        break;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageService.Error($"Worker loop crashed: {ex.Message}");
+        }
+    }
+
+    private bool TryDequeue(out TJob? job)
+    {
+        if (_highPriority.TryDequeue(out job)) return true;
+        if (_normalPriority.TryDequeue(out job)) return true;
+        job = null;
+        return false;
+    }
+
+    private async Task ProcessJobAsync(TJob job, CancellationToken ct)
+    {
+        try
+        {
+            await _processor(job, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_dedupSet) { _dedupSet.Remove(_keySelector(job)); }
+        }
+    }
+}

--- a/TBird.Maui.Background/SiteRateLimiter.cs
+++ b/TBird.Maui.Background/SiteRateLimiter.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TBird.Core;
+using TBird.Maui.Web;
+
+namespace TBird.Maui.Background;
+
+/// <summary>
+/// サイト別の HTTP GET 発行を直列化＋ディレイ＋transient リトライでゲートする共通サービス。
+///
+/// - 同一 siteKey へのリクエストは <see cref="SemaphoreSlim"/>(1,1) で直列化
+/// - リクエスト間は <c>getDelayMs</c> delegate で取得するディレイを挿入
+///   （リトライ予定の失敗も「サーバへ実際に投げた」扱いにし、次の試行まで同ディレイを尊重）
+/// - transient な <see cref="HttpRequestException"/> (5xx / 408 / 429 / ステータスなし) は
+///   最大 <c>maxAttempts</c> 回試行
+/// - 4xx クライアントエラー、TaskCanceledException、ct のキャンセル要求はリトライしない
+///
+/// 内部の <c>_siteGates</c> / <c>_lastRequestAt</c> はコンストラクタ受領の siteKeys 全要素で
+/// 事前初期化。未登録キーは <see cref="ArgumentException"/> で fail-fast（KeyNotFoundException
+/// より DI/初期化漏れの原因が分かりやすい）。
+/// </summary>
+public sealed class SiteRateLimiter
+{
+    private readonly HttpClient _httpClient;
+    private readonly Dictionary<string, SemaphoreSlim> _siteGates;
+    private readonly ConcurrentDictionary<string, DateTime> _lastRequestAt;
+    private readonly Func<Task<int>> _getDelayMs;
+    private readonly int _maxAttempts;
+    private readonly int _retryDelayMs;
+
+    public SiteRateLimiter(
+        HttpClient httpClient,
+        IEnumerable<string> siteKeys,
+        Func<Task<int>> getDelayMs,
+        int maxAttempts = 3,
+        int retryDelayMs = 500)
+    {
+        _httpClient = httpClient;
+        _getDelayMs = getDelayMs;
+        _maxAttempts = maxAttempts;
+        _retryDelayMs = retryDelayMs;
+        _siteGates = new Dictionary<string, SemaphoreSlim>();
+        _lastRequestAt = new ConcurrentDictionary<string, DateTime>();
+        foreach (var key in siteKeys)
+        {
+            _siteGates[key] = new SemaphoreSlim(1, 1);
+            _lastRequestAt[key] = DateTime.MinValue;
+        }
+    }
+
+    public async Task<string> GetStringAsync(string siteKey, string url, CancellationToken ct = default)
+    {
+        if (!_siteGates.TryGetValue(siteKey, out var gate))
+        {
+            throw new ArgumentException(
+                $"Unknown siteKey '{siteKey}'. Constructor must be initialized with all expected site keys.",
+                nameof(siteKey));
+        }
+
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            for (int attempt = 1; ; attempt++)
+            {
+                await EnforceDelayAsync(siteKey, ct).ConfigureAwait(false);
+                try
+                {
+                    var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+                    _lastRequestAt[siteKey] = DateTime.UtcNow;
+                    return result;
+                }
+                catch (HttpRequestException ex) when (attempt < _maxAttempts && TransientHttpErrorHelper.IsTransient(ex) && !ct.IsCancellationRequested)
+                {
+                    // リトライ予定の失敗も「サーバへ実際に投げた」扱いにし、次の試行まで
+                    // request_delay_ms を尊重する（礼儀+連続失敗時の負荷抑制）。
+                    _lastRequestAt[siteKey] = DateTime.UtcNow;
+                    MessageService.Warn(
+                        $"Transient failure [{siteKey}] {url} (attempt {attempt}/{_maxAttempts}): {ex.Message}");
+                    await Task.Delay(_retryDelayMs, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // ユーザ操作等によるキャンセルは異常ではないのでスタック付き ERROR を出さない。
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _lastRequestAt[siteKey] = DateTime.UtcNow;
+                    HttpRequestFailureLogger.Log(siteKey, url, ex);
+                    throw;
+                }
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task EnforceDelayAsync(string siteKey, CancellationToken ct)
+    {
+        var delayMs = await _getDelayMs().ConfigureAwait(false);
+        var last = _lastRequestAt[siteKey];
+        if (last == DateTime.MinValue) return;
+
+        var elapsed = (DateTime.UtcNow - last).TotalMilliseconds;
+        var remaining = delayMs - elapsed;
+        if (remaining > 0)
+        {
+            await Task.Delay((int)remaining, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/TBird.Maui.Background/TBird.Maui.Background.csproj
+++ b/TBird.Maui.Background/TBird.Maui.Background.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
+    <!-- UseMauiEssentials=true は MA002 警告対策のため明示的 PackageReference と併用。
+         .NET 8 以降は UseMauiEssentials の自動 PackageReference 注入が廃止されたため。 -->
+    <UseMauiEssentials>true</UseMauiEssentials>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="9.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TBird.Core\TBird.Core.csproj" />
+    <!-- SiteRateLimiter が非 transient 失敗時に Web.HttpRequestFailureLogger を呼ぶため参照。
+         Web (net8.0) → Background (net9.0-android) の片方向参照で循環なし。 -->
+    <ProjectReference Include="..\TBird.Maui.Web\TBird.Maui.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TBird.Maui.DB/IMigration.cs
+++ b/TBird.Maui.DB/IMigration.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using SQLite;
+
+namespace TBird.Maui.DB;
+
+/// <summary>
+/// スキーマ migration の最小インタフェース。
+/// FromVersion はこの migration が想定する開始バージョン
+/// （実行することで DB が FromVersion → FromVersion + 1 に上がる）。
+/// 実装は冪等であること（CREATE INDEX IF NOT EXISTS / DROP INDEX IF EXISTS /
+/// INSERT OR IGNORE / WHERE 句限定 DELETE 等）。
+/// </summary>
+public interface IMigration
+{
+    int FromVersion { get; }
+    Task ExecuteAsync(SQLiteAsyncConnection conn);
+}

--- a/TBird.Maui.DB/SqliteDatabaseBase.cs
+++ b/TBird.Maui.DB/SqliteDatabaseBase.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using SQLite;
+using TBird.Core;
+
+namespace TBird.Maui.DB;
+
+/// <summary>
+/// SQLite (sqlite-net-pcl) を使う MAUI アプリ向けの DB 基底クラス。
+///
+/// 派生クラスは以下を実装する:
+///   - <see cref="CreateTablesAsync"/> (必須): テーブル作成 + 既存カラム追加 + INDEX 再適用
+///   - <see cref="SeedAsync"/> (任意): 既定値シード（既存値を上書きしないこと）
+///   - <see cref="GetMigrations"/> (任意): IMigration 配列を FromVersion 昇順で返す
+///   - <see cref="ReadSchemaVersionAsync"/> / <see cref="WriteSchemaVersionAsync"/> (必須):
+///     スキーマバージョンの永続化先（既存ユーザ DB との互換性確保のため abstract）
+///
+/// 接続オブジェクトは <see cref="Connection"/> から常に非 null・同期アクセス可能。
+/// 初期化前後のチェックや例外スローは行わない（Repository の DI 構築時クラッシュ防止）。
+/// スキーマ準備の保証は呼出側が <see cref="EnsureInitializedAsync"/> をクエリ前に呼ぶ規約とする。
+/// </summary>
+public abstract class SqliteDatabaseBase
+{
+    private readonly SQLiteAsyncConnection _connection;
+    private readonly int _currentSchemaVersion;
+    private Task? _initTask;
+    private readonly object _initLock = new();
+
+    /// <summary>
+    /// </summary>
+    /// <param name="dbPath">SQLite ファイルの絶対パス（呼び出し側で FileSystem.AppDataDirectory 等から構築）</param>
+    /// <param name="currentSchemaVersion">最新のスキーマバージョン</param>
+    protected SqliteDatabaseBase(string dbPath, int currentSchemaVersion)
+    {
+        _connection = new SQLiteAsyncConnection(dbPath);
+        _currentSchemaVersion = currentSchemaVersion;
+    }
+
+    /// <summary>常に非 null。コンストラクタ生成時点で同期アクセス可能（例外スローしない）。</summary>
+    public SQLiteAsyncConnection Connection => _connection;
+
+    /// <summary>
+    /// 初回のみ実際の初期化を行う。複数箇所から呼ばれても 1 回しか走らない。
+    /// クエリ実行前に必ず呼び出すこと。
+    /// </summary>
+    public Task EnsureInitializedAsync()
+    {
+        lock (_initLock)
+        {
+            return _initTask ??= InitializeInternalAsync();
+        }
+    }
+
+    private async Task InitializeInternalAsync()
+    {
+        // 1. テーブル作成 + 既存カラム追加 + INDEX 再適用を派生に委譲
+        await CreateTablesAsync(_connection).ConfigureAwait(false);
+
+        // 2. 既定設定のシード（既存値は上書きしない冪等実装が派生側の責務）
+        await SeedAsync(_connection).ConfigureAwait(false);
+
+        // 3. スキーマバージョンを読み、必要な migration を順次適用
+        var currentVersion = await ReadSchemaVersionAsync(_connection).ConfigureAwait(false);
+        if (currentVersion < _currentSchemaVersion)
+        {
+            MessageService.Info($"Schema migration: v{currentVersion} -> v{_currentSchemaVersion}");
+            try
+            {
+                foreach (var migration in GetMigrations().Where(m => m.FromVersion >= currentVersion))
+                {
+                    await migration.ExecuteAsync(_connection).ConfigureAwait(false);
+                }
+                // 全 migration 成功時のみ SetSchemaVersion を 1 回呼ぶ。
+                // 途中失敗時は次回起動で再試行される（migration は冪等規約）。
+                await WriteSchemaVersionAsync(_connection, _currentSchemaVersion).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                MessageService.Warn($"Schema migration failed, will retry next launch: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// CreateTableAsync 呼び出し + EnsureColumnAsync による既存カラム追加 + INDEX 再適用を行う。
+    /// 初回 (テーブル無) でもアプリ起動するため、冪等な書き方とすること。
+    /// </summary>
+    protected abstract Task CreateTablesAsync(SQLiteAsyncConnection conn);
+
+    /// <summary>
+    /// 既定値シード。既存ユーザ DB を壊さないため、FindAsync で存在チェックしてから
+    /// InsertAsync する規約（InsertOrReplace は禁止）。デフォルトでは何もしない。
+    /// </summary>
+    protected virtual Task SeedAsync(SQLiteAsyncConnection conn) => Task.CompletedTask;
+
+    /// <summary>
+    /// migration 定義。FromVersion 昇順で返す責務は派生側にある。
+    /// デフォルトでは空配列を返す（v1 から動かないシンプル DB は override 不要）。
+    /// </summary>
+    protected virtual IReadOnlyList<IMigration> GetMigrations() => Array.Empty<IMigration>();
+
+    /// <summary>
+    /// 現在の DB のスキーマバージョンを返す。無レコード時は 1 を返すこと
+    /// （0 や currentSchemaVersion を返すと既存挙動と乖離する）。
+    /// </summary>
+    protected abstract Task<int> ReadSchemaVersionAsync(SQLiteAsyncConnection conn);
+
+    /// <summary>
+    /// スキーマバージョンを永続化する。
+    /// </summary>
+    protected abstract Task WriteSchemaVersionAsync(SQLiteAsyncConnection conn, int version);
+
+    /// <summary>
+    /// PRAGMA table_info で既存カラムの有無を確認し、未存在なら ALTER TABLE ADD COLUMN を実行する。
+    /// </summary>
+    protected async Task EnsureColumnAsync(SQLiteAsyncConnection conn, string table, string column, string ddlSuffix)
+    {
+        try
+        {
+            var cols = await conn.QueryAsync<PragmaColumnInfo>($"PRAGMA table_info({table})").ConfigureAwait(false);
+            if (cols.Any(c => string.Equals(c.name, column, StringComparison.OrdinalIgnoreCase))) return;
+            await conn.ExecuteAsync($"ALTER TABLE {table} ADD COLUMN {column} {ddlSuffix}").ConfigureAwait(false);
+            MessageService.Info($"Added column {table}.{column}");
+        }
+        catch (Exception ex)
+        {
+            MessageService.Warn($"EnsureColumnAsync {table}.{column} failed: {ex.Message}");
+        }
+    }
+
+    private class PragmaColumnInfo
+    {
+        public int cid { get; set; }
+        public string name { get; set; } = string.Empty;
+        public string type { get; set; } = string.Empty;
+        public int notnull { get; set; }
+        public string? dflt_value { get; set; }
+        public int pk { get; set; }
+    }
+}

--- a/TBird.Maui.DB/TBird.Maui.DB.csproj
+++ b/TBird.Maui.DB/TBird.Maui.DB.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="sqlite-net-pcl" Version="1.*" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TBird.Core\TBird.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TBird.Maui.Web/AngleSharpHelper.cs
+++ b/TBird.Maui.Web/AngleSharpHelper.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace TBird.Maui.Web;
+
+/// <summary>
+/// AngleSharp の Configuration / BrowsingContext / OpenAsync 3 行パターンを集約するヘルパ。
+/// 呼出側は <c>var doc = await AngleSharpHelper.ParseAsync(html, ct);</c> で済む。
+/// </summary>
+public static class AngleSharpHelper
+{
+    public static async Task<IDocument> ParseAsync(string html, CancellationToken ct = default)
+    {
+        var config = Configuration.Default;
+        var context = BrowsingContext.New(config);
+        return await context.OpenAsync(req => req.Content(html), ct).ConfigureAwait(false);
+    }
+}

--- a/TBird.Maui.Web/HttpRequestFailureLogger.cs
+++ b/TBird.Maui.Web/HttpRequestFailureLogger.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Text;
+using TBird.Core;
+
+namespace TBird.Maui.Web;
+
+/// <summary>
+/// HTTP リクエスト失敗時の詳細ログ出力。
+/// <see cref="System.Net.Http.HttpRequestException"/> の Message が "Connection failure" 等の
+/// 抽象的な文字列だけだと Android 側の真の原因 (UnknownHostException / SSLHandshakeException /
+/// EOFException 等) が見えないため、InnerException チェーンを最大 5 段まで吐く。
+/// </summary>
+public static class HttpRequestFailureLogger
+{
+    public static void Log(string siteKey, string url, Exception ex)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Request failed [").Append(siteKey).Append("] ").AppendLine(url);
+        var cur = ex;
+        int depth = 0;
+        while (cur is not null && depth < 5)
+        {
+            sb.Append("  [").Append(depth).Append("] ")
+              .Append(cur.GetType().FullName).Append(": ").AppendLine(cur.Message);
+            cur = cur.InnerException;
+            depth++;
+        }
+        var st = ex.StackTrace;
+        if (!string.IsNullOrEmpty(st))
+        {
+            sb.AppendLine("  Stack (top 3):");
+            var lines = st.Split('\n');
+            for (int i = 0; i < System.Math.Min(3, lines.Length); i++)
+            {
+                sb.Append("    ").AppendLine(lines[i].TrimEnd());
+            }
+        }
+        MessageService.Error(sb.ToString());
+    }
+}

--- a/TBird.Maui.Web/TBird.Maui.Web.csproj
+++ b/TBird.Maui.Web/TBird.Maui.Web.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- net8.0 を採用: TransientHttpErrorHelper.IsTransient が HttpRequestException.StatusCode
+         を参照するため netstandard2.0 不可（StatusCode は .NET 5.0+）。消費側 (LanobeReader /
+         TBird.Maui.Background) はいずれも net9.0-android のため downward 互換 OK。 -->
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TBird.Core\TBird.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TBird.Maui.Web/TransientHttpErrorHelper.cs
+++ b/TBird.Maui.Web/TransientHttpErrorHelper.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+
+namespace TBird.Maui.Web;
+
+/// <summary>
+/// HTTP リクエスト失敗の transient/非 transient 判定。
+/// 4xx クライアントエラーは恒久的（リトライ不要）、5xx / 408 / 429 とステータスなし
+/// （DNS / SSL / ソケット層の失敗）は transient とみなす。
+/// </summary>
+public static class TransientHttpErrorHelper
+{
+    public static bool IsTransient(HttpRequestException ex)
+    {
+        if (ex.StatusCode is { } code)
+        {
+            var n = (int)code;
+            return n >= 500 || n == 408 || n == 429;
+        }
+        return true;
+    }
+}

--- a/TBird.Maui.sln
+++ b/TBird.Maui.sln
@@ -1,0 +1,90 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TBird.Core", "TBird.Core\TBird.Core.csproj", "{EB08A2A3-FF77-4944-8478-8D742215908C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TBird.Maui", "TBird.Maui\TBird.Maui.csproj", "{B9874623-1F73-413A-9BA7-C2971DB9DBB7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TBird.Maui.DB", "TBird.Maui.DB\TBird.Maui.DB.csproj", "{86ED25CE-1619-4346-B91F-8CB6E7CD938A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TBird.Maui.Background", "TBird.Maui.Background\TBird.Maui.Background.csproj", "{493039DD-FF5C-4C11-8C3D-6588D01F08C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TBird.Maui.Web", "TBird.Maui.Web\TBird.Maui.Web.csproj", "{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Release|x64.Build.0 = Release|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB08A2A3-FF77-4944-8478-8D742215908C}.Release|x86.Build.0 = Release|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Debug|x64.Build.0 = Debug|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Debug|x86.Build.0 = Debug|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Release|x64.ActiveCfg = Release|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Release|x64.Build.0 = Release|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Release|x86.ActiveCfg = Release|Any CPU
+		{B9874623-1F73-413A-9BA7-C2971DB9DBB7}.Release|x86.Build.0 = Release|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Debug|x64.Build.0 = Debug|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Debug|x86.Build.0 = Debug|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Release|x64.ActiveCfg = Release|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Release|x64.Build.0 = Release|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Release|x86.ActiveCfg = Release|Any CPU
+		{86ED25CE-1619-4346-B91F-8CB6E7CD938A}.Release|x86.Build.0 = Release|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Debug|x64.Build.0 = Debug|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Debug|x86.Build.0 = Debug|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Release|x64.ActiveCfg = Release|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Release|x64.Build.0 = Release|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Release|x86.ActiveCfg = Release|Any CPU
+		{493039DD-FF5C-4C11-8C3D-6588D01F08C9}.Release|x86.Build.0 = Release|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Release|x64.Build.0 = Release|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC730E5B-3F88-4AE8-B4B3-8102EF898E96}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/TBird.Maui/Converters/BoolToColorConverter.cs
+++ b/TBird.Maui/Converters/BoolToColorConverter.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+
+namespace TBird.Maui.Converters;
+
+public class BoolToColorConverter : BindableObject, IValueConverter
+{
+    public static readonly BindableProperty TrueColorProperty =
+        BindableProperty.Create(nameof(TrueColor), typeof(Color), typeof(BoolToColorConverter), Colors.Black);
+
+    public static readonly BindableProperty FalseColorProperty =
+        BindableProperty.Create(nameof(FalseColor), typeof(Color), typeof(BoolToColorConverter), Colors.Gray);
+
+    public Color TrueColor
+    {
+        get => (Color)GetValue(TrueColorProperty);
+        set => SetValue(TrueColorProperty, value);
+    }
+
+    public Color FalseColor
+    {
+        get => (Color)GetValue(FalseColorProperty);
+        set => SetValue(FalseColorProperty, value);
+    }
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is true ? TrueColor : FalseColor;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/TBird.Maui/Converters/BoolToOpacityConverter.cs
+++ b/TBird.Maui/Converters/BoolToOpacityConverter.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+
+namespace TBird.Maui.Converters;
+
+public class BoolToOpacityConverter : BindableObject, IValueConverter
+{
+    public static readonly BindableProperty TrueOpacityProperty =
+        BindableProperty.Create(nameof(TrueOpacity), typeof(double), typeof(BoolToOpacityConverter), 1.0);
+
+    public static readonly BindableProperty FalseOpacityProperty =
+        BindableProperty.Create(nameof(FalseOpacity), typeof(double), typeof(BoolToOpacityConverter), 0.4);
+
+    public double TrueOpacity
+    {
+        get => (double)GetValue(TrueOpacityProperty);
+        set => SetValue(TrueOpacityProperty, value);
+    }
+
+    public double FalseOpacity
+    {
+        get => (double)GetValue(FalseOpacityProperty);
+        set => SetValue(FalseOpacityProperty, value);
+    }
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is true ? TrueOpacity : FalseOpacity;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/TBird.Maui/Converters/HasValueConverter.cs
+++ b/TBird.Maui/Converters/HasValueConverter.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Globalization;
+
+namespace TBird.Maui.Converters;
+
+public class HasValueConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value switch
+        {
+            null => false,
+            bool b => b,
+            string s => !string.IsNullOrEmpty(s),
+            ICollection c => c.Count > 0,
+            IEnumerable e => HasAny(e),
+            int i => i != 0,
+            long l => l != 0,
+            double d => d != 0,
+            float f => f != 0,
+            decimal m => m != 0,
+            _ => true,
+        };
+    }
+
+    private static bool HasAny(IEnumerable source)
+    {
+        var enumerator = source.GetEnumerator();
+        try
+        {
+            return enumerator.MoveNext();
+        }
+        finally
+        {
+            (enumerator as IDisposable)?.Dispose();
+        }
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/TBird.Maui/Converters/IntToBoolConverter.cs
+++ b/TBird.Maui/Converters/IntToBoolConverter.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+
+namespace TBird.Maui.Converters;
+
+public class IntToBoolConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int intValue)
+            return intValue > 0;
+        return false;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is true ? 1 : 0;
+    }
+}

--- a/TBird.Maui/Converters/InverseBoolConverter.cs
+++ b/TBird.Maui/Converters/InverseBoolConverter.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+
+namespace TBird.Maui.Converters;
+
+public class InverseBoolConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is not true;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is not true;
+    }
+}

--- a/TBird.Maui/MauiMessageService.cs
+++ b/TBird.Maui/MauiMessageService.cs
@@ -1,0 +1,117 @@
+using System.Runtime.CompilerServices;
+using TBird.Core;
+
+namespace TBird.Maui;
+
+/// <summary>
+/// ConsoleMessageService を継承し、Android/MAUI 環境向けに出力を logcat と
+/// FileSystem.AppDataDirectory/log/yyyy-MM-dd.log に振り分ける実装。
+///
+/// 全 5 メソッド (Error / Exception / Info / Warn / Debug) を override する。
+/// ConsoleMessageService の Writeline 経路 (Trace.WriteLine) は Android logcat に
+/// 転送されないため、明示的に System.Diagnostics.Debug.WriteLine を呼ぶ必要がある。
+///
+/// GetString は base 実装を再利用し、[appName] プレフィックスを付加する形に override する。
+/// MessageService.AppendLogfile は AppDomain.CurrentDomain.BaseDirectory 相対パスを使うため
+/// Android サンドボックスで書込権限エラーが出る。代わりに FileSystem.AppDataDirectory/log に書く。
+/// </summary>
+public class MauiMessageService : ConsoleMessageService
+{
+    private readonly string _appName;
+
+    public MauiMessageService(string appName)
+    {
+        _appName = appName;
+    }
+
+    // base.GetString は §1.5.4 で純粋関数化されているため副作用なし。
+    // base のフォーマット [Level][datetime][file][member][line]\n{message} の先頭に
+    // [appName] プレフィックスを付加して [LanobeReader][Level]... の形にする。
+    protected override string GetString(MessageType type,
+            string message,
+            string callerMemberName,
+            string callerFilePath,
+            int callerLineNumber)
+    {
+        var baseLine = base.GetString(type, message, callerMemberName, callerFilePath, callerLineNumber);
+        return $"[{_appName}]{baseLine}";
+    }
+
+    // Error / Exception: base 実装は Writeline (= Trace.WriteLine) +
+    // MessageService.AppendLogfile を呼ぶが、Android では Trace.WriteLine が logcat に
+    // 出ない & AppendLogfile が AppDomain.CurrentDomain.BaseDirectory 相対で
+    // サンドボックス書込権限エラーを起こす。base を呼ばずに同等出力を組み立てる。
+    public override void Error(string message,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerFilePath] string callerFilePath = "",
+        [CallerLineNumber] int callerLineNumber = 0)
+    {
+        var line = GetString(MessageType.Error, message, callerMemberName, callerFilePath, callerLineNumber);
+        System.Diagnostics.Debug.WriteLine(line);
+        TryAppendToAppData(line);
+    }
+
+    public override void Exception(System.Exception exception,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerFilePath] string callerFilePath = "",
+        [CallerLineNumber] int callerLineNumber = 0)
+    {
+        var line = GetString(MessageType.Exception, exception.ToString(), callerMemberName, callerFilePath, callerLineNumber);
+        System.Diagnostics.Debug.WriteLine(line);
+        TryAppendToAppData(line);
+    }
+
+    // Info / Warn / Debug: base.* は Trace.WriteLine を呼ぶが、Android では
+    // ConsoleMessageService の TextWriterTraceListener (Console.Out) が logcat に
+    // 転送されない。明示的に Debug.WriteLine で logcat 出力を担保する。
+    // ファイル書込は行わない（Error/Exception のみ AppData に書く）。
+    public override void Info(string message,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerFilePath] string callerFilePath = "",
+        [CallerLineNumber] int callerLineNumber = 0)
+    {
+        System.Diagnostics.Debug.WriteLine(GetString(MessageType.Info, message, callerMemberName, callerFilePath, callerLineNumber));
+    }
+
+    public override void Warn(string message,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerFilePath] string callerFilePath = "",
+        [CallerLineNumber] int callerLineNumber = 0)
+    {
+        System.Diagnostics.Debug.WriteLine(GetString(MessageType.Warn, message, callerMemberName, callerFilePath, callerLineNumber));
+    }
+
+    public override void Debug(string message,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerFilePath] string callerFilePath = "",
+        [CallerLineNumber] int callerLineNumber = 0)
+    {
+#if DEBUG
+        System.Diagnostics.Debug.WriteLine(GetString(MessageType.Debug, message, callerMemberName, callerFilePath, callerLineNumber));
+#else
+        if (CoreSetting.Instance.IsDebug)
+        {
+            System.Diagnostics.Debug.WriteLine(GetString(MessageType.Debug, message, callerMemberName, callerFilePath, callerLineNumber));
+        }
+#endif
+    }
+
+    // Confirm: Shell.Current.DisplayAlert は async Task<bool>。同期 bool を返す
+    // IMessageService.Confirm を素直にサポートできないため、base 実装 (true 固定) のまま。
+    // 将来必要になったら IMessageService に ConfirmAsync を追加する設計判断が必要。
+
+    private void TryAppendToAppData(string line)
+    {
+        try
+        {
+            var dir = System.IO.Path.Combine(FileSystem.AppDataDirectory, "log");
+            System.IO.Directory.CreateDirectory(dir);
+            var path = System.IO.Path.Combine(dir, $"{System.DateTime.Now:yyyy-MM-dd}.log");
+            System.IO.File.AppendAllText(path, line + "\n");
+        }
+        catch
+        {
+            // ログ書込失敗自体は飲み込む（logcat 出力は既に出ているため致命的でない）
+        }
+    }
+}

--- a/TBird.Maui/Services/NotificationPermissionService.cs
+++ b/TBird.Maui/Services/NotificationPermissionService.cs
@@ -1,0 +1,52 @@
+using TBird.Core;
+
+namespace TBird.Maui;
+
+/// <summary>
+/// 通知許可（POST_NOTIFICATIONS 等）をユーザーに依頼するヘルパー。
+/// 1 セッション内で 1 度のみ実行され、Granted ならそのまま返す。
+/// Rationale が必要な場合は Shell.Current.DisplayAlert で同意を取ってから RequestAsync を呼ぶ。
+/// </summary>
+/// <typeparam name="TPermission">
+/// Android 等のプラットフォーム固有 Permission クラス。
+/// アプリ側で BasePlatformPermission を継承した型を渡す（例: PostNotificationsPermission）。
+/// </typeparam>
+public class NotificationPermissionService<TPermission>
+    where TPermission : Permissions.BasePlatformPermission, new()
+{
+    private readonly string _title;
+    private readonly string _message;
+    private readonly string _acceptLabel;
+    private readonly string _declineLabel;
+    private bool _requestedThisSession;
+
+    public NotificationPermissionService(string title, string message, string acceptLabel, string declineLabel)
+    {
+        _title = title;
+        _message = message;
+        _acceptLabel = acceptLabel;
+        _declineLabel = declineLabel;
+    }
+
+    public async Task EnsureRequestedAsync()
+    {
+        if (_requestedThisSession) return;
+        _requestedThisSession = true;
+
+        var status = await Permissions.CheckStatusAsync<TPermission>();
+        if (status == PermissionStatus.Granted) return;
+
+        if (Permissions.ShouldShowRationale<TPermission>())
+        {
+            var accepted = await Shell.Current.DisplayAlert(_title, _message, _acceptLabel, _declineLabel);
+            if (!accepted)
+            {
+                MessageService.Info("User dismissed rationale dialog");
+                return;
+            }
+        }
+
+        var result = await Permissions.RequestAsync<TPermission>();
+        MessageService.Info($"Notification permission request result: {result}");
+    }
+}

--- a/TBird.Maui/TBird.Maui.csproj
+++ b/TBird.Maui/TBird.Maui.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
+    <!-- UseMaui=true により Microsoft.Maui アセンブリのコア部分を有効化。
+         BindableObject / IValueConverter / Color / Colors は Microsoft.Maui.Controls
+         PackageReference から明示解決する（純粋クラスライブラリでは SingleProject app と
+         挙動が異なるため auto FrameworkReference に依存しない）。
+         Permissions.BasePlatformPermission は UseMaui 経由で Essentials が含まれる想定。
+         型解決エラーが出る場合は UseMauiEssentials=true または Microsoft.Maui.Essentials
+         PackageReference を fallback として追加する。 -->
+    <UseMaui>true</UseMaui>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.*" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+    <!-- Microsoft.Maui.Controls.Compatibility は意図的に含めない（lib 依存膨張防止）。 -->
+    <ProjectReference Include="..\TBird.Core\TBird.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TBird.Maui/ViewModels/ErrorAwareViewModel.cs
+++ b/TBird.Maui/ViewModels/ErrorAwareViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace TBird.Maui.ViewModels;
+
+/// <summary>
+/// HasError / ErrorMessage を保持するエラー状態付き ViewModel 基底。
+/// View 側で HasError をトリガーにエラー UI（バナー等）を表示する想定。
+/// 確認ダイアログのような双方向対話用途には設計されていない（エラー通知の片方向状態のみ）。
+/// </summary>
+public abstract partial class ErrorAwareViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _hasError;
+
+    [ObservableProperty]
+    private string _errorMessage = string.Empty;
+
+    protected virtual void SetError(string message)
+    {
+        ErrorMessage = message;
+        HasError = true;
+    }
+
+    protected virtual void ClearError()
+    {
+        ErrorMessage = string.Empty;
+        HasError = false;
+    }
+}


### PR DESCRIPTION
## Summary

Android MAUI アプリ向けの共通基盤として、`TBird.Maui` / `TBird.Maui.DB` / `TBird.Maui.Background` / `TBird.Maui.Web` の 4 プロジェクトを `master` に追加する。LanobeReader (app-novelviewer) での実装・実機 verify 済み（PR #3 で別途取り込み）。

**`TBird.Library.sln` には MAUI 系プロジェクトを追加しない**設計のため、WPF 専業ブランチ (app-netkeiba / app-moviewer / app-ebook2pdf 等) の開発者は従来通り `TBird.Library.sln` を MAUI workload なしで開ける。MAUI 系の開発は新規 `TBird.Maui.sln` または各 app の `App.sln` 経由で行う。

## 構成

| プロジェクト | TFM | 主要内容 |
|---|---|---|
| TBird.Maui | net9.0-android | ErrorAwareViewModel / 5 Converter / NotificationPermissionService\<T\> / MauiMessageService |
| TBird.Maui.DB | netstandard2.0 | SqliteDatabaseBase / IMigration (sqlite-net-pcl + SQLitePCLRaw.bundle_green) |
| TBird.Maui.Background | net9.0-android | BackgroundJobBase / JobPriority / INetworkPolicy / MauiNetworkPolicy / PriorityJobQueue\<TJob, TKey\> / SiteRateLimiter |
| TBird.Maui.Web | net8.0 | AngleSharpHelper / TransientHttpErrorHelper / HttpRequestFailureLogger |

## 設計判断

### Lifetime / 境界規約
- `MauiNetworkPolicy` / `PriorityJobQueue` は Singleton 前提（ConnectivityChanged / WiFi イベント購読のリーク防止）。class header に `[DI-LIFETIME: SINGLETON]` タグ付き。
- `INetworkPolicy` は当面 PriorityJobQueue 内部 DI 接合専用。アプリ層 Repository / Service / ViewModel が直接 DI で受け取ることは禁止（具象 NetworkPolicyService 経由のみ）。

### PriorityJobQueue\<TJob, TKey\>
- High / Normal の 2 本キュー方式（現行 LanobeReader BackgroundJobQueue の踏襲、priority aging なし）
- `EnqueueAsync(job, JobPriority)` 戻り値 3 ケース全網羅 (`isEnabled=false drop` / `dedup drop` / `enqueued`)
- dedup HashSet と Queue.Enqueue は同一 lock 内で完結（StopWorker → SyncEnqueuedIdsFromQueues との race 回避）
- WorkerLoop 内で isEnabled / IsWifiConnected の二重ゲート防御
- OperationCanceledException は連続失敗カウントを増やさず break（StopWorker による正常キャンセル経路の保護）

### MauiMessageService
- ConsoleMessageService を継承し、Error / Exception / Info / Warn / Debug の **全 5 メソッド** を override
- Trace.WriteLine は Android logcat に転送されないため、System.Diagnostics.Debug.WriteLine を明示的に呼ぶ
- GetString override で \`[appName]\` プレフィックス付加、base.GetString 純粋関数を再利用してフォーマット中枢一元化
- Error / Exception のみ FileSystem.AppDataDirectory/log/yyyy-MM-dd.log に追記（容量肥大化防止）
- TBird.Core 側 ConsoleMessageService.AppendLogfile (AppDomain.CurrentDomain.BaseDirectory 相対) を呼ばずに Android サンドボックス書込権限エラーを回避

### SiteRateLimiter
- HttpClient + siteKeys + getDelayMs + maxAttempts + retryDelayMs をコンストラクタ受領
- 未登録 siteKey は `ArgumentException` で fail-fast (`KeyNotFoundException` よりデバッグ容易)
- 内部 \`Dictionary<string, SemaphoreSlim>\` + \`ConcurrentDictionary<string, DateTime>\` を siteKeys 全要素で事前初期化
- TransientHttpErrorHelper / HttpRequestFailureLogger は TBird.Maui.Web から参照（Background → Web の片方向 ProjectReference）

### SqliteDatabaseBase
- CreateTablesAsync (abstract) → SeedAsync (virtual) → ReadSchemaVersionAsync (abstract) → migrations → WriteSchemaVersionAsync (abstract) の順で初期化
- Connection プロパティは常に非 null・同期アクセス可（Repository DI 構築時クラッシュ防止）
- migration 配列は派生側が FromVersion 昇順保証、全成功時のみ WriteSchemaVersionAsync を呼ぶ（途中失敗は次回起動で再試行、冪等規約）
- 既存ユーザ DB の schema_version 永続化先（LanobeReader では app_settings テーブル）を派生側 abstract に委譲し既存データ互換維持

## プラン逸脱

- **TBird.Maui.Web の TFM**: プラン記載の `netstandard2.0` → `net8.0` に変更。理由: `HttpRequestException.StatusCode` (TransientHttpErrorHelper で使用) が .NET 5.0+ のため。消費側 (TBird.Maui.Background / LanobeReader) はいずれも net9.0-android で downward 互換 OK。csproj にコメントで根拠明示。
- **TBird.Maui.Background → TBird.Maui.Web の ProjectReference**: プラン §2.1 には記載なし。SiteRateLimiter が非 transient 失敗時に HttpRequestFailureLogger.Log() を呼ぶため必要。Web 側は Background を参照しないため循環なし。

## Test plan

- [x] `dotnet build TBird.Maui.sln` PR #2 ブランチ単独で 0 Warning / 0 Error
- [x] 4 lib プロジェクト個別ビルドも成功
- [x] `git diff origin/master -- TBird.Library.sln` 出力ゼロ（WPF 系 sln 無変更を確認）
- [x] PR #2 ブランチ上で `_Apps/` 変更なし（git status 確認済み）
- [x] LanobeReader (app-novelviewer 側、PR #3) で全 API 利用済み・実機 verify 済み（DB マイグレーション / Wi-Fi ゲート / なろう・カクヨム HTTP / 通知許可ダイアログ）

## Migration Notes

- **Microsoft.Maui.Controls バージョン**: `9.0.*` フローティング指定（LanobeReader.csproj と一貫）。将来 `Directory.Build.props` で `\$(MauiVersion)` 集約管理に移行検討。
- **CLAUDE.md 更新**: 本 PR 後に手動で「ライブラリ（全ブランチ共通）」セクションに 4 行追加予定（`docs(maui):` 別 commit / 別 PR）。

## 次のステップ

1. 本 PR (#2) のマージ
2. `chore: master を app-novelviewer に取り込み` の merge PR
3. PR #3 (app-novelviewer 側、`refactor(lanobereader):` LanobeReader 書き換え)

🤖 Generated with [Claude Code](https://claude.com/claude-code)