### PR TITLE
feat(lanobereader): ホーム画面に新着検知マークを追加

### DIFF
--- a/_Apps/Platforms/Android/NotificationHelper.cs
+++ b/_Apps/Platforms/Android/NotificationHelper.cs
@@ -20,6 +20,10 @@ public static class NotificationHelper
 			};
 
 			var manager = activity.GetSystemService(Context.NotificationService) as NotificationManager;
+			// ランチャーアイコンの通知ドット(新着バッジ)を明示的に有効化。
+			// 既定でも true だが意図を明示。チャンネルは作成後イミュータブルのため、
+			// 既存インストールではアプリ再インストール/データ削除まで反映されない (Android 仕様)。
+			updateChannel.SetShowBadge(true);
 			manager?.CreateNotificationChannel(updateChannel);
 		}
 	}

--- a/_Apps/Views/NovelListPage.xaml
+++ b/_Apps/Views/NovelListPage.xaml
@@ -55,9 +55,21 @@
 								<Label Grid.Row="0" Grid.Column="0" Grid.RowSpan="3"
                                        Text="★" FontSize="20" VerticalOptions="Center" Margin="0,0,6,0"
                                        TextColor="{Binding IsFavorite, Converter={StaticResource BoolToGoldConverter}}" />
-								<!-- Title -->
-								<Label Grid.Row="0" Grid.Column="1" Text="{Binding Title}"
-                                       FontSize="16" FontAttributes="Bold" LineBreakMode="TailTruncation" />
+								<!-- Title (+ 新着マーク) -->
+								<!-- HasUnconfirmedUpdate=false のとき NEW バッジ列(Auto)は幅0に潰れ、
+								     タイトルが全幅を使えるよう内側 Grid で構成する。 -->
+								<Grid Grid.Row="0" Grid.Column="1" ColumnDefinitions="Auto,*" ColumnSpacing="6">
+									<Border Grid.Column="0" Padding="5,1" VerticalOptions="Center"
+                                            BackgroundColor="{StaticResource DestructiveRed}"
+                                            IsVisible="{Binding HasUnconfirmedUpdate}">
+										<Border.StrokeShape>
+											<RoundRectangle CornerRadius="4" />
+										</Border.StrokeShape>
+										<Label Text="NEW" Style="{StaticResource BadgeLabel}" FontAttributes="Bold" />
+									</Border>
+									<Label Grid.Column="1" Text="{Binding Title}" VerticalOptions="Center"
+                                           FontSize="16" FontAttributes="Bold" LineBreakMode="TailTruncation" />
+								</Grid>
 
 								<!-- Site badge -->
 								<Border Grid.Row="0" Grid.Column="2" Padding="4,2"


### PR DESCRIPTION
## 概要
ユーザ要望「ホーム画面のアイコンに新着検知したらマークを付ける」への対応。

調査の結果、新着検知の仕組み自体は既に実装済みだったが、**表示部分だけが欠けていた**ことが判明したため、その表示を補った。

## 調査でわかったこと
- `Novel.HasUnconfirmedUpdate`（DB列 `has_unconfirmed_update`）は既存
- `UpdateCheckService` が新話検知時に `HasUnconfirmedUpdate=true` をセット（既存）
- `UpdateCheckWorker` が `ShowUpdateNotification` で通知を発火（既存）
- `NovelListViewModel.NavigateToDetail` で小説を開くとフラグをクリア（既存）
- **しかし XAML でこのフラグが一切使われておらず、画面にマークが出ていなかった**

## 変更内容

### 1. 一覧カードに「NEW」マーク追加（`NovelListPage.xaml`）
- タイトル横に `HasUnconfirmedUpdate` 連動の赤い「NEW」バッジを表示
- 小説を開くと既存ロジックでフラグがクリアされマークも消える
- 既存のサイトバッジ／未読バッジと同じスタイル（角丸 Border + `BadgeLabel`）で統一
- false 時は Auto 列が幅0に潰れ、従来どおりタイトルが全幅を使える内側 Grid 構成

### 2. 通知チャンネルにバッジ表示を明示有効化（`NotificationHelper.cs`）
- `updateChannel.SetShowBadge(true)` を追加し、ランチャーアイコンの通知ドット（新着バッジ）表示を保証
- 既定でも true だが意図を明示。※チャンネルは作成後イミュータブルのため既存インストールでは再インストール/データ削除まで反映されない（Android 仕様）

## 動作確認
- `dotnet build _Apps/LanobeReader.csproj` 成功（0 警告 / 0 エラー）
- エミュレータ（Pixel 7 / API 35）に配置し、通知発火時に**ランチャーアイコン右上へ通知ドットが点灯することを目視確認済み**

## 補足（実機での前提）
通知ドット表示には以下が必要:
- アプリの通知許可（Android 13+ は `POST_NOTIFICATIONS`）
- システム設定「通知ドットの許可」が ON

## 対象ブランチ
変更ファイルは `_Apps/` 配下（app-novelviewer 固有、master には存在しない）のため、ベースを app-novelviewer とする。