### PR TITLE
chore: .claude/ を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Claude Code working folder
+.claude/


### PR DESCRIPTION
## 概要
Claude Code の作業フォルダ `.claude/` を全ブランチで Git 追跡対象外にするため、共有ファイルである `.gitignore`（master 在籍）へ無視設定を追加する。

## 変更内容
- `.gitignore` 末尾に以下を追加:
  ```
  # Claude Code working folder
  .claude/
  ```

## 備考
- `.gitignore` は全ブランチ共有のため、CLAUDE.md の Git ワークフロー規約（対象ファイルが master に存在 → master からブランチ → master へ PR）に従いベースを master とする。
- app-novelviewer 等のブランチへは、master マージ時に取り込まれる。