### PR TITLE
feat(tbird-maui-background): SiteRateLimiter に PostJsonAsync を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 
 # Claude Code working folder
 .claude/
+
+# docs
+docs/

--- a/TBird.Maui.Background/SiteRateLimiter.cs
+++ b/TBird.Maui.Background/SiteRateLimiter.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using TBird.Core;
@@ -52,7 +54,50 @@ public sealed class SiteRateLimiter
         }
     }
 
-    public async Task<string> GetStringAsync(string siteKey, string url, CancellationToken ct = default)
+    /// <summary>
+    /// サイト別ゲート＋ディレイ＋transient リトライ越しに HTTP GET し、本文文字列を返す。
+    /// </summary>
+    public Task<string> GetStringAsync(string siteKey, string url, CancellationToken ct = default)
+        => SendAsync(siteKey, url, c => _httpClient.GetStringAsync(url, c), ct);
+
+    /// <summary>
+    /// サイト別ゲート＋ディレイ＋transient リトライ越しに JSON 本文を POST し、応答本文文字列を返す。
+    /// 認証ヘッダ等は <see cref="HttpClient.DefaultRequestHeaders"/> 側で付与する想定（GET と同じ HttpClient を共用）。
+    /// 非 2xx 応答は <see cref="HttpStatusCode"/> 付きの <see cref="HttpRequestException"/> として例外化し、
+    /// GET と同じく transient（5xx / 408 / 429）はリトライ、それ以外は呼出側へ伝播する。
+    /// 失敗時はサーバが返したエラー本文（認証失敗・上流エラー説明等）を例外メッセージに含める
+    /// （Android では <see cref="HttpRequestException.Message"/> が抽象的なため、原因究明性を確保する）。
+    /// <para>
+    /// ⚠️ transient リトライは同一 <paramref name="jsonBody"/> を再送する。検索・参照系のように
+    /// 同じ本文を複数回受け取っても副作用が重複しない冪等なエンドポイントにのみ使うこと。
+    /// 状態を変更する非冪等エンドポイントでは二重適用が起こりうる（冪等性は呼出側の責任）。
+    /// </para>
+    /// </summary>
+    public Task<string> PostJsonAsync(string siteKey, string url, string jsonBody, CancellationToken ct = default)
+        => SendAsync(siteKey, url, async c =>
+        {
+            using var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+            using var response = await _httpClient.PostAsync(url, content, c).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                // EnsureSuccessStatusCode() は本文を読まず throw するため、中継サーバが返すエラー JSON が失われる。
+                // 本文を読んで例外メッセージに含めつつ、StatusCode を引き継いだ HttpRequestException を投げて
+                // transient 判定（TransientHttpErrorHelper.IsTransient）を従来どおり機能させる。
+                var error = await response.Content.ReadAsStringAsync(c).ConfigureAwait(false);
+                throw new HttpRequestException(
+                    $"POST {url} failed: {(int)response.StatusCode} {response.ReasonPhrase}. Body: {Truncate(error)}",
+                    null,
+                    response.StatusCode);
+            }
+            return await response.Content.ReadAsStringAsync(c).ConfigureAwait(false);
+        }, ct);
+
+    /// <summary>
+    /// HTTP 送信を siteKey 単位で直列化し、ディレイ挿入＋transient リトライでゲートする共通処理。
+    /// <paramref name="send"/> が実際の HTTP 呼び出し（GET / POST 等）を行う。
+    /// </summary>
+    private async Task<string> SendAsync(
+        string siteKey, string url, Func<CancellationToken, Task<string>> send, CancellationToken ct)
     {
         if (!_siteGates.TryGetValue(siteKey, out var gate))
         {
@@ -69,7 +114,7 @@ public sealed class SiteRateLimiter
                 await EnforceDelayAsync(siteKey, ct).ConfigureAwait(false);
                 try
                 {
-                    var result = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+                    var result = await send(ct).ConfigureAwait(false);
                     _lastRequestAt[siteKey] = DateTime.UtcNow;
                     return result;
                 }
@@ -114,4 +159,12 @@ public sealed class SiteRateLimiter
             await Task.Delay((int)remaining, ct).ConfigureAwait(false);
         }
     }
+
+    /// <summary>POST 失敗時の例外メッセージへ載せるエラー本文を上限長で切り詰める（ログ肥大化防止）。</summary>
+    private const int MaxErrorBodyChars = 1000;
+
+    private static string Truncate(string s)
+        => string.IsNullOrEmpty(s) || s.Length <= MaxErrorBodyChars
+            ? s
+            : s.Substring(0, MaxErrorBodyChars) + "…(truncated)";
 }


### PR DESCRIPTION
## 概要

`TBird.Maui.Background.SiteRateLimiter` に **POST(JSON) 送信用の `PostJsonAsync`** を追加し、GET と共通のレート制御 / transient リトライ基盤を POST でも再利用できるようにする。あわせてルート `.gitignore` に `docs/` を追加する。

ライブラリ（master に存在する共有資産）への変更のため、アプリ固有コード（`_Apps/`）とは分離して master へ向けて PR する。

## 背景

`app-new-book-checker`（新刊チェッカー）の楽天Kobo 連携を**中継サーバー経由の POST** へ移行した際、これまで GET 専用だった `SiteRateLimiter` を POST にも対応させる必要が生じた。レート制御（サイト別ゲート + ディレイ）と transient リトライは GET・POST で共通化したい。

## 変更内容

### `TBird.Maui.Background/SiteRateLimiter.cs`

- HTTP 送信本体を `private SendAsync(siteKey, url, send, ct)` に集約。サイト別ゲートでの直列化・ディレイ挿入・transient リトライをここで一元化し、実際の HTTP 呼び出し（GET/POST）を `Func<CancellationToken, Task<string>>` で受け取る形にリファクタ。
  - 既存 `GetStringAsync` は `SendAsync` を呼ぶ薄いラッパーに変更（挙動は不変）。
- **`PostJsonAsync(siteKey, url, jsonBody, ct)` を新設**。
  - JSON 本文を `application/json` で POST し、応答本文文字列を返す。
  - 認証ヘッダ等は GET と共用する `HttpClient.DefaultRequestHeaders` 側で付与する想定。
  - 非 2xx 応答は**本文を読んでエラーメッセージに含めた上で** `HttpStatusCode` 付きの `HttpRequestException` として throw。
    - `EnsureSuccessStatusCode()` は本文を読まず throw するため中継サーバ／上流のエラー JSON が失われる。Android では `HttpRequestException.Message` が抽象的で原因究明性が低いため、本文を載せて投げる。
    - `HttpStatusCode` を引き継ぐことで `TransientHttpErrorHelper.IsTransient`（5xx/408/429）によるリトライ判定を GET と同様に機能させる。
  - エラー本文は `MaxErrorBodyChars`(1000) で `Truncate` し、ログ肥大化を防止。
- ⚠️ transient リトライは同一 `jsonBody` を再送するため、**冪等なエンドポイント専用**である旨を doc コメントで明記（非冪等エンドポイントの二重適用は呼出側責任）。

### `.gitignore`

- `docs/` を追加。

## 影響範囲

- 既存 `GetStringAsync` の挙動は不変（共通化のための内部リファクタのみ）。
- 新規 `PostJsonAsync` の追加は後方互換。

## テスト

- ビルド: 当該変更を含む `app-new-book-checker` 側の `App.sln` 全体ビルドが成功済み（0 Errors、既存の XamlC/NU1608 警告のみ）。
- 実利用: 中継サーバー（ASP.NET Core 9）に対するローカルスモークテストで、`PostJsonAsync` 経由のレート制御・429 リトライ・非 2xx エラー本文の透過を確認済み。
