### PR TITLE
docs: SiteRateLimiter の doc cref を Exception.Message に訂正 (CS1574)

### DIFF
--- a/TBird.Maui.Background/SiteRateLimiter.cs
+++ b/TBird.Maui.Background/SiteRateLimiter.cs
@@ -66,7 +66,7 @@ public sealed class SiteRateLimiter
     /// 非 2xx 応答は <see cref="HttpStatusCode"/> 付きの <see cref="HttpRequestException"/> として例外化し、
     /// GET と同じく transient（5xx / 408 / 429）はリトライ、それ以外は呼出側へ伝播する。
     /// 失敗時はサーバが返したエラー本文（認証失敗・上流エラー説明等）を例外メッセージに含める
-    /// （Android では <see cref="HttpRequestException.Message"/> が抽象的なため、原因究明性を確保する）。
+    /// （Android では <see cref="Exception.Message"/> が抽象的なため、原因究明性を確保する）。
     /// <para>
     /// ⚠️ transient リトライは同一 <paramref name="jsonBody"/> を再送する。検索・参照系のように
     /// 同じ本文を複数回受け取っても副作用が重複しない冪等なエンドポイントにのみ使うこと。


### PR DESCRIPTION
## 概要
`TBird.Maui.Background/SiteRateLimiter.cs` の `PostJsonAsync` doc コメントの cref が解決不能な CS1574 警告を解消する。

## 背景
PR #153（`app-new-book-checker` 系の警告解消）で検出された CS1574 のうち、本ファイルは **全ブランチ共有ライブラリ** `TBird.Maui.Background` に属する。CLAUDE.md のブランチ規則「ファイルが base に存在 → base へ PR」に従い、ファイルが存在する **master を base** とする。master を起点に修正することで、`app-new-book-checker` を含む他の `app-*` ブランチおよび各 `App.sln` でも同警告が解消される。

## 原因
`Message` プロパティは基底 `System.Exception` で宣言され、`HttpRequestException` では再宣言されない。そのため doc コメントの `<see cref="HttpRequestException.Message"/>` は解決できず CS1574 となる。

## 修正
宣言元である `<see cref="Exception.Message"/>` へ訂正（1行のみ）。コメントの意図（「Android では例外メッセージが抽象的なため原因究明性を確保」）は不変。実行コードへの影響なし。

## 検証
- `origin/master` および `origin/app-new-book-checker` の双方で当該 cref（line 69）と `PostJsonAsync`（line 76）の存在を確認済み。
- cref 先 `Exception.Message` は `System.Exception` で実在し解決可能。

## 後続
本 PR マージ後、master を `app-new-book-checker` へマージすれば、PR #153 側はこの共有ライブラリ変更を含めずに 0 警告を維持できる（PR #153 から当該1行を取り下げる）。