### PR TITLE
feat: 未定→未来日へ遷移した既知巻の予約開始を通知（レビュー#5）

### DIFF
--- a/_Apps/CLAUDE.md
+++ b/_Apps/CLAUDE.md
@@ -200,7 +200,8 @@ internal sealed class Secrets : ISecretsProvider
 - 既存巻は毎回書誌情報を上書き更新する。**ただし `IsPurchased / IsFavorite / IsCalendarRegistered / IsNewDetected / DetectedAt` は絶対に上書きしない**。
 - `SeriesId` は ItemNumber 全体 UNIQUE のため1巻1シリーズ。SeriesId 設定済みの既存巻は別シリーズのチェックでも変更しない。`SeriesId=NULL`（発掘導線の単発巻）が同定ヒットした時のみ当該シリーズを設定。
 - 予約/発売確定はカラムを持たず、`ReleaseDate` と現在日時の比較で都度判定。通知は**予約検知時のみ**。
-- 通知発行後に `IsNewDetected` を降ろす。複数検知時は通知を**1件に集約**。
+- **予約検知の対象**: ①未発売（未来日）の**新刊 INSERT**、②**既知巻が「未来日でない（未定/発売済）→未来日」へ遷移**したケース（登録時に発売日未定だった巻の予約開始を取りこぼさないため。F-005）。②は購入済みを除外し、`markNewDetected` 時のみ。**②でも `IsNewDetected` 等のフラグ列は上書きしない**（上記の保護ルールを厳守）。遷移は旧/新発売日の比較で一度だけ成立し、未来日が保存された次回以降は再通知されない（自己限定的）。
+- 通知発行後に `IsNewDetected` を降ろす（INSERT 時に立てた新刊分のみ。②の遷移分は立てていないので書き戻し不要）。複数検知時は通知を**1件に集約**。
 
 ### 7.4 除外フィルタ
 - タイトルに除外キーワード（Preferences `exclude_keywords`、初期 `["分冊","単話","話売り"]`）を含む巻は DB に取り込まない。

--- a/_Apps/NewReleaseChecker.Core/Services/NewReleaseCheckService.cs
+++ b/_Apps/NewReleaseChecker.Core/Services/NewReleaseCheckService.cs
@@ -92,12 +92,10 @@ public sealed class NewReleaseCheckService
                     if (ContainsExcludeKeyword(c.Title, excludes)) continue;
                     if (!SeriesIdentifier.IsSameSeries(registeredSet, c.Author)) continue;
 
-                    var (isNew, book) = await UpsertAsync(c, s.Id, now, nowIso, markNewDetected: true, existingByItemNumber);
-                    if (isNew)
-                    {
-                        totalNew++;
-                        if (book.IsNewDetected == 1) reservations.Add((book, s));
-                    }
+                    var (isNewItem, isNewReservation, book) = await UpsertAsync(c, s.Id, now, nowIso, markNewDetected: true, existingByItemNumber);
+                    if (isNewItem) totalNew++;
+                    // 新規予約検知（新刊INSERT＝未発売 / 既知巻の未定→未来日 遷移）を通知対象に集約する。
+                    if (isNewReservation) reservations.Add((book, s));
                 }
 
                 await _series.TouchLastCheckedAsync(s.Id, nowIso);
@@ -118,10 +116,12 @@ public sealed class NewReleaseCheckService
                 await NotifyReservationsAsync(reservations);
                 notified = reservations.Count;
             }
-            // 通知の有無に関わらず IsNewDetected を降ろす。通知 OFF のまま放置すると INSERT 時に立てた
-            // IsNewDetected=1 が残留し、再有効化後はその巻が既存扱いで再検知されず永久に未通知になるため。
+            // INSERT 時に IsNewDetected=1 を立てた新刊のみ、通知の有無に関わらず降ろす（通知 OFF のまま放置すると
+            // 残留し、再有効化後に既存扱いで再検知されず永久に未通知になるため）。
+            // 既知巻の未定→未来日 遷移分は IsNewDetected を立てていない（=0）ので書き戻し不要＝ユーザーフラグ列を触らない。
             foreach (var (book, _) in reservations)
             {
+                if (book.IsNewDetected != 1) continue;
                 book.IsNewDetected = 0;
                 await _book.UpdateFlagsAsync(book);
             }
@@ -195,11 +195,15 @@ public sealed class NewReleaseCheckService
     }
 
     /// <summary>
-    /// 候補巻を DB に反映する。
+    /// 候補巻を DB に反映する。戻り値は (IsNewItem: DB に無い ItemNumber を INSERT したか,
+    /// IsNewReservation: 今回新たに予約開始として検知したか＝通知対象か, Book)。
     /// 新刊（DB に無い ItemNumber）なら INSERT（IsFavorite=1、予約検知かつ markNewDetected なら IsNewDetected=1）。
-    /// 既存巻なら書誌列のみ上書き（ユーザーフラグ列は保護）。SeriesId=NULL の既存巻のみ当該シリーズを設定。
+    /// 既存巻なら書誌列のみ上書き（ユーザーフラグ列は §7.3 どおり一切保護＝上書きしない）。SeriesId=NULL の
+    /// 既存巻のみ当該シリーズを設定。既存巻が「未来日でない（未定/発売済）→未来日」へ遷移した場合は、
+    /// IsNewDetected 列を触らずに IsNewReservation=true を返して予約開始を通知に乗せる（F-005 の取りこぼし対策）。
+    /// 遷移は old/new 発売日比較で一度だけ成立し、未来日が保存された次回以降は再通知されない（自己限定的）。
     /// </summary>
-    private async Task<(bool IsNew, Book Book)> UpsertAsync(
+    private async Task<(bool IsNewItem, bool IsNewReservation, Book Book)> UpsertAsync(
         RakutenBook c, int seriesId, DateTime now, string nowIso, bool markNewDetected,
         Dictionary<string, Book> existingByItemNumber)
     {
@@ -209,6 +213,7 @@ public sealed class NewReleaseCheckService
         if (existing == null)
         {
             var isFuture = ReleaseDateParser.IsFuture(iso, now);
+            var newDetected = markNewDetected && isFuture;
             var book = new Book
             {
                 SeriesId = seriesId,
@@ -222,15 +227,18 @@ public sealed class NewReleaseCheckService
                 ItemUrl = c.ItemUrl,
                 Caption = c.Caption,
                 IsFavorite = 1,
-                IsNewDetected = (markNewDetected && isFuture) ? 1 : 0,
+                IsNewDetected = newDetected ? 1 : 0,
                 DetectedAt = nowIso,
             };
             book.Id = await _book.InsertAsync(book);
             existingByItemNumber[c.ItemNumber] = book; // 同一 Run 内の二重 INSERT 防止
-            return (true, book);
+            return (true, newDetected, book);
         }
 
-        // 既存巻: 書誌列のみ上書き
+        // 既存巻: 予約開始の遷移判定のため、書誌を上書きする前の発売日で「以前は未来日だったか」を確定する。
+        var wasFuture = ReleaseDateParser.IsFuture(existing.ReleaseDate, now);
+
+        // 既存巻: 書誌列のみ上書き（ユーザーフラグ列は触らない＝§7.3）
         existing.Isbn = c.Isbn;
         existing.Title = c.Title;
         existing.Author = c.Author;
@@ -248,7 +256,12 @@ public sealed class NewReleaseCheckService
             existing.SeriesId = seriesId;
         }
 
-        return (false, existing);
+        // 「未来日でない（未定/発売済）」→「未来日」へ遷移した既知巻は予約開始として通知する。
+        // 購入済みは対象外。IsNewDetected 列は更新しない（次回は wasFuture=true となり再通知されない）。
+        var isFutureNow = ReleaseDateParser.IsFuture(iso, now);
+        var newReservation = markNewDetected && !wasFuture && isFutureNow && existing.IsPurchased == 0;
+
+        return (false, newReservation, existing);
     }
 
     private async Task NotifyReservationsAsync(IReadOnlyList<(Book Book, Series Series)> reservations)


### PR DESCRIPTION
## 概要
コードレビュー指摘 **#5「登録時に発売日未定だった既知巻が後日予約開始しても通知されない」** を修正。前回のレビューでは「仕様 §7.3 と衝突する」と保留したが、**フラグ列を一切上書きせずに実装できる**ことが分かったため対応した。`app-new-book-checker` 直上の単一コミット。**ビルド: App.sln 0 警告 / 0 エラー**。

## 背景（なぜ保留→対応に変わったか）
- 旧来の新刊検知は **ItemNumber の新規性のみ**。登録時に未定（発売日 NULL）で取り込まれた巻は既知 ItemNumber 扱いとなり、後日その巻に予約（未来日）が付いても既存分岐（書誌更新のみ）を通り `IsNewDetected` が立たず、**予約開始が永久に未通知**だった。
- 仕様 §7.3 は「既存巻の `IsNewDetected` 等フラグ列は**絶対に上書きしない**」と規定。当初はこの規定と衝突すると判断し保留していた。
- 再検討の結果、**`IsNewDetected` 列を触らず**、`UpsertAsync` 内で持っている「旧発売日」と「新発売日」の比較だけで予約開始の遷移を検知でき、§7.3・§11 を厳守したまま通知に乗せられることが判明した。

## 変更
- `UpsertAsync` の戻り値を `(IsNewItem, IsNewReservation, Book)` の3要素へ変更。
- 既存巻の書誌を上書きする**前**に旧発売日で `wasFuture` を確定 → 上書き後の `isFutureNow` と比較。
- `markNewDetected && !wasFuture && isFutureNow && IsPurchased==0` を満たす既知巻を**新規予約**として `reservations` に集約し通知。
- **`IsNewDetected` 列は一切更新しない**。遷移は旧/新発売日比較で**一度だけ**成立し、未来日が保存された次回以降は `wasFuture=true` で再通知されない（自己限定的）。
- 通知後の `IsNewDetected` 降ろしは **INSERT 分（=1）のみ**対象。遷移分は立てていない（=0）ので書き戻し不要＝ユーザーフラグ列を触らない。
- 登録時（`markNewDetected:false`）は遷移検知が無効なので、登録で既存の未来日巻を一斉通知することはない。

## 仕様の整合
- `_Apps/CLAUDE.md` §7.3 に「予約検知の対象＝①未発売の新刊 INSERT ②既知巻の未定/発売済→未来日 遷移」を明文化。`IsPurchased/IsFavorite/IsCalendarRegistered/IsNewDetected/DetectedAt` を上書きしない保護ルールは維持。
- ℹ️ 製品仕様の正である `新刊チェッカー要件定義書.md` §3.2/§7.3 にも同趣旨を反映するのが望ましい（必要なら別途対応）。
