### PR TITLE
Secrets系ファイルの無視パターンをルート.gitignoreに集約

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,7 @@ MigrationBackup/
 
 # docs
 docs/
+
+#secret files
+**/*Secrets.cs
+**/*Secrets.json


### PR DESCRIPTION
## 概要
各 `_Apps` 配下の `.gitignore` に散在していた秘密情報の無視パターンを、ルート `.gitignore` に集約する。

## 変更内容
ルート `.gitignore` に以下を追加:
```
#secret files
**/*Secrets.cs
**/*Secrets.json
```
- `**/*Secrets.cs` … App の `Secrets.cs` をカバー
- `**/*Secrets.json` … Relay の `appsettings.Secrets.json` をカバー（`appsettings.` を `*` が吸収）

## 背景
従来 `_Apps/.gitignore` と `_Apps/NewReleaseChecker.Relay/.gitignore` に個別定義していたが、ビルド成果物(bin/obj)はルートの標準VS .gitignoreで既にカバー済みのため、残る secrets パターンのみをルートに寄せて重複を解消する。`_Apps` 配下の2ファイル削除は app-new-book-checker 側のPR(#163)で実施。

## マージ順の注意
本PRを先にマージし、master を app-new-book-checker 系へ反映してから #163 をマージすると、secrets の無視がルートで途切れずカバーされる。