### PR TITLE
feat(lanobereader): 更新通知の信頼性を向上（Doze貫通・経路統合・ラウンドロビン）

### DIFF
--- a/_Apps/LanobeReader/App.xaml.cs
+++ b/_Apps/LanobeReader/App.xaml.cs
@@ -14,6 +14,7 @@ public partial class App : Application
     private readonly NovelRepository _novelRepo;
     private readonly UpdateCheckService _updateCheckService;
     private readonly PrefetchService _prefetchService;
+    private readonly IUpdateNotificationService _notifier;
 
     public App(
         DatabaseService dbService,
@@ -21,7 +22,8 @@ public partial class App : Application
         EpisodeCacheRepository cacheRepo,
         NovelRepository novelRepo,
         UpdateCheckService updateCheckService,
-        PrefetchService prefetchService)
+        PrefetchService prefetchService,
+        IUpdateNotificationService notifier)
     {
         InitializeComponent();
 
@@ -31,6 +33,7 @@ public partial class App : Application
         _novelRepo = novelRepo;
         _updateCheckService = updateCheckService;
         _prefetchService = prefetchService;
+        _notifier = notifier;
 
         // Global exception handler
         AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
@@ -107,7 +110,13 @@ public partial class App : Application
     {
         try
         {
-            await _updateCheckService.CheckAllAsync().ConfigureAwait(false);
+            // 起動時チェックは新着を DB へ取り込み、アプリ内一覧の NEW 表示を最新化する。
+            // ShowUpdatesAsync は前面中（IsForeground）はシステム通知を抑止するため、通常の
+            // コールドスタート（OnResume で前面確定済み）では通知は出ない＝ユーザは一覧で新着を見る。
+            // 初期化中にアプリが背面化した稀なケースのみ、ここで通知が出る。
+            // バックグラウンド検出時の確実な通知は WorkManager / アラーム経路が担う。
+            var updates = await _updateCheckService.CheckAllAsync().ConfigureAwait(false);
+            await _notifier.ShowUpdatesAsync(updates).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/_Apps/LanobeReader/App.xaml.cs
+++ b/_Apps/LanobeReader/App.xaml.cs
@@ -14,7 +14,6 @@ public partial class App : Application
     private readonly NovelRepository _novelRepo;
     private readonly UpdateCheckService _updateCheckService;
     private readonly PrefetchService _prefetchService;
-    private readonly IUpdateNotificationService _notifier;
 
     public App(
         DatabaseService dbService,
@@ -22,8 +21,7 @@ public partial class App : Application
         EpisodeCacheRepository cacheRepo,
         NovelRepository novelRepo,
         UpdateCheckService updateCheckService,
-        PrefetchService prefetchService,
-        IUpdateNotificationService notifier)
+        PrefetchService prefetchService)
     {
         InitializeComponent();
 
@@ -33,7 +31,6 @@ public partial class App : Application
         _novelRepo = novelRepo;
         _updateCheckService = updateCheckService;
         _prefetchService = prefetchService;
-        _notifier = notifier;
 
         // Global exception handler
         AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
@@ -110,13 +107,12 @@ public partial class App : Application
     {
         try
         {
-            // 起動時チェックは新着を DB へ取り込み、アプリ内一覧の NEW 表示を最新化する。
-            // ShowUpdatesAsync は前面中（IsForeground）はシステム通知を抑止するため、通常の
-            // コールドスタート（OnResume で前面確定済み）では通知は出ない＝ユーザは一覧で新着を見る。
-            // 初期化中にアプリが背面化した稀なケースのみ、ここで通知が出る。
-            // バックグラウンド検出時の確実な通知は WorkManager / アラーム経路が担う。
-            var updates = await _updateCheckService.CheckAllAsync().ConfigureAwait(false);
-            await _notifier.ShowUpdatesAsync(updates).ConfigureAwait(false);
+            // 起動時チェックは新着を DB へ取り込み、アプリ内一覧の NEW 表示を最新化することだけを担う。
+            // ここでは通知を投稿しない: コールドスタートはほぼ必ず前面で、一覧の NEW 表示と
+            // UpdatesDetectedMessage による即時再読込で新着は見える。起動直後の前面未確定期に通知を出すと
+            // 直後の OnResume.CancelAll が消す「フラッシュ」になるため、通知経路は背面検出を担う
+            // WorkManager / アラーム経路に一本化する。
+            await _updateCheckService.CheckAllAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/_Apps/LanobeReader/Features/notify_reliability_testing.md
+++ b/_Apps/LanobeReader/Features/notify_reliability_testing.md
@@ -1,0 +1,159 @@
+# 更新通知の信頼性テスト手順（Doze / バックグラウンド）
+
+`feature/novelviewer-notify-reliability` の動作確認用メモ。
+対象: exact アラーム → 前面サービス（`UpdateCheckForegroundService`）→ 新着チェック → 通知の経路。
+
+> ⚠️ エミュレータは「ロジック・権限・FGS 起動」の検証用。OEM 独自の省電力キル
+> （Xiaomi / Samsung 等）は再現できないため、最終確認は実機（できれば対象 OEM 機）で行う。
+
+---
+
+## 0. 前提
+
+- **API 34 / Google APIs** のエミュレータ or 実機（`targetSdk = 34`）。
+- **Debug ビルド**で検証（短縮間隔とログが有効）。
+- アプリ ID: `com.tbird.lanobereader`
+
+> 💡 **Windows のフィルタ**: 本書は `grep -iE "a|b"` 表記だが、Windows cmd には `grep` が無い。
+> - cmd: `... | findstr /I "a b c"`（スペース区切り＝OR）
+> - PowerShell: `... | Select-String -Pattern "a|b|c"`
+> - OS 非依存: `adb shell "logcat | grep -iE 'a|b'"`（grep をデバイス側で実行）
+
+---
+
+## 1. 間隔を短縮する（待ち時間の短縮）
+
+[DebugSchedulingConfig.cs](../Platforms/Android/DebugSchedulingConfig.cs) の定数を一時的に変更してリビルド:
+
+```csharp
+public const int AlarmOverrideMinutes = 15;   // 0 = 無効。テスト後は必ず 0 に戻す
+```
+
+- アラーム（Doze 貫通経路）の発火が「時間」→「分」になる。
+- **9 分未満を指定しても、Doze 中はシステムのレート制限で実発火は ~9〜10 分間隔になる**点に注意。
+- 定期 WorkManager 側は最短 15 分（WorkManager の下限）。本経路のテストはアラーム側で行う。
+- ⚠️ コミット前に必ず `0` へ戻す。
+
+---
+
+## 2. Doze を強制してテスト
+
+```bash
+# 充電を外す（Doze はバッテリ駆動が条件）
+adb shell dumpsys battery unplug
+
+# deviceidle を有効化し、深い Doze へ一気に遷移
+adb shell dumpsys deviceidle enable
+adb shell dumpsys deviceidle force-idle        # → "Stepped to deep: IDLE"
+
+# 状態確認
+adb shell dumpsys deviceidle get deep          # IDLE になっていること
+
+# （任意）ネットを擬似的に絞って制約耐性を見る
+adb shell svc data disable
+adb shell svc wifi disable
+```
+
+### アラーム発火を誘発（間隔を待たずに進める）
+
+```bash
+adb shell dumpsys deviceidle step              # メンテ窓へ進めて保留アラームを発火
+# 必要に応じて複数回 step
+```
+
+### 後始末（必ず実行）
+
+```bash
+adb shell svc data enable
+adb shell svc wifi enable
+adb shell dumpsys deviceidle unforce
+adb shell dumpsys battery reset
+```
+
+---
+
+## 3. FGS＋チェック処理を発火させる
+
+> ❌ `adb shell am start-foreground-service -n .../UpdateCheckForegroundService` は
+> **使えない**。サービスは `Exported=false`（本番的に正しい）のため、adb シェル（uid 2000）
+> からの起動は `Permission Denial` で拒否される。FGS は必ず「アプリ自身が」アラーム経由で
+> 起動する必要がある。
+
+正しい手順（実アラームを発火させ、アプリにFGSを起動させる）:
+
+```bash
+# 1) DebugSchedulingConfig.AlarmOverrideMinutes = 2 などにしてリビルド・インストール
+# 2) アプリを一度起動してアラームを武装（ログに "Update alarm (exact) scheduled in 2... " 相当）
+# 3) すぐ画面OFF/背面化し、指定分だけ待つ
+#    → 時刻が来ると UpdateAlarmReceiver → UpdateCheckForegroundService（アプリ起動なので許可）
+```
+
+Doze 下で試す場合は、武装後すぐ `force-idle` して指定分待つ（exact アラームは Doze 中も時刻通り発火）:
+
+```bash
+adb shell dumpsys battery unplug
+adb shell dumpsys deviceidle force-idle
+# 指定分待つ → アラーム発火 → FGS 起動
+```
+
+→ 「更新を確認中…」の常駐通知が出て、ログに `CheckAll` → 新着通知が流れれば成功。
+
+---
+
+## 4. ログ確認
+
+```bash
+adb logcat -c    # クリア
+adb logcat | grep -iE "Update alarm|foreground|CheckAll|FGS|notif"
+```
+
+### ✅ 成功の目安
+
+| ログ | 意味 |
+|------|------|
+| `Update alarm (exact) scheduled in ...` | exact で武装できている（不正確に落ちていない） |
+| `[DEBUG] Alarm override: firing in 15 min` | デバッグ短縮が効いている |
+| 「更新を確認中」通知 → 数秒後に消える | FGS が起動し処理完遂 |
+| `ShowUpdateNotification` 相当の新着通知 | 通知経路 OK |
+
+### ❌ 異常の目安
+
+| ログ | 意味・対処 |
+|------|-----------|
+| `Update alarm (inexact) scheduled ...` | exact 権限を取得できていない。`USE_EXACT_ALARM` 付与状況を確認（下記） |
+| `startForeground denied; fallback to WorkManager` | 背面からの FGS 起動が拒否された。exact アラーム経由でないと起きやすい |
+| `IPlatformApplication.Current is null, retry later` | プロセス未初期化。FGS は ~3 秒待つが、それでも null なら起動直後すぎる |
+| `Failed to resolve services` | DI 解決失敗（登録漏れ） |
+
+### 権限・状態の確認
+
+```bash
+# exact アラーム可否（true なら exact 経路が使える）
+adb shell dumpsys alarm | grep -i com.tbird.lanobereader
+
+# 電池最適化の除外状態
+adb shell dumpsys deviceidle whitelist | grep -i lanobereader
+
+# 登録済みサービス/レシーバの確認
+adb shell dumpsys package com.tbird.lanobereader | grep -iE "Service|Receiver"
+```
+
+---
+
+## 5. 再起動後の再武装（BootReceiver）
+
+```bash
+adb reboot
+# 起動後
+adb logcat | grep -iE "Boot re-arm|Update alarm"
+```
+
+→ `Update alarm (exact) scheduled ...` が出れば、再起動後の再武装 OK。
+
+---
+
+## 6. 実機での最終確認（推奨）
+
+- `AlarmOverrideMinutes = 15` のまま実機に入れ、**画面 OFF＋放置で 1〜2 サイクル**通知が来るか。
+- 対象 OEM 機（Xiaomi/Samsung 等）では、初回起動時の電池最適化除外ダイアログで「許可」した場合としない場合の差を確認。
+- 確認できたら `AlarmOverrideMinutes = 0` に戻してコミット。

--- a/_Apps/LanobeReader/Helpers/SettingsKeys.cs
+++ b/_Apps/LanobeReader/Helpers/SettingsKeys.cs
@@ -14,6 +14,9 @@ public static class SettingsKeys
     public const string NOVEL_SORT_KEY = "novel_sort_key";
     public const string LAST_SCHEDULED_HOURS = "last_scheduled_hours";
     public const string AUTO_MARK_READ_ENABLED = "auto_mark_read_enabled";
+    // いずれかの経路で更新チェックを完遂した時刻(epoch ms)の Preferences ミラー。
+    // アラームの冗長発火ゲート(UpdateAlarmScheduler.ShouldSkipRedundantCheck)が参照する。
+    public const string LAST_CHECK_COMPLETED_MS = "last_check_completed_ms";
 
     // Default values
     public const int DEFAULT_CACHE_MONTHS = 3;

--- a/_Apps/LanobeReader/MauiProgram.cs
+++ b/_Apps/LanobeReader/MauiProgram.cs
@@ -81,6 +81,11 @@ public static class MauiProgram
         builder.Services.AddSingleton<INovelServiceFactory, NovelServiceFactory>();
         builder.Services.AddSingleton<UpdateCheckService>();
 
+        // 新着通知 / 定期スケジュールの Android 実装。フォアグラウンド(App.xaml.cs)・
+        // バックグラウンド(UpdateCheckWorker)・設定変更(SettingsViewModel)から共通利用する。
+        builder.Services.AddSingleton<IUpdateNotificationService, UpdateNotificationService>();
+        builder.Services.AddSingleton<IUpdateScheduler, AndroidUpdateScheduler>();
+
         // NotificationPermissionService<PostNotificationsPermission>: コンストラクタ引数 4 つを
         // ファクトリで渡す。タイトル / 本文 / ボタン文言は現行 LanobeReader のローカライズ済テキスト。
         builder.Services.AddSingleton(sp =>

--- a/_Apps/LanobeReader/Models/Novel.cs
+++ b/_Apps/LanobeReader/Models/Novel.cs
@@ -39,6 +39,14 @@ public class Novel
     [Column("has_check_error")]
     public bool HasCheckError { get; set; }
 
+    /// <summary>
+    /// この小説を最後に更新チェックした日時(ISO8601 "o", UTC)。null=未チェック。
+    /// 更新チェックを「古い順(未チェック優先)」で回し、3分上限等で打ち切られても
+    /// 次回が続きから拾えるようにするため (ラウンドロビン)。
+    /// </summary>
+    [Column("last_checked_at")]
+    public string? LastCheckedAt { get; set; }
+
     [Column("is_favorite")]
     public bool IsFavorite { get; set; }
 

--- a/_Apps/LanobeReader/Platforms/Android/ActivityForegroundCallbacks.cs
+++ b/_Apps/LanobeReader/Platforms/Android/ActivityForegroundCallbacks.cs
@@ -1,0 +1,27 @@
+using Android.App;
+using Android.OS;
+using AObject = Java.Lang.Object;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// アプリ全体の Activity ライフサイクルを監視し、可視(Started)Activity 数で前面/背面を判定する。
+/// <see cref="AppForegroundTracker"/> のカウンタを駆動する唯一の経路。
+///
+/// Started/Stopped 境界で数える理由: 権限・電池最適化のシステムダイアログや、アプリ自身の
+/// DisplayAlert は直下の Activity を Pause させるが Stop はさせない。Resume/Pause で数えると
+/// 「ユーザは見ているのに背面扱い」となる隙が生じ、その間に背面経路の通知が出てしまう。
+/// 真に不可視になる Stop までは前面とみなす。OnActivityStarted は OnActivityResumed より先に
+/// 走るため、MainActivity.OnResume の CancelAll より前に前面フラグが立つ。
+/// </summary>
+public class ActivityForegroundCallbacks : AObject, global::Android.App.Application.IActivityLifecycleCallbacks
+{
+    public void OnActivityStarted(Activity? activity) => AppForegroundTracker.OnActivityStarted();
+    public void OnActivityStopped(Activity? activity) => AppForegroundTracker.OnActivityStopped();
+
+    public void OnActivityCreated(Activity? activity, Bundle? savedInstanceState) { }
+    public void OnActivityResumed(Activity? activity) { }
+    public void OnActivityPaused(Activity? activity) { }
+    public void OnActivitySaveInstanceState(Activity? activity, Bundle? outState) { }
+    public void OnActivityDestroyed(Activity? activity) { }
+}

--- a/_Apps/LanobeReader/Platforms/Android/AndroidManifest.xml
+++ b/_Apps/LanobeReader/Platforms/Android/AndroidManifest.xml
@@ -9,4 +9,17 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- 電池最適化からの除外を直接要求するために必要(サイドロード運用)。OEM 実機での
+         バックグラウンド更新チェックの信頼性向上のため。 -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- 再起動後に更新チェックアラームを再武装するために必要。 -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- exact アラーム: Doze を貫通しつつ、Android 12+ で前面サービスのバックグラウンド起動を
+         許可する条件を満たす。サイドロード運用のため USE_EXACT_ALARM の Play ポリシー制限は対象外。
+         API 33+ は USE_EXACT_ALARM、API 31-32 は SCHEDULE_EXACT_ALARM を使用。 -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <!-- アラーム発火時に Doze 中も新着チェックを完遂する前面サービス(shortService 種別)。
+         shortService は専用パーミッション不要で FOREGROUND_SERVICE のみでよい。 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 </manifest>

--- a/_Apps/LanobeReader/Platforms/Android/AndroidUpdateScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/AndroidUpdateScheduler.cs
@@ -1,0 +1,15 @@
+using LanobeReader.Services;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// <see cref="IUpdateScheduler"/> の Android 実装。WorkManager の定期ワークを再登録する。
+/// </summary>
+public class AndroidUpdateScheduler : IUpdateScheduler
+{
+	public void Schedule(int intervalHours)
+	{
+		// 二機構（WorkManager + アラーム）の同一間隔武装は UpdateSchedulingCoordinator に一元化。
+		UpdateSchedulingCoordinator.ArmBoth(global::Android.App.Application.Context, intervalHours);
+	}
+}

--- a/_Apps/LanobeReader/Platforms/Android/AppForegroundTracker.cs
+++ b/_Apps/LanobeReader/Platforms/Android/AppForegroundTracker.cs
@@ -1,0 +1,15 @@
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// アプリが前面(フォアグラウンド)にあるかを追跡する。
+/// 前面時はアプリ内 UI が新着(NEW)を直接表示するため、システム通知の投稿を抑止する。
+/// これにより「前面で出した通知を直後の OnResume.CancelAll が消す」機能同士の競合を防ぐ。
+/// </summary>
+public static class AppForegroundTracker
+{
+    private static volatile bool _isForeground;
+
+    public static bool IsForeground => _isForeground;
+
+    public static void SetForeground(bool value) => _isForeground = value;
+}

--- a/_Apps/LanobeReader/Platforms/Android/AppForegroundTracker.cs
+++ b/_Apps/LanobeReader/Platforms/Android/AppForegroundTracker.cs
@@ -1,15 +1,30 @@
+using System.Threading;
+
 namespace LanobeReader.Platforms.Android;
 
 /// <summary>
-/// アプリが前面(フォアグラウンド)にあるかを追跡する。
+/// アプリが前面(フォアグラウンド)にあるかを、可視(Started)Activity 数で追跡する。
 /// 前面時はアプリ内 UI が新着(NEW)を直接表示するため、システム通知の投稿を抑止する。
 /// これにより「前面で出した通知を直後の OnResume.CancelAll が消す」機能同士の競合を防ぐ。
+/// カウンタの増減はアプリ全体の <see cref="ActivityForegroundCallbacks"/> が駆動する
+/// (個々の Activity に依存しないため、Activity が複数になっても前面判定が崩れない)。
 /// </summary>
 public static class AppForegroundTracker
 {
-    private static volatile bool _isForeground;
+    private static int _startedActivityCount;
 
-    public static bool IsForeground => _isForeground;
+    public static bool IsForeground => Volatile.Read(ref _startedActivityCount) > 0;
 
-    public static void SetForeground(bool value) => _isForeground = value;
+    /// <summary>Activity が可視(Started)になった。前面 Activity 数を 1 増やす。</summary>
+    public static void OnActivityStarted() => Interlocked.Increment(ref _startedActivityCount);
+
+    /// <summary>Activity が不可視(Stopped)になった。前面 Activity 数を 1 減らす(下限 0)。</summary>
+    public static void OnActivityStopped()
+    {
+        // 順序逆転・二重通知に対する防御。負値には陥らせない。
+        if (Interlocked.Decrement(ref _startedActivityCount) < 0)
+        {
+            Interlocked.Exchange(ref _startedActivityCount, 0);
+        }
+    }
 }

--- a/_Apps/LanobeReader/Platforms/Android/BatteryOptimizationHelper.cs
+++ b/_Apps/LanobeReader/Platforms/Android/BatteryOptimizationHelper.cs
@@ -1,0 +1,60 @@
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Provider;
+using Microsoft.Maui.Storage;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// 電池最適化(Doze / OEM の積極的な省電力)からの除外をユーザに一度だけ依頼するヘルパ。
+/// OEM 実機ではこれが WorkManager 定期実行が動かない最大要因となるため、緩和策として提供。
+/// ※効果は OEM により限定的。Google Play 配布時は REQUEST_IGNORE_BATTERY_OPTIMIZATIONS の
+///   ポリシー制限があるが、本アプリはサイドロード運用のため利用可能。
+/// </summary>
+public static class BatteryOptimizationHelper
+{
+	private const string AskedKey = "battery_opt_prompted";
+
+	/// <summary>
+	/// 未除外かつ未プロンプトであれば、説明ダイアログ→システムの除外要求ダイアログを一度だけ表示する。
+	/// </summary>
+	public static void PromptOnceIfNeeded(Activity activity)
+	{
+		if (Build.VERSION.SdkInt < BuildVersionCodes.M) return;
+		if (Preferences.Get(AskedKey, false)) return;
+
+		var pm = activity.GetSystemService(Context.PowerService) as PowerManager;
+		var pkg = activity.PackageName;
+		if (pm is null || pkg is null) return;
+		if (pm.IsIgnoringBatteryOptimizations(pkg)) return;
+
+		MainThread.BeginInvokeOnMainThread(async () =>
+		{
+			try
+			{
+				// Shell 未準備(起動直後)なら今回は見送り、次回 OnResume で再試行する。
+				if (Shell.Current is null) return;
+				if (Preferences.Get(AskedKey, false)) return;
+				Preferences.Set(AskedKey, true);
+
+				var ok = await Shell.Current.DisplayAlert(
+					"バックグラウンド更新の許可",
+					"新着をバックグラウンドで確実に通知するため、電池の最適化を無効にすることを推奨します。設定画面を開きますか？",
+					"設定を開く", "後で");
+				if (!ok) return;
+
+				var intent = new Intent(
+					Settings.ActionRequestIgnoreBatteryOptimizations,
+					global::Android.Net.Uri.Parse($"package:{pkg}"));
+				intent.SetFlags(ActivityFlags.NewTask);
+				activity.StartActivity(intent);
+			}
+			catch (Exception ex)
+			{
+				MessageService.Warn($"Battery optimization prompt failed: {ex.Message}");
+			}
+		});
+	}
+}

--- a/_Apps/LanobeReader/Platforms/Android/BootReceiver.cs
+++ b/_Apps/LanobeReader/Platforms/Android/BootReceiver.cs
@@ -1,0 +1,19 @@
+using Android.App;
+using Android.Content;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+// 再起動でアラームは消えるため再武装する。WorkManager 定期は自前の boot 受信で復帰する。
+[BroadcastReceiver(Enabled = true, Exported = true)]
+[IntentFilter(new[] { Intent.ActionBootCompleted })]
+public class BootReceiver : BroadcastReceiver
+{
+    public override void OnReceive(Context? context, Intent? intent)
+    {
+        if (context is null) return;
+        if (intent?.Action != Intent.ActionBootCompleted) return;
+        try { UpdateAlarmScheduler.ScheduleFromCache(context); }
+        catch (Exception ex) { MessageService.Warn($"Boot re-arm failed: {ex.Message}"); }
+    }
+}

--- a/_Apps/LanobeReader/Platforms/Android/DebugSchedulingConfig.cs
+++ b/_Apps/LanobeReader/Platforms/Android/DebugSchedulingConfig.cs
@@ -1,0 +1,16 @@
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// 実機での通知信頼性テスト用のデバッグ設定。値は DEBUG ビルドでのみ参照され、
+/// Release ビルドには一切影響しない（参照箇所が #if DEBUG でガードされている）。
+/// </summary>
+internal static class DebugSchedulingConfig
+{
+    /// <summary>
+    /// 0 より大きいとき、更新チェックアラームの発火間隔を「時間」ではなく、この「分」で上書きする。
+    /// 例: 15 にすると約15分ごとに発火。<b>テスト後は必ず 0 に戻すこと。</b>
+    /// 注意: Doze 中の AllowWhileIdle / exact アラームはシステムにより最短 ~9〜10 分へ
+    /// レート制限されるため、9 分未満を指定しても実発火間隔はそれ以上空く。
+    /// </summary>
+    public static readonly int AlarmOverrideMinutes = 0;
+}

--- a/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
+++ b/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
@@ -90,13 +90,12 @@ public class MainActivity : MauiAppCompatActivity
         HandleIntent(Intent);
     }
 
+    // 前面/背面の追跡は MainApplication が登録する ActivityForegroundCallbacks がアプリ全体の
+    // Activity ライフサイクル(Started/Stopped)から一元的に行う。個々の Activity では行わない。
+
     protected override void OnResume()
     {
         base.OnResume();
-
-        // 前面化を記録。以降 UpdateNotificationService は前面中の通知投稿を抑止し、
-        // 直下の CancelAll(バッジクリア)と前面通知が打ち消し合う競合を防ぐ。
-        AppForegroundTracker.SetForeground(true);
 
         // 新着バッジ(ランチャーアイコンのドット)はアクティブな通知に紐づく Android 仕様のため、
         // アプリを前面化した時点で通知をクリアしてバッジを消す。
@@ -106,13 +105,6 @@ public class MainActivity : MauiAppCompatActivity
 
         // 電池最適化の除外を一度だけ依頼(OEM 実機でのバックグラウンド更新の信頼性向上)。
         BatteryOptimizationHelper.PromptOnceIfNeeded(this);
-    }
-
-    protected override void OnPause()
-    {
-        base.OnPause();
-        // 背面化を記録。背面中はバックグラウンド更新通知の投稿を許可する。
-        AppForegroundTracker.SetForeground(false);
     }
 
     protected override void OnNewIntent(Intent? intent)
@@ -142,7 +134,23 @@ public class MainActivity : MauiAppCompatActivity
                     var route = episodeId > 0
                         ? $"reader?novelId={novelId}&episodeId={episodeId}&siteType={siteType}&siteNovelId={siteNovelId}"
                         : $"episodes?novelId={novelId}";
-                    await Shell.Current.GoToAsync(route);
+                    try
+                    {
+                        // コールドスタートの通知タップでは Shell 構築前にここへ到達しうる。async void 内の
+                        // NRE はプロセスを巻き込むため、null ガード + 握りつぶしでクラッシュを防ぐ。
+                        if (Shell.Current is not null)
+                        {
+                            await Shell.Current.GoToAsync(route);
+                        }
+                        else
+                        {
+                            MessageService.Warn("Shell.Current is null on notification tap; navigation skipped");
+                        }
+                    }
+                    catch (System.Exception ex)
+                    {
+                        MessageService.Warn($"Notification deep-link navigation failed: {ex.Message}");
+                    }
                 });
             }
         }

--- a/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
+++ b/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
@@ -41,8 +41,9 @@ public class MainActivity : MauiAppCompatActivity
 
                 if (services is null)
                 {
-                    MessageService.Warn("DI not ready in OnCreate; scheduling with default interval");
-                    UpdateCheckScheduler.SchedulePeriodicCheck(ctx);
+                    MessageService.Warn("DI not ready in OnCreate; scheduling with cached interval");
+                    // WorkManager とアラームを同一のキャッシュ間隔で武装し、両機構の間隔不一致を防ぐ。
+                    UpdateSchedulingCoordinator.ArmBothFromCache(ctx);
                     return;
                 }
 
@@ -50,7 +51,7 @@ public class MainActivity : MauiAppCompatActivity
                 var settingsRepo = services.GetService<AppSettingsRepository>();
                 if (dbService is null || settingsRepo is null)
                 {
-                    UpdateCheckScheduler.SchedulePeriodicCheck(ctx);
+                    UpdateSchedulingCoordinator.ArmBothFromCache(ctx);
                     return;
                 }
 
@@ -71,15 +72,47 @@ public class MainActivity : MauiAppCompatActivity
                     await settingsRepo.SetValueAsync(
                         SettingsKeys.LAST_SCHEDULED_HOURS, hours.ToString()).ConfigureAwait(false);
                 }
+
+                // アラームは毎起動で再武装（冪等・自己修復）。同一 PendingIntent を上書きするだけ。
+                UpdateAlarmScheduler.ScheduleNext(ctx, hours);
             }
             catch (Exception ex)
             {
                 MessageService.Warn($"Schedule worker failed: {ex.Message}");
-                try { UpdateCheckScheduler.SchedulePeriodicCheck(ctx); } catch { /* 諦める */ }
+                // 最終フォールバックは耐障害性を優先し、片方の失敗でもう片方を巻き込まないよう
+                // 各機構を独立 try で武装する（このため Coordinator.ArmBoth は経由しない）。
+                var cached = UpdateAlarmScheduler.GetCachedIntervalHours();
+                try { UpdateCheckScheduler.SchedulePeriodicCheck(ctx, cached); } catch { /* 諦める */ }
+                try { UpdateAlarmScheduler.ScheduleNext(ctx, cached); } catch { /* 諦める */ }
             }
         });
 
         HandleIntent(Intent);
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+
+        // 前面化を記録。以降 UpdateNotificationService は前面中の通知投稿を抑止し、
+        // 直下の CancelAll(バッジクリア)と前面通知が打ち消し合う競合を防ぐ。
+        AppForegroundTracker.SetForeground(true);
+
+        // 新着バッジ(ランチャーアイコンのドット)はアクティブな通知に紐づく Android 仕様のため、
+        // アプリを前面化した時点で通知をクリアしてバッジを消す。
+        // = 「新着があったらアプリを開くまではバッジを維持」を実現する。
+        try { NotificationHelper.CancelAll(this); }
+        catch (Exception ex) { MessageService.Warn($"CancelAll failed: {ex.Message}"); }
+
+        // 電池最適化の除外を一度だけ依頼(OEM 実機でのバックグラウンド更新の信頼性向上)。
+        BatteryOptimizationHelper.PromptOnceIfNeeded(this);
+    }
+
+    protected override void OnPause()
+    {
+        base.OnPause();
+        // 背面化を記録。背面中はバックグラウンド更新通知の投稿を許可する。
+        AppForegroundTracker.SetForeground(false);
     }
 
     protected override void OnNewIntent(Intent? intent)
@@ -100,12 +133,16 @@ public class MainActivity : MauiAppCompatActivity
             var siteType = intent.GetIntExtra("siteType", 1);
             var siteNovelId = intent.GetStringExtra("siteNovelId") ?? "";
 
-            if (novelId > 0 && episodeId > 0)
+            if (novelId > 0)
             {
                 MainThread.BeginInvokeOnMainThread(async () =>
                 {
-                    await Shell.Current.GoToAsync(
-                        $"reader?novelId={novelId}&episodeId={episodeId}&siteType={siteType}&siteNovelId={siteNovelId}");
+                    // 未読話が解決できた場合はリーダーへ直行。解決できない(episodeId<=0)場合でも
+                    // 無反応にせず、その小説の話一覧へ遷移してユーザの意図(=その小説を開く)を満たす。
+                    var route = episodeId > 0
+                        ? $"reader?novelId={novelId}&episodeId={episodeId}&siteType={siteType}&siteNovelId={siteNovelId}"
+                        : $"episodes?novelId={novelId}";
+                    await Shell.Current.GoToAsync(route);
                 });
             }
         }

--- a/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
+++ b/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
@@ -31,13 +31,8 @@ public class MainActivity : MauiAppCompatActivity
         {
             try
             {
-                IServiceProvider? services = null;
-                for (int i = 0; i < 30; i++)
-                {
-                    services = IPlatformApplication.Current?.Services;
-                    if (services is not null) break;
-                    await Task.Delay(100).ConfigureAwait(false);
-                }
+                // DI 待ちは UpdateCheckRunner と共通の PlatformServiceReadiness に集約(コピー乖離防止)。
+                var services = await PlatformServiceReadiness.WaitForServicesAsync().ConfigureAwait(false);
 
                 if (services is null)
                 {

--- a/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
+++ b/_Apps/LanobeReader/Platforms/Android/MainActivity.cs
@@ -68,9 +68,17 @@ public class MainActivity : MauiAppCompatActivity
                     SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS).ConfigureAwait(false);
                 if (hours != lastScheduled)
                 {
+                    // 間隔が変わったときは Update で既存ワークを新間隔へ更新。
                     UpdateCheckScheduler.SchedulePeriodicCheck(ctx, hours);
                     await settingsRepo.SetValueAsync(
                         SettingsKeys.LAST_SCHEDULED_HOURS, hours.ToString()).ConfigureAwait(false);
+                }
+                else
+                {
+                    // 間隔不変でも定期ワークが未登録なら登録する(既定間隔の新規インストールは差分が無く
+                    // 初回 no-op になり WorkManager ベースラインが欠落するのを防ぐ)。Keep のため既存
+                    // ワークがあれば周期はリセットされない。
+                    UpdateCheckScheduler.EnsurePeriodicCheck(ctx, hours);
                 }
 
                 // アラームは毎起動で再武装（冪等・自己修復）。同一 PendingIntent を上書きするだけ。

--- a/_Apps/LanobeReader/Platforms/Android/MainApplication.cs
+++ b/_Apps/LanobeReader/Platforms/Android/MainApplication.cs
@@ -1,5 +1,6 @@
 using Android.App;
 using Android.Runtime;
+using LanobeReader.Platforms.Android;
 
 namespace LanobeReader;
 
@@ -8,6 +9,15 @@ public class MainApplication : MauiApplication
 {
     public MainApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
     {
+    }
+
+    public override void OnCreate()
+    {
+        base.OnCreate();
+        // 前面/背面の判定をアプリ全体の可視(Started)Activity 数で一元管理する。個々の Activity に
+        // SetForeground を書かせる方式は単一 Activity を暗黙の前提とし、将来 Activity が増えると
+        // 前面状態を取りこぼすため、アプリ全体のライフサイクルコールバックへ集約する。
+        RegisterActivityLifecycleCallbacks(new ActivityForegroundCallbacks());
     }
 
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();

--- a/_Apps/LanobeReader/Platforms/Android/NotificationHelper.cs
+++ b/_Apps/LanobeReader/Platforms/Android/NotificationHelper.cs
@@ -37,7 +37,7 @@ public static class NotificationHelper
 	}
 
 	public static void ShowUpdateNotification(Context context, int notificationId, string title, string body,
-		int novelId, int episodeId, int siteType, string siteNovelId)
+		int novelId, int episodeId, int siteType, string siteNovelId, int badgeNumber = 0)
 	{
 		if (!HasNotificationPermission(context)) return;
 
@@ -52,15 +52,32 @@ public static class NotificationHelper
 			context, notificationId, intent,
 			PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
-		var notification = new NotificationCompat.Builder(context, UPDATE_CHANNEL_ID)!
+		var builder = new NotificationCompat.Builder(context, UPDATE_CHANNEL_ID)!
 			.SetSmallIcon(global::Android.Resource.Drawable.IcDialogInfo)!
 			.SetContentTitle(title)!
 			.SetContentText(body)!
+			// dismissible: ユーザがスワイプで消せる。タップで開いた場合も自動で消える。
+			// アプリ前面化時(MainActivity.OnResume)にも CancelAll でクリアし、バッジ(通知ドット)を消す。
+			// ※通知をスワイプで消すとバッジも消えるのは Android 仕様(バッジは通知に紐づく)。
 			.SetAutoCancel(true)!
 			.SetContentIntent(pendingIntent)!
-			.SetPriority(NotificationCompat.PriorityDefault)!
-			.Build();
+			.SetPriority(NotificationCompat.PriorityDefault)!;
 
-		NotificationManagerCompat.From(context)?.Notify(notificationId, notification!);
+		// OEM ランチャー(Samsung/Xiaomi 等)向けに数字バッジを設定。0 のときは点(ドット)のみ。
+		if (badgeNumber > 0)
+		{
+			builder.SetNumber(badgeNumber);
+		}
+
+		NotificationManagerCompat.From(context)?.Notify(notificationId, builder.Build()!);
+	}
+
+	/// <summary>
+	/// 全ての新着通知をクリアする(=ランチャーアイコンのバッジも消える)。
+	/// 「アプリを開くまでバッジを維持」を実現するため、アプリ前面化時に呼ぶ。
+	/// </summary>
+	public static void CancelAll(Context context)
+	{
+		NotificationManagerCompat.From(context)?.CancelAll();
 	}
 }

--- a/_Apps/LanobeReader/Platforms/Android/NotificationHelper.cs
+++ b/_Apps/LanobeReader/Platforms/Android/NotificationHelper.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Android.Content;
 using Android.OS;
+using Android.Service.Notification;
 using AndroidX.Core.App;
 
 namespace LanobeReader.Platforms.Android;
@@ -73,11 +74,27 @@ public static class NotificationHelper
 	}
 
 	/// <summary>
-	/// 全ての新着通知をクリアする(=ランチャーアイコンのバッジも消える)。
+	/// 新着「更新通知」(<see cref="UPDATE_CHANNEL_ID"/>)のみをクリアする(=ランチャーアイコンのバッジも消える)。
 	/// 「アプリを開くまでバッジを維持」を実現するため、アプリ前面化時に呼ぶ。
+	/// 実行中の前面サービス(<c>update_check_progress</c> チャンネルの常駐通知)は対象外。CancelAll で
+	/// 巻き込むと進行中チェックの前面通知が消え、サービスの前面状態に干渉するため、チャンネルで限定する。
 	/// </summary>
 	public static void CancelAll(Context context)
 	{
+		if (Build.VERSION.SdkInt >= BuildVersionCodes.M
+			&& context.GetSystemService(Context.NotificationService) is NotificationManager manager)
+		{
+			foreach (var sbn in manager.GetActiveNotifications() ?? Array.Empty<StatusBarNotification>())
+			{
+				if (sbn.Notification?.ChannelId == UPDATE_CHANNEL_ID)
+				{
+					manager.Cancel(sbn.Tag, sbn.Id);
+				}
+			}
+			return;
+		}
+
+		// 旧 OS フォールバック(minSdk 上は到達しない)。
 		NotificationManagerCompat.From(context)?.CancelAll();
 	}
 }

--- a/_Apps/LanobeReader/Platforms/Android/PlatformServiceReadiness.cs
+++ b/_Apps/LanobeReader/Platforms/Android/PlatformServiceReadiness.cs
@@ -1,0 +1,25 @@
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// MAUI の DI コンテナ(<see cref="IPlatformApplication.Current"/>.Services)が準備できるまで待つ共通ヘルパ。
+/// FGS / Worker / MainActivity いずれも MainApplication 初期化完了前に起動しうるため、短時間ポーリングで待つ。
+/// 待ち budget / 間隔 / null 処理を 1 箇所に集約し、複数経路でのコピー乖離(レース再発)を防ぐ。
+/// </summary>
+internal static class PlatformServiceReadiness
+{
+    /// <summary>
+    /// DI コンテナが利用可能になるまで最大 <paramref name="maxAttempts"/>×<paramref name="delayMs"/>ms 待つ。
+    /// 取得できれば <see cref="IServiceProvider"/> を、時間内に準備できなければ null を返す
+    /// (呼び出し側は WorkManager のバックオフ等にリトライを委ねる)。
+    /// </summary>
+    public static async Task<IServiceProvider?> WaitForServicesAsync(int maxAttempts = 30, int delayMs = 100)
+    {
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            var services = IPlatformApplication.Current?.Services;
+            if (services is not null) return services;
+            await Task.Delay(delayMs).ConfigureAwait(false);
+        }
+        return null;
+    }
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateAlarmReceiver.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateAlarmReceiver.cs
@@ -16,7 +16,20 @@ public class UpdateAlarmReceiver : BroadcastReceiver
         try { UpdateAlarmScheduler.ScheduleFromCache(context); }
         catch (Exception ex) { MessageService.Warn($"Re-arm alarm failed: {ex.Message}"); }
 
-        // 2) 前面サービスで Doze を貫通して即チェック。前面起動が拒否された場合は
+        // 2) 直近に(WorkManager 等で)チェック完了済みなら、FGS 起動は冗長なので省く。
+        //    健全運用時はアラームを真のバックストップに留め、毎周期の常駐通知・端末ウェイクを避ける。
+        //    Doze 等で WorkManager が滞ると最終完了が古くなりゲートを通過し、以降の FGS 経路が動く。
+        try
+        {
+            if (UpdateAlarmScheduler.ShouldSkipRedundantCheck())
+            {
+                MessageService.Info("Recent check detected; skipping redundant FGS (alarm re-armed)");
+                return;
+            }
+        }
+        catch (Exception ex) { MessageService.Warn($"Redundancy gate failed; proceeding with FGS: {ex.Message}"); }
+
+        // 3) 前面サービスで Doze を貫通して即チェック。前面起動が拒否された場合は
         //    サービス側が WorkManager 経路へフォールバックする（UpdateCheckForegroundService）。
         try { UpdateCheckForegroundService.Start(context); }
         catch (Exception ex)

--- a/_Apps/LanobeReader/Platforms/Android/UpdateAlarmReceiver.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateAlarmReceiver.cs
@@ -1,0 +1,29 @@
+using Android.App;
+using Android.Content;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+// Exported=false: 明示 PendingIntent 経由のみ（暗黙 intent-filter 不要）。
+[BroadcastReceiver(Enabled = true, Exported = false)]
+public class UpdateAlarmReceiver : BroadcastReceiver
+{
+    public override void OnReceive(Context? context, Intent? intent)
+    {
+        if (context is null) return;
+
+        // 1) まず次回を再武装（例外で連鎖が切れないよう最優先）。
+        try { UpdateAlarmScheduler.ScheduleFromCache(context); }
+        catch (Exception ex) { MessageService.Warn($"Re-arm alarm failed: {ex.Message}"); }
+
+        // 2) 前面サービスで Doze を貫通して即チェック。前面起動が拒否された場合は
+        //    サービス側が WorkManager 経路へフォールバックする（UpdateCheckForegroundService）。
+        try { UpdateCheckForegroundService.Start(context); }
+        catch (Exception ex)
+        {
+            MessageService.Warn($"Start FGS failed; fallback to WorkManager: {ex.Message}");
+            try { UpdateCheckScheduler.EnqueueOneTimeCheck(context); }
+            catch (Exception ex2) { MessageService.Error($"Enqueue one-time check failed: {ex2.Message}"); }
+        }
+    }
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateAlarmScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateAlarmScheduler.cs
@@ -1,0 +1,90 @@
+using Android.App;
+using Android.Content;
+using Android.OS;
+using LanobeReader.Helpers;
+using Microsoft.Maui.Storage;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// 更新チェック起床アラーム。WorkManager 定期実行が Doze 中（特にモバイル通信時）に
+/// 延期される問題の緩和策。Doze を貫通して発火し、前面サービス経路で一回限りのチェックを
+/// 起動して、毎回次回を再武装する。
+///
+/// 可能なら setExactAndAllowWhileIdle（exact）を使う。exact アラームは Android 12+ で
+/// 「バックグラウンドからの前面サービス起動」が許可される条件に該当するため、電池最適化の
+/// 除外可否に依存せず <see cref="UpdateCheckForegroundService"/> を確実に起動できる。
+/// exact 権限が無い/取得不可なら setAndAllowWhileIdle（不正確）へフォールバックする。
+/// </summary>
+public static class UpdateAlarmScheduler
+{
+    private const int RequestCode = 1001;
+    public const string ActionFire = "com.tbird.lanobereader.UPDATE_ALARM";
+    // 受信側(Receiver/BootReceiver)が DB 非依存で間隔を取得するための Preferences ミラー。
+    public const string IntervalPrefKey = "alarm_interval_hours";
+
+    public static void ScheduleNext(Context context, int intervalHours)
+    {
+        if (intervalHours <= 0) intervalHours = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS;
+        Preferences.Set(IntervalPrefKey, intervalHours);
+
+        var am = context.GetSystemService(Context.AlarmService) as AlarmManager;
+        if (am is null) return;
+
+        var pi = BuildPendingIntent(context);
+        var triggerAt = Java.Lang.JavaSystem.CurrentTimeMillis() + (long)intervalHours * 3600_000L;
+
+#if DEBUG
+        // 実機テスト用: 間隔を分単位に短縮（Release では未参照）。
+        if (DebugSchedulingConfig.AlarmOverrideMinutes > 0)
+        {
+            triggerAt = Java.Lang.JavaSystem.CurrentTimeMillis()
+                + (long)DebugSchedulingConfig.AlarmOverrideMinutes * 60_000L;
+            MessageService.Info($"[DEBUG] Alarm override: firing in {DebugSchedulingConfig.AlarmOverrideMinutes} min");
+        }
+#endif
+
+        // exact アラームは前面サービスの背面起動を許可する条件（Android 12+）に該当する。
+        // API 31+ は権限の有無を実機判定し、不可なら不正確アラームへフォールバック。
+        var useExact = Build.VERSION.SdkInt < BuildVersionCodes.S || am.CanScheduleExactAlarms();
+        if (useExact)
+        {
+            am.SetExactAndAllowWhileIdle(AlarmType.RtcWakeup, triggerAt, pi);
+            MessageService.Info($"Update alarm (exact) scheduled in {intervalHours}h");
+        }
+        else
+        {
+            // 不正確アラーム → Doze 中もメンテ窓で発火するが、前面起動は電池最適化除外に依存。
+            am.SetAndAllowWhileIdle(AlarmType.RtcWakeup, triggerAt, pi);
+            MessageService.Info($"Update alarm (inexact) scheduled in {intervalHours}h");
+        }
+    }
+
+    public static void ScheduleFromCache(Context context)
+    {
+        ScheduleNext(context, GetCachedIntervalHours());
+    }
+
+    /// <summary>
+    /// DB 非依存で間隔を取得する Preferences ミラーの値を返す(欠落時は既定値)。
+    /// MainActivity のフォールバック分岐で WorkManager とアラームの間隔を一致させるために使用。
+    /// </summary>
+    public static int GetCachedIntervalHours()
+        => Preferences.Get(IntervalPrefKey, SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS);
+
+    public static void Cancel(Context context)
+    {
+        var am = context.GetSystemService(Context.AlarmService) as AlarmManager;
+        am?.Cancel(BuildPendingIntent(context));
+    }
+
+    private static PendingIntent BuildPendingIntent(Context context)
+    {
+        var intent = new Intent(context, typeof(UpdateAlarmReceiver));
+        intent.SetAction(ActionFire);
+        return PendingIntent.GetBroadcast(
+            context, RequestCode, intent,
+            PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable)!;
+    }
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateAlarmScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateAlarmScheduler.cs
@@ -24,6 +24,24 @@ public static class UpdateAlarmScheduler
     // 受信側(Receiver/BootReceiver)が DB 非依存で間隔を取得するための Preferences ミラー。
     public const string IntervalPrefKey = "alarm_interval_hours";
 
+    /// <summary>
+    /// 次回発火までの実効間隔(ミリ秒)。Release は設定間隔そのもの。DEBUG では短縮上書きを反映。
+    /// アラームの発火時刻と冗長発火ゲートの窓を「同じ間隔」で算出するため一元化している。
+    /// </summary>
+    internal static long GetEffectiveIntervalMs(int intervalHours)
+    {
+        if (intervalHours <= 0) intervalHours = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS;
+        var ms = (long)intervalHours * 3600_000L;
+#if DEBUG
+        // 実機テスト用: 間隔を分単位に短縮（Release では未参照）。
+        if (DebugSchedulingConfig.AlarmOverrideMinutes > 0)
+        {
+            ms = (long)DebugSchedulingConfig.AlarmOverrideMinutes * 60_000L;
+        }
+#endif
+        return ms;
+    }
+
     public static void ScheduleNext(Context context, int intervalHours)
     {
         if (intervalHours <= 0) intervalHours = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS;
@@ -33,15 +51,15 @@ public static class UpdateAlarmScheduler
         if (am is null) return;
 
         var pi = BuildPendingIntent(context);
-        var triggerAt = Java.Lang.JavaSystem.CurrentTimeMillis() + (long)intervalHours * 3600_000L;
+        // 実効間隔(DEBUG 短縮上書きを含む)は GetEffectiveIntervalMs に一元化。ログもこの結果から
+        // 導出し、上書きロジックを二重評価して表示値が実値と乖離するのを防ぐ。
+        var effectiveMs = GetEffectiveIntervalMs(intervalHours);
+        var triggerAt = Java.Lang.JavaSystem.CurrentTimeMillis() + effectiveMs;
 
 #if DEBUG
-        // 実機テスト用: 間隔を分単位に短縮（Release では未参照）。
         if (DebugSchedulingConfig.AlarmOverrideMinutes > 0)
         {
-            triggerAt = Java.Lang.JavaSystem.CurrentTimeMillis()
-                + (long)DebugSchedulingConfig.AlarmOverrideMinutes * 60_000L;
-            MessageService.Info($"[DEBUG] Alarm override: firing in {DebugSchedulingConfig.AlarmOverrideMinutes} min");
+            MessageService.Info($"[DEBUG] Alarm override active: firing in ~{effectiveMs / 60_000L} min");
         }
 #endif
 
@@ -72,6 +90,22 @@ public static class UpdateAlarmScheduler
     /// </summary>
     public static int GetCachedIntervalHours()
         => Preferences.Get(IntervalPrefKey, SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS);
+
+    /// <summary>
+    /// アラーム発火時、直近に(いずれかの経路で)チェックが完了済みなら冗長な FGS 起動を省くべきか返す。
+    /// WorkManager 定期が健全に動いている間はアラームを真のバックストップに留め、毎周期の常駐通知・
+    /// 端末ウェイク・電池消費を避ける狙い。閾値は「実効間隔の半分」とし、これより新しい完了が
+    /// あれば冗長とみなす。Doze 等で WorkManager が滞ると最終完了時刻が古くなりゲートを通過する。
+    /// 完了時刻の記録は全経路の合流点 UpdateCheckService.CheckAllAsync が一元的に行う
+    /// (SettingsKeys.LAST_CHECK_COMPLETED_MS)。
+    /// </summary>
+    public static bool ShouldSkipRedundantCheck()
+    {
+        var last = Preferences.Get(SettingsKeys.LAST_CHECK_COMPLETED_MS, 0L);
+        if (last <= 0L) return false; // 完了履歴が無ければ必ず実行する。
+        var elapsed = Java.Lang.JavaSystem.CurrentTimeMillis() - last;
+        return elapsed >= 0 && elapsed < GetEffectiveIntervalMs(GetCachedIntervalHours()) / 2;
+    }
 
     public static void Cancel(Context context)
     {

--- a/_Apps/LanobeReader/Platforms/Android/UpdateAlarmScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateAlarmScheduler.cs
@@ -91,11 +91,19 @@ public static class UpdateAlarmScheduler
     public static int GetCachedIntervalHours()
         => Preferences.Get(IntervalPrefKey, SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS);
 
+    // 冗長ゲートの窓 = 実効間隔の 7/8。アラームと WorkManager 定期は同一周期で動くため、健全時の発火時点で
+    // 直近完了は通常 ~1 周期前後経過している。窓を半分にすると elapsed≈interval>interval/2 で毎周期 FGS が
+    // 貫通し、常駐通知・端末ウェイク・二重チェックが起き続けて「真のバックストップ」の狙いが成立しない。
+    // 窓を ~1 周期へ広げ、WorkManager が ~1 周期沈黙した時(=真に Doze 等で滞った時)だけアラームを貫通させる。
+    // 完全な 1 倍ではなく 7/8 とするのは発火ジッタによる境界フラップ(僅差で skip/実行が交互)を避けるマージン。
+    private const long RedundancyWindowNumerator = 7;
+    private const long RedundancyWindowDenominator = 8;
+
     /// <summary>
     /// アラーム発火時、直近に(いずれかの経路で)チェックが完了済みなら冗長な FGS 起動を省くべきか返す。
     /// WorkManager 定期が健全に動いている間はアラームを真のバックストップに留め、毎周期の常駐通知・
-    /// 端末ウェイク・電池消費を避ける狙い。閾値は「実効間隔の半分」とし、これより新しい完了が
-    /// あれば冗長とみなす。Doze 等で WorkManager が滞ると最終完了時刻が古くなりゲートを通過する。
+    /// 端末ウェイク・電池消費を避ける狙い。閾値は「実効間隔の 7/8」とし、これより新しい完了があれば
+    /// 冗長とみなす。Doze 等で WorkManager が ~1 周期滞ると最終完了時刻が古くなりゲートを通過する。
     /// 完了時刻の記録は全経路の合流点 UpdateCheckService.CheckAllAsync が一元的に行う
     /// (SettingsKeys.LAST_CHECK_COMPLETED_MS)。
     /// </summary>
@@ -104,7 +112,9 @@ public static class UpdateAlarmScheduler
         var last = Preferences.Get(SettingsKeys.LAST_CHECK_COMPLETED_MS, 0L);
         if (last <= 0L) return false; // 完了履歴が無ければ必ず実行する。
         var elapsed = Java.Lang.JavaSystem.CurrentTimeMillis() - last;
-        return elapsed >= 0 && elapsed < GetEffectiveIntervalMs(GetCachedIntervalHours()) / 2;
+        var window = GetEffectiveIntervalMs(GetCachedIntervalHours())
+            * RedundancyWindowNumerator / RedundancyWindowDenominator;
+        return elapsed >= 0 && elapsed < window;
     }
 
     public static void Cancel(Context context)

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckForegroundService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckForegroundService.cs
@@ -61,7 +61,15 @@ public class UpdateCheckForegroundService : Service
         {
             try
             {
-                await UpdateCheckRunner.RunAsync(ApplicationContext!, _cts.Token).ConfigureAwait(false);
+                var outcome = await UpdateCheckRunner.RunAsync(ApplicationContext!, _cts.Token).ConfigureAwait(false);
+                if (outcome == UpdateCheckRunner.Outcome.Retry)
+                {
+                    // プロセス未初期化等でチェックを実行できなかった。FGS は再試行機構を持たないため、
+                    // WorkManager のバックオフ再試行へ委ねて取りこぼしを防ぐ(コールドブート窓対策)。
+                    MessageService.Warn("FGS check returned Retry; enqueueing WorkManager fallback");
+                    try { UpdateCheckScheduler.EnqueueOneTimeCheck(ApplicationContext!); }
+                    catch (Exception ex2) { MessageService.Error($"Fallback enqueue failed: {ex2.Message}"); }
+                }
             }
             catch (Exception ex)
             {

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckForegroundService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckForegroundService.cs
@@ -1,0 +1,140 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.OS;
+using AndroidX.Core.App;
+using AndroidX.Core.Content;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// アラーム発火時に Doze を貫通して新着チェックを「その場で完遂」する前面サービス。
+/// WorkManager は Doze 中、ネットワーク制約付きジョブを次のメンテ窓まで延期しうるため、
+/// アラーム（exact / AllowWhileIdle）の起床ウィンドウ内で同期的に処理して延期を回避する。
+/// 背面からの前面起動が拒否された場合（例外）は WorkManager 経路へフォールバックする。
+///
+/// 種別 = shortService: 背面起動される短時間タスク専用（API 34+）。背面起動の許可条件が緩く
+/// exact アラームの一時 allowlist と相性が良い。dataSync の API 35 背面起動制限・6h/日上限を回避。
+/// 制約は「約3分以内に終える」こと（チェックは通常数秒。超過時は <see cref="OnTimeout(int)"/> で停止）。
+/// </summary>
+// Name を明示し、テスト時に `adb shell am start-foreground-service` で安定して指定できるようにする。
+[Service(Name = "com.tbird.lanobereader.UpdateCheckForegroundService",
+    Enabled = true, Exported = false, ForegroundServiceType = ForegroundService.TypeShortService)]
+public class UpdateCheckForegroundService : Service
+{
+    public const string CHANNEL_ID = "update_check_progress";
+    // novel.Id を notificationId に使う更新通知と衝突しない固定 ID。
+    private const int OngoingNotificationId = 1_000_000;
+
+    // shortService の3分上限到達(OnTimeout)時にチェック処理をきれいに中断するためのトークン。
+    private CancellationTokenSource? _cts;
+
+    /// <summary>前面サービスを起動する。Android 8.0+ の背面起動規約に従い StartForegroundService 経由。</summary>
+    public static void Start(Context context)
+    {
+        var intent = new Intent(context, typeof(UpdateCheckForegroundService));
+        ContextCompat.StartForegroundService(context, intent);
+    }
+
+    public override IBinder? OnBind(Intent? intent) => null;
+
+    public override StartCommandResult OnStartCommand(Intent? intent, StartCommandFlags flags, int startId)
+    {
+        try
+        {
+            // 8.0+ は起動直後の startForeground が必須。12+ で背面起動が許可されない場合は
+            // ここで例外となるため、WorkManager 経路へフォールバックして即終了する。
+            StartInForeground();
+        }
+        catch (Exception ex)
+        {
+            MessageService.Warn($"startForeground denied; fallback to WorkManager: {ex.Message}");
+            try { UpdateCheckScheduler.EnqueueOneTimeCheck(ApplicationContext!); }
+            catch (Exception ex2) { MessageService.Error($"Fallback enqueue failed: {ex2.Message}"); }
+            StopSelf(startId);
+            return StartCommandResult.NotSticky;
+        }
+
+        _cts = new CancellationTokenSource();
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await UpdateCheckRunner.RunAsync(ApplicationContext!, _cts.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                MessageService.Error($"Foreground update check failed: {ex.Message}");
+            }
+            finally
+            {
+                try { StopForeground(StopForegroundFlags.Remove); } catch { /* 既に停止済み */ }
+                StopSelf(startId);
+            }
+        });
+
+        // 処理中に kill されても自動再起動しない（次回はアラーム/定期ワークが担う）。
+        return StartCommandResult.NotSticky;
+    }
+
+    private void StartInForeground()
+    {
+        EnsureChannel();
+
+        var notification = new NotificationCompat.Builder(this, CHANNEL_ID)!
+            .SetSmallIcon(global::Android.Resource.Drawable.IcDialogInfo)!
+            .SetContentTitle("更新を確認中")!
+            .SetContentText("新着をチェックしています…")!
+            .SetPriority(NotificationCompat.PriorityLow)!
+            .SetOngoing(true)!
+            .Build();
+
+        if (Build.VERSION.SdkInt >= BuildVersionCodes.Q)
+        {
+            StartForeground(OngoingNotificationId, notification!, ForegroundService.TypeShortService);
+        }
+        else
+        {
+            StartForeground(OngoingNotificationId, notification!);
+        }
+    }
+
+    /// <summary>
+    /// shortService の実行上限（約3分）に達した場合にシステムから呼ばれる安全網。
+    /// 通常はチェックが数秒で終わり自己停止するため呼ばれない。呼ばれたら速やかに停止する。
+    /// </summary>
+    public override void OnTimeout(int startId)
+    {
+        MessageService.Warn("FGS short-service timeout reached; cancelling check and stopping");
+        // チェックを中断。進行中の作品は LastCheckedAt 未更新のまま残り、次回その作品から再開する。
+        try { _cts?.Cancel(); } catch { /* 破棄済み */ }
+        try { StopForeground(StopForegroundFlags.Remove); } catch { /* 既に停止済み */ }
+        StopSelf(startId);
+    }
+
+    public override void OnDestroy()
+    {
+        try { _cts?.Cancel(); } catch { /* 破棄済み */ }
+        _cts?.Dispose();
+        _cts = null;
+        base.OnDestroy();
+    }
+
+    private void EnsureChannel()
+    {
+        if (Build.VERSION.SdkInt < BuildVersionCodes.O) return;
+
+        var manager = GetSystemService(NotificationService) as NotificationManager;
+        if (manager is null) return;
+        if (manager.GetNotificationChannel(CHANNEL_ID) is not null) return;
+
+        // Low 重要度 = 音/ヘッドアップなし。バッジも出さない（更新通知本体とは別チャンネル）。
+        var channel = new NotificationChannel(CHANNEL_ID, "更新チェック", NotificationImportance.Low)
+        {
+            Description = "バックグラウンドで新着を確認している間に表示する通知"
+        };
+        channel.SetShowBadge(false);
+        manager.CreateNotificationChannel(channel);
+    }
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckForegroundService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckForegroundService.cs
@@ -30,6 +30,10 @@ public class UpdateCheckForegroundService : Service
     // shortService の3分上限到達(OnTimeout)時にチェック処理をきれいに中断するためのトークン。
     private CancellationTokenSource? _cts;
 
+    // チェック進行中フラグ(0=待機, 1=実行中)。同一インスタンスに OnStartCommand が近接二重発火しても
+    // 2 本目のチェックを起こさせず、_cts の差し替えによる「誤キャンセル/取りこぼし」を防ぐ。
+    private int _isRunning;
+
     /// <summary>前面サービスを起動する。Android 8.0+ の背面起動規約に従い StartForegroundService 経由。</summary>
     public static void Start(Context context)
     {
@@ -56,12 +60,24 @@ public class UpdateCheckForegroundService : Service
             return StartCommandResult.NotSticky;
         }
 
-        _cts = new CancellationTokenSource();
+        // 多重起動ガード: 既にチェック進行中なら 2 本目を起こさない。進行中タスクがサービスと前面通知を
+        // 所有しており、その finally が StopForeground/StopSelf するため、ここでは何もせず即終了する
+        // (StopSelf(startId) すると最新 startId 扱いで進行中タスクごとサービスを止めてしまうため呼ばない)。
+        if (Interlocked.CompareExchange(ref _isRunning, 1, 0) != 0)
+        {
+            MessageService.Info("FGS check already running; skipping duplicate start");
+            return StartCommandResult.NotSticky;
+        }
+
+        // クロージャはローカル変数 cts を参照する。フィールド _cts を直接参照すると、万一 2 本目が
+        // すり抜けて _cts を差し替えた場合に誤ったトークンを掴むため、起動時の cts を確定捕捉する。
+        var cts = new CancellationTokenSource();
+        _cts = cts;
         _ = Task.Run(async () =>
         {
             try
             {
-                var outcome = await UpdateCheckRunner.RunAsync(ApplicationContext!, _cts.Token).ConfigureAwait(false);
+                var outcome = await UpdateCheckRunner.RunAsync(ApplicationContext!, cts.Token).ConfigureAwait(false);
                 if (outcome == UpdateCheckRunner.Outcome.Retry)
                 {
                     // プロセス未初期化等でチェックを実行できなかった。FGS は再試行機構を持たないため、
@@ -77,8 +93,10 @@ public class UpdateCheckForegroundService : Service
             }
             finally
             {
+                Interlocked.Exchange(ref _isRunning, 0);
                 try { StopForeground(StopForegroundFlags.Remove); } catch { /* 既に停止済み */ }
-                StopSelf(startId);
+                // 多重起動を抑止しているため進行中タスクは常に 1 本。最新 startId に依存せず確実に停止する。
+                StopSelf();
             }
         });
 

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
@@ -19,13 +19,8 @@ public static class UpdateCheckRunner
     public static async Task<Outcome> RunAsync(Context appContext, CancellationToken ct = default)
     {
         // MainApplication 初期化完了前に起動しうる（FGS / Worker いずれも）。最大 ~3 秒だけ待つ。
-        IServiceProvider? services = null;
-        for (int i = 0; i < 30; i++)
-        {
-            services = IPlatformApplication.Current?.Services;
-            if (services is not null) break;
-            await Task.Delay(100).ConfigureAwait(false);
-        }
+        // 待ちロジックは MainActivity と共通の PlatformServiceReadiness に集約(コピー乖離防止)。
+        var services = await PlatformServiceReadiness.WaitForServicesAsync().ConfigureAwait(false);
 
         if (services is null)
         {

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
@@ -1,0 +1,71 @@
+using Android.Content;
+using LanobeReader.Helpers;
+using LanobeReader.Services;
+using LanobeReader.Services.Database;
+using Microsoft.Extensions.DependencyInjection;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// 更新チェックの実処理（DI 解決 → DB 初期化 → アラーム再同期 → CheckAll → 通知）を一元化する。
+/// WorkManager 経路（<see cref="UpdateCheckWorker"/>）と前面サービス経路
+/// （<see cref="UpdateCheckForegroundService"/>）の双方から呼び、ロジック重複を避ける。
+/// </summary>
+public static class UpdateCheckRunner
+{
+    public enum Outcome { Success, Retry, Failure }
+
+    public static async Task<Outcome> RunAsync(Context appContext, CancellationToken ct = default)
+    {
+        // MainApplication 初期化完了前に起動しうる（FGS / Worker いずれも）。最大 ~3 秒だけ待つ。
+        IServiceProvider? services = null;
+        for (int i = 0; i < 30; i++)
+        {
+            services = IPlatformApplication.Current?.Services;
+            if (services is not null) break;
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        if (services is null)
+        {
+            // 呼び出し側のリトライ（WorkManager のバックオフ等）に委ねる。
+            MessageService.Warn("IPlatformApplication.Current is null, retry later");
+            return Outcome.Retry;
+        }
+
+        var dbService = services.GetService<DatabaseService>();
+        var updateCheckService = services.GetService<UpdateCheckService>();
+        var notifier = services.GetService<IUpdateNotificationService>();
+        if (dbService is null || updateCheckService is null || notifier is null)
+        {
+            MessageService.Error("Failed to resolve services");
+            return Outcome.Failure;
+        }
+
+        // DB 初期化（アプリ起動完了前に走る可能性があるため明示）。
+        await dbService.EnsureInitializedAsync().ConfigureAwait(false);
+
+        // 権威ある DB の間隔値でアラームを再武装し、Preferences ミラーの drift を是正する。
+        var settingsRepo = services.GetService<AppSettingsRepository>();
+        if (settingsRepo is not null)
+        {
+            try
+            {
+                var hours = await settingsRepo.GetIntValueAsync(
+                    SettingsKeys.UPDATE_INTERVAL_HOURS,
+                    SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS).ConfigureAwait(false);
+                UpdateAlarmScheduler.ScheduleNext(appContext, hours);
+            }
+            catch (Exception ex)
+            {
+                MessageService.Warn($"Alarm re-sync from DB failed: {ex.Message}");
+            }
+        }
+
+        // 通知表示はフォアグラウンド経路(App.xaml.cs)と共通の IUpdateNotificationService に集約。
+        var updates = await updateCheckService.CheckAllAsync(ct).ConfigureAwait(false);
+        await notifier.ShowUpdatesAsync(updates).ConfigureAwait(false);
+        return Outcome.Success;
+    }
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
@@ -66,6 +66,9 @@ public static class UpdateCheckRunner
         // 通知表示はフォアグラウンド経路(App.xaml.cs)と共通の IUpdateNotificationService に集約。
         var updates = await updateCheckService.CheckAllAsync(ct).ConfigureAwait(false);
         await notifier.ShowUpdatesAsync(updates).ConfigureAwait(false);
+
+        // 完了時刻の記録は UpdateCheckService.CheckAllAsync(全経路の合流点)へ一元化済み。
+        // ここで個別にマークすると経路ごとの記録漏れリスクが戻るため行わない。
         return Outcome.Success;
     }
 }

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckRunner.cs
@@ -46,7 +46,14 @@ public static class UpdateCheckRunner
         // DB 初期化（アプリ起動完了前に走る可能性があるため明示）。
         await dbService.EnsureInitializedAsync().ConfigureAwait(false);
 
+        // 通知表示はフォアグラウンド経路(App.xaml.cs)と共通の IUpdateNotificationService に集約。
+        var updates = await updateCheckService.CheckAllAsync(ct).ConfigureAwait(false);
+        await notifier.ShowUpdatesAsync(updates).ConfigureAwait(false);
+
         // 権威ある DB の間隔値でアラームを再武装し、Preferences ミラーの drift を是正する。
+        // チェック「後」に行う: 受信側(UpdateAlarmReceiver)が発火直後にキャッシュ間隔で次回を再武装済みのため、
+        // ここでの再同期前にプロセスが kill されても次回アラームは確保されている。再同期をチェック前に置くと、
+        // kill 時に「次回が丸ごと1間隔先」へ押し出されるだけで近接リトライの機会を失う。
         var settingsRepo = services.GetService<AppSettingsRepository>();
         if (settingsRepo is not null)
         {
@@ -62,10 +69,6 @@ public static class UpdateCheckRunner
                 MessageService.Warn($"Alarm re-sync from DB failed: {ex.Message}");
             }
         }
-
-        // 通知表示はフォアグラウンド経路(App.xaml.cs)と共通の IUpdateNotificationService に集約。
-        var updates = await updateCheckService.CheckAllAsync(ct).ConfigureAwait(false);
-        await notifier.ShowUpdatesAsync(updates).ConfigureAwait(false);
 
         // 完了時刻の記録は UpdateCheckService.CheckAllAsync(全経路の合流点)へ一元化済み。
         // ここで個別にマークすると経路ごとの記録漏れリスクが戻るため行わない。

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckScheduler.cs
@@ -37,7 +37,21 @@ public static class UpdateCheckScheduler
         MessageService.Info("Enqueued one-time update check (alarm)");
     }
 
+    /// <summary>
+    /// 定期ワークを新間隔で登録/更新する(Update)。間隔が変わったときに呼ぶ。
+    /// </summary>
     public static void SchedulePeriodicCheck(Context context, int intervalHours = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS)
+        => EnqueuePeriodic(context, intervalHours, ExistingPeriodicWorkPolicy.Update!);
+
+    /// <summary>
+    /// 定期ワークが未登録なら登録する(Keep)。既定間隔の新規インストールは差分判定が no-op となり
+    /// WorkManager ベースラインが欠落するため、毎起動で「存在保証」武装する。Keep のため既存ワークが
+    /// あれば周期はリセットされない。
+    /// </summary>
+    public static void EnsurePeriodicCheck(Context context, int intervalHours = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS)
+        => EnqueuePeriodic(context, intervalHours, ExistingPeriodicWorkPolicy.Keep!);
+
+    private static void EnqueuePeriodic(Context context, int intervalHours, ExistingPeriodicWorkPolicy policy)
     {
         var constraints = new Constraints.Builder()
             .SetRequiredNetworkType(NetworkType.Connected!)
@@ -54,9 +68,9 @@ public static class UpdateCheckScheduler
 
         WorkManager.GetInstance(context)!.EnqueueUniquePeriodicWork(
             UpdateCheckWorker.WORK_TAG,
-            ExistingPeriodicWorkPolicy.Update!,
+            policy,
             workRequest);
 
-        MessageService.Info($"Scheduled periodic check every {intervalHours} hours");
+        MessageService.Info($"Scheduled periodic check every {intervalHours} hours ({policy})");
     }
 }

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckScheduler.cs
@@ -1,4 +1,5 @@
 using Android.Content;
+using Android.OS;
 using AndroidX.Work;
 using LanobeReader.Helpers;
 using TBird.Core;
@@ -7,6 +8,35 @@ namespace LanobeReader.Platforms.Android;
 
 public static class UpdateCheckScheduler
 {
+    public const string ONETIME_WORK = "lanobe_update_check_once";
+
+    /// <summary>
+    /// アラーム発火時に一回限りの更新チェックを実行する。API 31+ は通知不要の expedited ジョブで
+    /// Doze 中も実行。古い OS は通常ワークにフォールバック。
+    /// Replace を使い、ネットワーク制約で滞留した古いインスタンスへ後続発火が併合されて
+    /// 握り潰される事態を防ぐ(実際の重複実行は UpdateCheckService 側の単一実行ガードが抑止)。
+    /// </summary>
+    public static void EnqueueOneTimeCheck(Context context)
+    {
+        var constraints = new Constraints.Builder()
+            .SetRequiredNetworkType(NetworkType.Connected!)
+            .Build();
+
+        var builder = new OneTimeWorkRequest.Builder(typeof(UpdateCheckWorker))
+            .SetConstraints(constraints)
+            .AddTag(UpdateCheckWorker.WORK_TAG);
+
+        if (Build.VERSION.SdkInt >= BuildVersionCodes.S)
+        {
+            builder.SetExpedited(OutOfQuotaPolicy.RunAsNonExpeditedWorkRequest!);
+        }
+
+        WorkManager.GetInstance(context)!.EnqueueUniqueWork(
+            ONETIME_WORK, ExistingWorkPolicy.Replace!, builder.Build());
+
+        MessageService.Info("Enqueued one-time update check (alarm)");
+    }
+
     public static void SchedulePeriodicCheck(Context context, int intervalHours = 6)
     {
         var constraints = new Constraints.Builder()
@@ -17,6 +47,8 @@ public static class UpdateCheckScheduler
                 typeof(UpdateCheckWorker),
                 TimeSpan.FromHours(intervalHours))
             .SetConstraints(constraints)
+            // Worker が Retry を返した場合(DI 未初期化等)の再試行間隔。指数バックオフ・初期 30 秒。
+            .SetBackoffCriteria(BackoffPolicy.Exponential!, TimeSpan.FromSeconds(30))
             .AddTag(UpdateCheckWorker.WORK_TAG)
             .Build();
 

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckScheduler.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckScheduler.cs
@@ -37,7 +37,7 @@ public static class UpdateCheckScheduler
         MessageService.Info("Enqueued one-time update check (alarm)");
     }
 
-    public static void SchedulePeriodicCheck(Context context, int intervalHours = 6)
+    public static void SchedulePeriodicCheck(Context context, int intervalHours = SettingsKeys.DEFAULT_UPDATE_INTERVAL_HOURS)
     {
         var constraints = new Constraints.Builder()
             .SetRequiredNetworkType(NetworkType.Connected!)

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckWorker.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckWorker.cs
@@ -1,10 +1,6 @@
 using Android.Content;
 using AndroidX.Work;
-using LanobeReader.Helpers;
 using TBird.Core;
-using LanobeReader.Models;
-using LanobeReader.Services;
-using LanobeReader.Services.Database;
 
 namespace LanobeReader.Platforms.Android;
 
@@ -20,50 +16,15 @@ public class UpdateCheckWorker : Worker
     {
         try
         {
-            var services = IPlatformApplication.Current?.Services;
-            if (services is null)
+            // Worker threads have no SynchronizationContext, so blocking on Task.Run is safe here.
+            // 実処理は前面サービス経路と共通の UpdateCheckRunner に集約。
+            var outcome = Task.Run(() => UpdateCheckRunner.RunAsync(ApplicationContext)).GetAwaiter().GetResult();
+            return outcome switch
             {
-                // MainApplication 初期化完了前に Worker が起動した可能性。
-                // Retry で WorkManager のバックオフに任せる（次回はプロセスが暖まっている見込み）。
-                MessageService.Warn("IPlatformApplication.Current is null, retry later");
-                return Result.InvokeRetry();
-            }
-
-            var dbService = services.GetService<DatabaseService>();
-            var novelRepo = services.GetService<NovelRepository>();
-            var episodeRepo = services.GetService<EpisodeRepository>();
-            var updateCheckService = services.GetService<UpdateCheckService>();
-
-            if (dbService is null || novelRepo is null || episodeRepo is null || updateCheckService is null)
-            {
-                MessageService.Error("Failed to resolve services");
-                return Result.InvokeFailure();
-            }
-
-            // Ensure DB is initialized (Worker may run before app startup completes)
-            dbService.EnsureInitializedAsync().GetAwaiter().GetResult();
-
-            // Worker threads have no SynchronizationContext, so blocking on Task.Run is safe here
-            var updates = Task.Run(() => updateCheckService.CheckAllAsync()).GetAwaiter().GetResult();
-
-            foreach (var (novel, newCount) in updates)
-            {
-                // Get first unread episode for deep link
-                var firstUnread = Task.Run(() => episodeRepo.GetFirstUnreadEpisodeAsync(novel.Id)).GetAwaiter().GetResult();
-                var episodeId = firstUnread?.Id ?? 0;
-
-                NotificationHelper.ShowUpdateNotification(
-                    ApplicationContext,
-                    novel.Id, // Use novel ID as notification ID
-                    "ラノベリーダ",
-                    $"{novel.Title}: {newCount}話更新",
-                    novel.Id,
-                    episodeId,
-                    novel.SiteType,
-                    novel.NovelId);
-            }
-
-            return Result.InvokeSuccess();
+                UpdateCheckRunner.Outcome.Retry => Result.InvokeRetry(),
+                UpdateCheckRunner.Outcome.Failure => Result.InvokeFailure(),
+                _ => Result.InvokeSuccess(),
+            };
         }
         catch (Exception ex)
         {

--- a/_Apps/LanobeReader/Platforms/Android/UpdateCheckWorker.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateCheckWorker.cs
@@ -8,8 +8,18 @@ public class UpdateCheckWorker : Worker
 {
     public const string WORK_TAG = "lanobe_update_check";
 
+    // WorkManager が停止(quota 失効/制約喪失/システム回収)を通知したとき、進行中の巡回を
+    // 協調キャンセルするためのトークン。これにより CheckAll のラウンドロビン「続きから再開」が機能する。
+    private readonly CancellationTokenSource _cts = new();
+
     public UpdateCheckWorker(Context context, WorkerParameters workerParams) : base(context, workerParams)
     {
+    }
+
+    public override void OnStopped()
+    {
+        try { _cts.Cancel(); } catch { /* 破棄済み */ }
+        base.OnStopped();
     }
 
     public override Result DoWork()
@@ -18,7 +28,7 @@ public class UpdateCheckWorker : Worker
         {
             // Worker threads have no SynchronizationContext, so blocking on Task.Run is safe here.
             // 実処理は前面サービス経路と共通の UpdateCheckRunner に集約。
-            var outcome = Task.Run(() => UpdateCheckRunner.RunAsync(ApplicationContext)).GetAwaiter().GetResult();
+            var outcome = Task.Run(() => UpdateCheckRunner.RunAsync(ApplicationContext, _cts.Token)).GetAwaiter().GetResult();
             return outcome switch
             {
                 UpdateCheckRunner.Outcome.Retry => Result.InvokeRetry(),
@@ -30,6 +40,10 @@ public class UpdateCheckWorker : Worker
         {
             MessageService.Error($"Unexpected error: {ex.Message}");
             return Result.InvokeFailure();
+        }
+        finally
+        {
+            _cts.Dispose();
         }
     }
 }

--- a/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
@@ -1,6 +1,7 @@
 using LanobeReader.Models;
 using LanobeReader.Services;
 using LanobeReader.Services.Database;
+using LanobeReader.Views;
 using TBird.Core;
 
 namespace LanobeReader.Platforms.Android;
@@ -25,10 +26,10 @@ public class UpdateNotificationService : IUpdateNotificationService
 	{
 		if (updates.Count == 0) return;
 
-		// アプリが前面にある間はシステム通知を出さない。アプリ内一覧が新着(NEW)を直接表示しており、
-		// かつ MainActivity.OnResume の CancelAll が直後に消すため(= 機能同士の競合)。
-		// この時点で DB は更新済みのため、ユーザは一覧画面で新着を確認できる。
-		if (AppForegroundTracker.IsForeground) return;
+		// 一覧(本棚)ページが前面に表示されている間だけシステム通知を抑止する。一覧は新着(NEW)を
+		// 直接表示し、かつ MainActivity.OnResume の CancelAll が直後に消すため(= 機能同士の競合)。
+		// 他ページ(Reader/Settings 等)滞在中は一覧の NEW が見えないため、抑止せず通知を出す。
+		if (AppForegroundTracker.IsForeground && NovelListPage.IsShowing) return;
 
 		var context = global::Android.App.Application.Context;
 
@@ -58,9 +59,9 @@ public class UpdateNotificationService : IUpdateNotificationService
 			targets = new Dictionary<int, int>();
 		}
 
-		// 上の await 中にアプリが前面化した場合、MainActivity.OnResume の CancelAll が既に走った後に
+		// 上の await 中に一覧が前面化した場合、MainActivity.OnResume の CancelAll が既に走った後に
 		// 通知を投稿すると消えない通知が残る(冒頭の前面判定との TOCTOU)。投稿直前に再判定して中止する。
-		if (AppForegroundTracker.IsForeground) return;
+		if (AppForegroundTracker.IsForeground && NovelListPage.IsShowing) return;
 
 		for (int i = 0; i < updates.Count; i++)
 		{

--- a/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
@@ -36,8 +36,9 @@ public class UpdateNotificationService : IUpdateNotificationService
 		// COUNT クエリで算出(全件ロードを避ける)。
 		var unconfirmedCount = await _novelRepo.CountUnconfirmedAsync().ConfigureAwait(false);
 
-		foreach (var (novel, newCount) in updates)
+		for (int i = 0; i < updates.Count; i++)
 		{
+			var (novel, newCount) = updates[i];
 			try
 			{
 				// ディープリンク先 = その小説の最初の未読話。未読が無ければ最後に読んだ話へ
@@ -45,6 +46,11 @@ public class UpdateNotificationService : IUpdateNotificationService
 				var target = await _episodeRepo.GetFirstUnreadEpisodeAsync(novel.Id).ConfigureAwait(false)
 					?? await _episodeRepo.GetLastReadEpisodeAsync(novel.Id).ConfigureAwait(false);
 				var episodeId = target?.Id ?? 0;
+
+				// 数字バッジは最後の 1 通にのみ総数を付ける。各通知に総数を付けると、通知ごとの
+				// number を合算する OEM ランチャーで「通知数 × 総数」に膨らむため。
+				// (合算式: 0+0+…+総数=総数 / 最大式: 総数 のどちらでも正しい値になる)
+				var badge = (i == updates.Count - 1) ? unconfirmedCount : 0;
 
 				NotificationHelper.ShowUpdateNotification(
 					context,
@@ -55,7 +61,7 @@ public class UpdateNotificationService : IUpdateNotificationService
 					episodeId,
 					novel.SiteType,
 					novel.NovelId,
-					unconfirmedCount);
+					badge);
 			}
 			catch (Exception ex)
 			{

--- a/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
@@ -35,22 +35,28 @@ public class UpdateNotificationService : IUpdateNotificationService
 		// OEM ランチャー(Samsung/Xiaomi 等)の数字バッジ用に「未確認更新を持つ小説数」を
 		// COUNT クエリで算出(全件ロードを避ける)。
 		var unconfirmedCount = await _novelRepo.CountUnconfirmedAsync().ConfigureAwait(false);
+		// 別クエリの COUNT は、挿入とこの COUNT の間に確認操作/CancelAll が走ると今回投稿する
+		// 通知数を下回りうる(0 になることも)。表示中の通知数を下回らないよう下限を担保する。
+		var badgeTotal = Math.Max(unconfirmedCount, updates.Count);
+
+		// ディープリンク先(各小説の最初の未読話、無ければ最後に読んだ話)を 1 度の集約クエリで解決。
+		// 作品ごとに 2 クエリを逐次発行する従来方式(最大 2×N 往復)を避ける。
+		var novelIds = updates.Select(u => u.novel.Id).ToList();
+		var targets = await _episodeRepo.GetDeepLinkTargetEpisodeIdsAsync(novelIds).ConfigureAwait(false);
 
 		for (int i = 0; i < updates.Count; i++)
 		{
 			var (novel, newCount) = updates[i];
 			try
 			{
-				// ディープリンク先 = その小説の最初の未読話。未読が無ければ最後に読んだ話へ
-				// フォールバックし、タップが無反応になる事態を避ける。
-				var target = await _episodeRepo.GetFirstUnreadEpisodeAsync(novel.Id).ConfigureAwait(false)
-					?? await _episodeRepo.GetLastReadEpisodeAsync(novel.Id).ConfigureAwait(false);
-				var episodeId = target?.Id ?? 0;
+				// ディープリンク先 = その小説の最初の未読話(無ければ最後に読んだ話)。
+				// 解決できない場合は 0 とし、タップ時は話一覧へ遷移する(MainActivity 側)。
+				var episodeId = targets.TryGetValue(novel.Id, out var id) ? id : 0;
 
 				// 数字バッジは最後の 1 通にのみ総数を付ける。各通知に総数を付けると、通知ごとの
 				// number を合算する OEM ランチャーで「通知数 × 総数」に膨らむため。
 				// (合算式: 0+0+…+総数=総数 / 最大式: 総数 のどちらでも正しい値になる)
-				var badge = (i == updates.Count - 1) ? unconfirmedCount : 0;
+				var badge = (i == updates.Count - 1) ? badgeTotal : 0;
 
 				NotificationHelper.ShowUpdateNotification(
 					context,

--- a/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
@@ -1,0 +1,67 @@
+using LanobeReader.Models;
+using LanobeReader.Services;
+using LanobeReader.Services.Database;
+using TBird.Core;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// <see cref="IUpdateNotificationService"/> の Android 実装。
+/// 新着のディープリンク先(最初の未読話)解決と、OEM ランチャー向け数字バッジ
+/// (未確認更新を持つ小説数)の算出を行い、NotificationHelper で通知を表示する。
+/// </summary>
+public class UpdateNotificationService : IUpdateNotificationService
+{
+	private readonly EpisodeRepository _episodeRepo;
+	private readonly NovelRepository _novelRepo;
+
+	public UpdateNotificationService(EpisodeRepository episodeRepo, NovelRepository novelRepo)
+	{
+		_episodeRepo = episodeRepo;
+		_novelRepo = novelRepo;
+	}
+
+	public async Task ShowUpdatesAsync(IReadOnlyList<(Novel novel, int newEpisodeCount)> updates)
+	{
+		if (updates.Count == 0) return;
+
+		// アプリが前面にある間はシステム通知を出さない。アプリ内一覧が新着(NEW)を直接表示しており、
+		// かつ MainActivity.OnResume の CancelAll が直後に消すため(= 機能同士の競合)。
+		// この時点で DB は更新済みのため、ユーザは一覧画面で新着を確認できる。
+		if (AppForegroundTracker.IsForeground) return;
+
+		var context = global::Android.App.Application.Context;
+
+		// OEM ランチャー(Samsung/Xiaomi 等)の数字バッジ用に「未確認更新を持つ小説数」を
+		// COUNT クエリで算出(全件ロードを避ける)。
+		var unconfirmedCount = await _novelRepo.CountUnconfirmedAsync().ConfigureAwait(false);
+
+		foreach (var (novel, newCount) in updates)
+		{
+			try
+			{
+				// ディープリンク先 = その小説の最初の未読話。未読が無ければ最後に読んだ話へ
+				// フォールバックし、タップが無反応になる事態を避ける。
+				var target = await _episodeRepo.GetFirstUnreadEpisodeAsync(novel.Id).ConfigureAwait(false)
+					?? await _episodeRepo.GetLastReadEpisodeAsync(novel.Id).ConfigureAwait(false);
+				var episodeId = target?.Id ?? 0;
+
+				NotificationHelper.ShowUpdateNotification(
+					context,
+					novel.Id, // notificationId = novel.Id（同一小説の通知は上書き）
+					"ラノベリーダ",
+					$"{novel.Title}: {newCount}話更新",
+					novel.Id,
+					episodeId,
+					novel.SiteType,
+					novel.NovelId,
+					unconfirmedCount);
+			}
+			catch (Exception ex)
+			{
+				// 1 件の失敗で残りの通知が止まらないよう小説単位で握りつぶしてログのみ。
+				MessageService.Warn($"ShowUpdateNotification failed for novel {novel.Id}: {ex.Message}");
+			}
+		}
+	}
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateNotificationService.cs
@@ -32,17 +32,35 @@ public class UpdateNotificationService : IUpdateNotificationService
 
 		var context = global::Android.App.Application.Context;
 
-		// OEM ランチャー(Samsung/Xiaomi 等)の数字バッジ用に「未確認更新を持つ小説数」を
-		// COUNT クエリで算出(全件ロードを避ける)。
-		var unconfirmedCount = await _novelRepo.CountUnconfirmedAsync().ConfigureAwait(false);
-		// 別クエリの COUNT は、挿入とこの COUNT の間に確認操作/CancelAll が走ると今回投稿する
-		// 通知数を下回りうる(0 になることも)。表示中の通知数を下回らないよう下限を担保する。
-		var badgeTotal = Math.Max(unconfirmedCount, updates.Count);
+		// バッジ数とディープリンク先を解決する。どちらも通知本体とは別物のため、ここでのクエリ失敗で
+		// 通知全体を止めない: バッジは表示中の通知数、遷移先は話一覧(episodeId=0)へフォールバックし、
+		// 通知だけは確実に投稿する。
+		int badgeTotal;
+		Dictionary<int, int> targets;
+		try
+		{
+			// OEM ランチャー(Samsung/Xiaomi 等)の数字バッジ用に「未確認更新を持つ小説数」を
+			// COUNT クエリで算出(全件ロードを避ける)。
+			var unconfirmedCount = await _novelRepo.CountUnconfirmedAsync().ConfigureAwait(false);
+			// 別クエリの COUNT は、挿入とこの COUNT の間に確認操作/CancelAll が走ると今回投稿する
+			// 通知数を下回りうる(0 になることも)。表示中の通知数を下回らないよう下限を担保する。
+			badgeTotal = Math.Max(unconfirmedCount, updates.Count);
 
-		// ディープリンク先(各小説の最初の未読話、無ければ最後に読んだ話)を 1 度の集約クエリで解決。
-		// 作品ごとに 2 クエリを逐次発行する従来方式(最大 2×N 往復)を避ける。
-		var novelIds = updates.Select(u => u.novel.Id).ToList();
-		var targets = await _episodeRepo.GetDeepLinkTargetEpisodeIdsAsync(novelIds).ConfigureAwait(false);
+			// ディープリンク先(各小説の最初の未読話、無ければ最後に読んだ話)を 1 度の集約クエリで解決。
+			// 作品ごとに 2 クエリを逐次発行する従来方式(最大 2×N 往復)を避ける。
+			var novelIds = updates.Select(u => u.novel.Id).ToList();
+			targets = await _episodeRepo.GetDeepLinkTargetEpisodeIdsAsync(novelIds).ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			MessageService.Warn($"Notification metadata resolution failed; using fallback: {ex.Message}");
+			badgeTotal = updates.Count;
+			targets = new Dictionary<int, int>();
+		}
+
+		// 上の await 中にアプリが前面化した場合、MainActivity.OnResume の CancelAll が既に走った後に
+		// 通知を投稿すると消えない通知が残る(冒頭の前面判定との TOCTOU)。投稿直前に再判定して中止する。
+		if (AppForegroundTracker.IsForeground) return;
 
 		for (int i = 0; i < updates.Count; i++)
 		{

--- a/_Apps/LanobeReader/Platforms/Android/UpdateSchedulingCoordinator.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateSchedulingCoordinator.cs
@@ -1,0 +1,35 @@
+using Android.Content;
+
+namespace LanobeReader.Platforms.Android;
+
+/// <summary>
+/// 更新チェックの二機構（WorkManager 定期ワーク + setAndAllowWhileIdle アラーム）を
+/// 「常に同一間隔でペア武装する」唯一の地点。
+/// MainActivity のフォールバック各分岐・設定変更（<see cref="AndroidUpdateScheduler"/>）は
+/// 必ずここを経由し、両機構の間隔が静かに乖離（drift）する事態を構造的に防ぐ。
+///
+/// ※ 通常起動の正常経路（MainActivity）と Worker の DB 再同期は、意図的にここを経由しない:
+///   - 正常経路: 定期ワークは「DB 値 != 前回 schedule 値」のときのみ再登録し、毎起動での
+///     周期リセットを避ける。アラームのみ毎起動で冪等に再武装する。
+///   - Worker 再同期: 定期ワークは Preferences ミラーに依存せず drift しないため、
+///     毎実行で再登録すると周期がリセットされ続ける。アラーム（Preferences ミラー依存）のみ是正する。
+/// </summary>
+public static class UpdateSchedulingCoordinator
+{
+    /// <summary>
+    /// WorkManager 定期ワークとアラームを同一間隔で武装する。
+    /// 設定変更時・DI/DB が利用不能なフォールバック時の唯一の経路。
+    /// </summary>
+    public static void ArmBoth(Context context, int intervalHours)
+    {
+        UpdateCheckScheduler.SchedulePeriodicCheck(context, intervalHours); // WiFi 等で堅実なベースライン
+        UpdateAlarmScheduler.ScheduleNext(context, intervalHours);          // Doze 貫通
+    }
+
+    /// <summary>
+    /// キャッシュ（Preferences ミラー）の間隔で両機構を武装する。
+    /// DI/DB 未準備のフォールバック分岐用。
+    /// </summary>
+    public static void ArmBothFromCache(Context context)
+        => ArmBoth(context, UpdateAlarmScheduler.GetCachedIntervalHours());
+}

--- a/_Apps/LanobeReader/Platforms/Android/UpdateSchedulingCoordinator.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateSchedulingCoordinator.cs
@@ -4,21 +4,25 @@ namespace LanobeReader.Platforms.Android;
 
 /// <summary>
 /// 更新チェックの二機構（WorkManager 定期ワーク + setAndAllowWhileIdle アラーム）を
-/// 「常に同一間隔でペア武装する」唯一の地点。
-/// MainActivity のフォールバック各分岐・設定変更（<see cref="AndroidUpdateScheduler"/>）は
-/// 必ずここを経由し、両機構の間隔が静かに乖離（drift）する事態を構造的に防ぐ。
+/// 同一間隔でペア武装する共通ヘルパ。間隔が「一括で指定される」経路
+/// ―― 設定変更（<see cref="AndroidUpdateScheduler"/>）と、DI/DB 利用不能時の
+/// フォールバック（MainActivity の OnCreate 早期 return 分岐）―― の重複を畳む。
 ///
-/// ※ 通常起動の正常経路（MainActivity）と Worker の DB 再同期は、意図的にここを経由しない:
-///   - 正常経路: 定期ワークは「DB 値 != 前回 schedule 値」のときのみ再登録し、毎起動での
-///     周期リセットを避ける。アラームのみ毎起動で冪等に再武装する。
-///   - Worker 再同期: 定期ワークは Preferences ミラーに依存せず drift しないため、
+/// ※ 重要: 本クラスは drift を強制的に防ぐ「単一の関門」ではない。両機構を別々に扱うべき
+///   正常経路は、意図的に本クラスを経由せず各スケジューラを直接呼ぶ:
+///   - MainActivity 正常経路: 定期ワークは「DB 値 != 前回 schedule 値」のときのみ再登録し
+///     毎起動の周期リセットを避ける一方、アラームは毎起動で冪等に再武装する（非対称なため）。
+///   - MainActivity catch フォールバック: 片方の失敗でもう片方を巻き込まないよう各機構を独立 try で武装する。
+///   - Worker / FGS の DB 再同期: 定期ワークは Preferences ミラーに依存せず drift しないため、
 ///     毎実行で再登録すると周期がリセットされ続ける。アラーム（Preferences ミラー依存）のみ是正する。
+///   これらの経路を本クラスへ無理に集約すると上記の周期リセット等を招くため、共通化はあくまで
+///   「間隔を一括指定する経路」に限定している。drift 是正の実体は ScheduleNext の冪等再武装が担う。
 /// </summary>
 public static class UpdateSchedulingCoordinator
 {
     /// <summary>
     /// WorkManager 定期ワークとアラームを同一間隔で武装する。
-    /// 設定変更時・DI/DB が利用不能なフォールバック時の唯一の経路。
+    /// 間隔を一括指定する経路（設定変更時・DI/DB が利用不能なフォールバック時）で利用する。
     /// </summary>
     public static void ArmBoth(Context context, int intervalHours)
     {

--- a/_Apps/LanobeReader/Platforms/Android/UpdateSchedulingCoordinator.cs
+++ b/_Apps/LanobeReader/Platforms/Android/UpdateSchedulingCoordinator.cs
@@ -3,20 +3,14 @@ using Android.Content;
 namespace LanobeReader.Platforms.Android;
 
 /// <summary>
-/// 更新チェックの二機構（WorkManager 定期ワーク + setAndAllowWhileIdle アラーム）を
-/// 同一間隔でペア武装する共通ヘルパ。間隔が「一括で指定される」経路
-/// ―― 設定変更（<see cref="AndroidUpdateScheduler"/>）と、DI/DB 利用不能時の
-/// フォールバック（MainActivity の OnCreate 早期 return 分岐）―― の重複を畳む。
+/// 更新チェックの二機構（WorkManager 定期ワーク + アラーム）を同一間隔でペア武装する共通ヘルパ。
+/// 「間隔を一括指定する」経路 ―― 設定変更（<see cref="AndroidUpdateScheduler"/>）と DI/DB 利用不能時の
+/// フォールバック ―― の重複だけを畳む。
 ///
-/// ※ 重要: 本クラスは drift を強制的に防ぐ「単一の関門」ではない。両機構を別々に扱うべき
-///   正常経路は、意図的に本クラスを経由せず各スケジューラを直接呼ぶ:
-///   - MainActivity 正常経路: 定期ワークは「DB 値 != 前回 schedule 値」のときのみ再登録し
-///     毎起動の周期リセットを避ける一方、アラームは毎起動で冪等に再武装する（非対称なため）。
-///   - MainActivity catch フォールバック: 片方の失敗でもう片方を巻き込まないよう各機構を独立 try で武装する。
-///   - Worker / FGS の DB 再同期: 定期ワークは Preferences ミラーに依存せず drift しないため、
-///     毎実行で再登録すると周期がリセットされ続ける。アラーム（Preferences ミラー依存）のみ是正する。
-///   これらの経路を本クラスへ無理に集約すると上記の周期リセット等を招くため、共通化はあくまで
-///   「間隔を一括指定する経路」に限定している。drift 是正の実体は ScheduleNext の冪等再武装が担う。
+/// 注意: 本クラスは drift を防ぐ単一の関門ではない。両機構を非対称に扱う正常経路(MainActivity の
+/// 通常分岐・Worker/FGS の DB 再同期)は意図的に本クラスを経由せず各スケジューラを直接呼ぶ
+/// (定期ワークを毎回再登録すると周期がリセットされ続けるため)。drift 是正の実体は ScheduleNext の
+/// 冪等再武装が担う。
 /// </summary>
 public static class UpdateSchedulingCoordinator
 {
@@ -26,8 +20,12 @@ public static class UpdateSchedulingCoordinator
     /// </summary>
     public static void ArmBoth(Context context, int intervalHours)
     {
+        // 失敗しうる側(exact アラーム: 一部 OEM で権限失効時に SecurityException)を先に武装する。
+        // ここで例外が出れば WorkManager 側は未変更で、両機構が旧間隔のまま揃う(=ドリフトしない。
+        // 次回起動の MainActivity 冪等再武装で新間隔へ自己修復)。逆順だと WorkManager だけ新間隔で
+        // アラームが旧間隔という不一致が残る。
+        UpdateAlarmScheduler.ScheduleNext(context, intervalHours);          // Doze 貫通(失敗しうる)
         UpdateCheckScheduler.SchedulePeriodicCheck(context, intervalHours); // WiFi 等で堅実なベースライン
-        UpdateAlarmScheduler.ScheduleNext(context, intervalHours);          // Doze 貫通
     }
 
     /// <summary>

--- a/_Apps/LanobeReader/Services/Database/DatabaseService.cs
+++ b/_Apps/LanobeReader/Services/Database/DatabaseService.cs
@@ -26,6 +26,7 @@ public class DatabaseService : SqliteDatabaseBase
         // 2. 既存カラム追加（新規カラムの後方互換）
         await EnsureColumnAsync(conn, "novels", "is_favorite", "INTEGER NOT NULL DEFAULT 0").ConfigureAwait(false);
         await EnsureColumnAsync(conn, "novels", "favorited_at", "TEXT NULL").ConfigureAwait(false);
+        await EnsureColumnAsync(conn, "novels", "last_checked_at", "TEXT NULL").ConfigureAwait(false);
         await EnsureColumnAsync(conn, "episodes", "is_favorite", "INTEGER NOT NULL DEFAULT 0").ConfigureAwait(false);
         await EnsureColumnAsync(conn, "episodes", "favorited_at", "TEXT NULL").ConfigureAwait(false);
 

--- a/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
@@ -114,6 +114,53 @@ public class EpisodeRepository
             .FirstOrDefaultAsync().ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// 複数小説のディープリンク先エピソード Id をまとめて解決する。各小説につき
+    /// 「最初の未読話(最小 episode_no)」、未読が無ければ「最後に読んだ話(最大 episode_no)」。
+    /// 通知ループでの作品ごと逐次クエリ(最大 2×N 往復)を 2 クエリに集約する。戻り値は novelId -> episodeId。
+    /// 該当話が無い小説はキーを持たない(呼び出し側で 0 フォールバック)。
+    /// </summary>
+    public async Task<Dictionary<int, int>> GetDeepLinkTargetEpisodeIdsAsync(IReadOnlyList<int> novelIds)
+    {
+        var result = new Dictionary<int, int>();
+        if (novelIds.Count == 0) return result;
+        await EnsureAsync().ConfigureAwait(false);
+
+        var placeholders = string.Join(",", novelIds.Select(_ => "?"));
+        var args = novelIds.Cast<object>().ToArray();
+
+        // 各小説の最初の未読話(最小 episode_no)。
+        var firstUnread = await _db.QueryAsync<EpisodeRef>(
+            $"SELECT e.novel_id AS NovelId, e.id AS Id FROM episodes e " +
+            $"WHERE e.is_read = 0 AND e.novel_id IN ({placeholders}) " +
+            $"AND e.episode_no = (SELECT MIN(episode_no) FROM episodes " +
+            $"WHERE novel_id = e.novel_id AND is_read = 0)",
+            args).ConfigureAwait(false);
+        foreach (var r in firstUnread) result[r.NovelId] = r.Id;
+
+        // 未読が無い小説は最後に読んだ話(最大 episode_no)へフォールバック。
+        var remaining = novelIds.Where(id => !result.ContainsKey(id)).ToList();
+        if (remaining.Count > 0)
+        {
+            var ph2 = string.Join(",", remaining.Select(_ => "?"));
+            var args2 = remaining.Cast<object>().ToArray();
+            var lastRead = await _db.QueryAsync<EpisodeRef>(
+                $"SELECT e.novel_id AS NovelId, e.id AS Id FROM episodes e " +
+                $"WHERE e.is_read = 1 AND e.novel_id IN ({ph2}) " +
+                $"AND e.episode_no = (SELECT MAX(episode_no) FROM episodes " +
+                $"WHERE novel_id = e.novel_id AND is_read = 1)",
+                args2).ConfigureAwait(false);
+            foreach (var r in lastRead) result[r.NovelId] = r.Id;
+        }
+        return result;
+    }
+
+    private sealed class EpisodeRef
+    {
+        public int NovelId { get; set; }
+        public int Id { get; set; }
+    }
+
     public async Task InsertAllAsync(IEnumerable<Episode> episodes)
     {
         await EnsureAsync().ConfigureAwait(false);

--- a/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
@@ -161,7 +161,16 @@ public class EpisodeRepository
                 $"AND e.episode_no = (SELECT {agg}(episode_no) FROM episodes " +
                 $"WHERE novel_id = e.novel_id AND is_read = {isRead})",
                 args).ConfigureAwait(false);
-            foreach (var r in rows) result[r.NovelId] = r.Id;
+            // episodes(novel_id, episode_no) に一意制約は無く、重複 episode_no 行があると
+            // 同一 novel に複数行が返りうる。最小 id を採用して遷移先を決定的にする
+            // (行順依存で通知タップ先がブレるのを防ぐ)。
+            foreach (var r in rows)
+            {
+                if (!result.TryGetValue(r.NovelId, out var existing) || r.Id < existing)
+                {
+                    result[r.NovelId] = r.Id;
+                }
+            }
         }
     }
 

--- a/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
@@ -126,33 +126,43 @@ public class EpisodeRepository
         if (novelIds.Count == 0) return result;
         await EnsureAsync().ConfigureAwait(false);
 
-        var placeholders = string.Join(",", novelIds.Select(_ => "?"));
-        var args = novelIds.Cast<object>().ToArray();
-
         // 各小説の最初の未読話(最小 episode_no)。
-        var firstUnread = await _db.QueryAsync<EpisodeRef>(
-            $"SELECT e.novel_id AS NovelId, e.id AS Id FROM episodes e " +
-            $"WHERE e.is_read = 0 AND e.novel_id IN ({placeholders}) " +
-            $"AND e.episode_no = (SELECT MIN(episode_no) FROM episodes " +
-            $"WHERE novel_id = e.novel_id AND is_read = 0)",
-            args).ConfigureAwait(false);
-        foreach (var r in firstUnread) result[r.NovelId] = r.Id;
+        await ResolveTargetEpisodesAsync(novelIds, isRead: 0, useMin: true, result).ConfigureAwait(false);
 
         // 未読が無い小説は最後に読んだ話(最大 episode_no)へフォールバック。
         var remaining = novelIds.Where(id => !result.ContainsKey(id)).ToList();
         if (remaining.Count > 0)
         {
-            var ph2 = string.Join(",", remaining.Select(_ => "?"));
-            var args2 = remaining.Cast<object>().ToArray();
-            var lastRead = await _db.QueryAsync<EpisodeRef>(
-                $"SELECT e.novel_id AS NovelId, e.id AS Id FROM episodes e " +
-                $"WHERE e.is_read = 1 AND e.novel_id IN ({ph2}) " +
-                $"AND e.episode_no = (SELECT MAX(episode_no) FROM episodes " +
-                $"WHERE novel_id = e.novel_id AND is_read = 1)",
-                args2).ConfigureAwait(false);
-            foreach (var r in lastRead) result[r.NovelId] = r.Id;
+            await ResolveTargetEpisodesAsync(remaining, isRead: 1, useMin: false, result).ConfigureAwait(false);
         }
         return result;
+    }
+
+    /// <summary>
+    /// novelIds の各小説について is_read=<paramref name="isRead"/> の話の中で episode_no が
+    /// 最小(<paramref name="useMin"/>=true)/最大の話 Id を解決し <paramref name="result"/> へ詰める。
+    /// SQLite の変数上限(既定 999)に達しないよう IN 句の引数をチャンク分割して照会する。
+    /// </summary>
+    private async Task ResolveTargetEpisodesAsync(
+        IReadOnlyList<int> novelIds, int isRead, bool useMin, Dictionary<int, int> result)
+    {
+        const int ChunkSize = 900;
+        // isRead(0/1) と agg(MIN/MAX) はコード由来のリテラルでユーザ入力ではないため SQL に直接埋めてよい。
+        // 可変長の novelIds のみプレースホルダでパラメータ化する。
+        var agg = useMin ? "MIN" : "MAX";
+        for (int offset = 0; offset < novelIds.Count; offset += ChunkSize)
+        {
+            var chunk = novelIds.Skip(offset).Take(ChunkSize).ToList();
+            var placeholders = string.Join(",", chunk.Select(_ => "?"));
+            var args = chunk.Cast<object>().ToArray();
+            var rows = await _db.QueryAsync<EpisodeRef>(
+                $"SELECT e.novel_id AS NovelId, e.id AS Id FROM episodes e " +
+                $"WHERE e.is_read = {isRead} AND e.novel_id IN ({placeholders}) " +
+                $"AND e.episode_no = (SELECT {agg}(episode_no) FROM episodes " +
+                $"WHERE novel_id = e.novel_id AND is_read = {isRead})",
+                args).ConfigureAwait(false);
+            foreach (var r in rows) result[r.NovelId] = r.Id;
+        }
     }
 
     private sealed class EpisodeRef

--- a/_Apps/LanobeReader/Services/Database/NovelRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/NovelRepository.cs
@@ -163,6 +163,18 @@ public class NovelRepository
         return await _db.UpdateAsync(novel).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// last_checked_at 列のみを更新する軽量メソッド。更新チェックで状態に変化が無い
+    /// (新着なし・エラー状態も不変)作品の巡回タイムスタンプ前進に使い、全カラム UPDATE を避ける。
+    /// </summary>
+    public async Task UpdateLastCheckedAtAsync(int novelId, string lastCheckedAt)
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        await _db.ExecuteAsync(
+            "UPDATE novels SET last_checked_at = ? WHERE id = ?",
+            lastCheckedAt, novelId).ConfigureAwait(false);
+    }
+
     public async Task SetFavoriteAsync(int novelId, bool favorite)
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);

--- a/_Apps/LanobeReader/Services/Database/NovelRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/NovelRepository.cs
@@ -42,6 +42,20 @@ public class NovelRepository
             .ToListAsync().ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// 更新チェック用に「最後にチェックした時刻が古い順(未チェック=null を最優先)」で全件取得する。
+    /// SQLite では NULL が ASC で先頭に来るため、未チェックの小説が最優先で回る。
+    /// 3分上限等で打ち切られても次回が続きから拾える (ラウンドロビン) ようにするため、
+    /// UI 表示用の <see cref="GetAllAsync"/>(last_updated_at 降順) とは別順序で返す。
+    /// </summary>
+    public async Task<List<Novel>> GetAllForCheckAsync()
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.Table<Novel>()
+            .OrderBy(n => n.LastCheckedAt)
+            .ToListAsync().ConfigureAwait(false);
+    }
+
     public async Task<List<NovelWithUnread>> GetAllWithUnreadCountAsync(string sortKey)
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
@@ -194,5 +208,17 @@ public class NovelRepository
     {
         await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
         return await _db.Table<Novel>().CountAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// 未確認の更新を持つ小説数を COUNT クエリで取得する(全件ロードを避ける)。
+    /// OEM ランチャーの数字バッジ用。
+    /// </summary>
+    public async Task<int> CountUnconfirmedAsync()
+    {
+        await _dbService.EnsureInitializedAsync().ConfigureAwait(false);
+        return await _db.Table<Novel>()
+            .Where(n => n.HasUnconfirmedUpdate)
+            .CountAsync().ConfigureAwait(false);
     }
 }

--- a/_Apps/LanobeReader/Services/IUpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Services/IUpdateNotificationService.cs
@@ -1,0 +1,19 @@
+using LanobeReader.Models;
+
+namespace LanobeReader.Services;
+
+/// <summary>
+/// 新着更新をユーザに通知する抽象。
+/// フォアグラウンド(アプリ起動時の CheckAllAsync)・バックグラウンド(WorkManager)の
+/// どちらの検出経路からも同じ通知を出すために導入。
+/// 従来はバックグラウンド Worker のみが通知を出していたため、アプリ起動時の検出が
+/// 新着を DB に取り込んで「黙って消費」し、通知が出ない問題があった。
+/// Android 実装が NotificationHelper を呼ぶ。
+/// </summary>
+public interface IUpdateNotificationService
+{
+	/// <summary>
+	/// 検出された更新の一覧について新着通知を表示する。空なら何もしない。
+	/// </summary>
+	Task ShowUpdatesAsync(IReadOnlyList<(Novel novel, int newEpisodeCount)> updates);
+}

--- a/_Apps/LanobeReader/Services/IUpdateNotificationService.cs
+++ b/_Apps/LanobeReader/Services/IUpdateNotificationService.cs
@@ -3,11 +3,17 @@ using LanobeReader.Models;
 namespace LanobeReader.Services;
 
 /// <summary>
-/// 新着更新をユーザに通知する抽象。
-/// フォアグラウンド(アプリ起動時の CheckAllAsync)・バックグラウンド(WorkManager)の
-/// どちらの検出経路からも同じ通知を出すために導入。
-/// 従来はバックグラウンド Worker のみが通知を出していたため、アプリ起動時の検出が
-/// 新着を DB に取り込んで「黙って消費」し、通知が出ない問題があった。
+/// 新着更新の通知ロジックを 1 箇所に集約する抽象。全検出経路(フォアグラウンドの起動時
+/// CheckAllAsync・バックグラウンドの WorkManager / 前面サービス)から同一実装を呼び、
+/// 経路ごとの通知差異・ロジック重複を無くすために導入。
+///
+/// 役割分担: 新着の提示はアプリの前面/背面で異なる。
+/// - 前面時(<c>AppForegroundTracker.IsForeground</c>): システム通知は出さない。アプリ内一覧の
+///   NEW 表示で示す。前面で通知すると直後の <c>MainActivity</c> の CancelAll(バッジクリア)と
+///   打ち消し合うため、実装側で前面時は早期 return する。
+/// - 背面時: システム通知を投稿する(バックグラウンド検出の確実な通知はこの経路が担う)。
+/// この設計上、起動時(コールドスタート)の検出は通常 NEW 表示で示され通知は出ない。起動直後に
+/// アプリが背面化した稀なケースのみ、起動時経路からも通知が出る。
 /// Android 実装が NotificationHelper を呼ぶ。
 /// </summary>
 public interface IUpdateNotificationService

--- a/_Apps/LanobeReader/Services/IUpdateScheduler.cs
+++ b/_Apps/LanobeReader/Services/IUpdateScheduler.cs
@@ -1,0 +1,14 @@
+namespace LanobeReader.Services;
+
+/// <summary>
+/// 定期更新チェック(WorkManager)のスケジュール抽象。
+/// 設定画面で更新間隔を変更した際に即時に再スケジュールするために導入。
+/// 従来は次回アプリ起動時(MainActivity の差分チェック)まで反映されなかった。
+/// </summary>
+public interface IUpdateScheduler
+{
+	/// <summary>
+	/// 指定した間隔(時間)で定期更新チェックを再スケジュールする。
+	/// </summary>
+	void Schedule(int intervalHours);
+}

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -37,9 +37,10 @@ public class UpdateCheckService
 
         try
         {
-            var novels = await _novelRepo.GetAllAsync().ConfigureAwait(false);
+            // 「最後にチェックした時刻が古い順(未チェック=null 優先)」で回す。3分上限(shortService)
+            // 等で打ち切られても、次回が続きから拾える (ラウンドロビン) ようにするため。
+            var novels = await _novelRepo.GetAllForCheckAsync().ConfigureAwait(false);
             var updates = new List<(Novel, int)>();
-            var failedIds = new HashSet<int>();
 
             foreach (var novel in novels)
             {
@@ -49,6 +50,7 @@ public class UpdateCheckService
                 // ユーザがアプリを開かない限り更新追跡から脱落する問題があったため (H-2)。
                 // 通知は notificationId=novel.Id で上書き表示されるため重複通知にはならない。
 
+                var cancelled = false;
                 try
                 {
                     var service = _serviceFactory.GetService((SiteType)novel.SiteType);
@@ -77,7 +79,6 @@ public class UpdateCheckService
                             {
                                 novel.Author = author;
                             }
-                            await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
 
                             updates.Add((novel, newEpisodes.Count));
 
@@ -99,21 +100,29 @@ public class UpdateCheckService
                             }
                         }
                     }
-                }
-                catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-                {
-                    MessageService.Warn($"Failed to check {novel.Title}: {ex.Message}");
-                    novel.HasCheckError = true;
-                    await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
-                    failedIds.Add(novel.Id);
-                    continue;
-                }
-            }
 
-            // Reset error flags on success
-            foreach (var novel in novels.Where(n => n.HasCheckError && !failedIds.Contains(n.Id)))
-            {
-                novel.HasCheckError = false;
+                    novel.HasCheckError = false; // 成功時はエラーフラグを解除
+                }
+                catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        // 打ち切り(3分上限等)。この作品は LastCheckedAt を更新せず、
+                        // 次回この作品から再開できるようにループを抜ける。
+                        cancelled = true;
+                    }
+                    else
+                    {
+                        MessageService.Warn($"Failed to check {novel.Title}: {ex.Message}");
+                        novel.HasCheckError = true;
+                    }
+                }
+
+                if (cancelled) break;
+
+                // 成功・失敗いずれも LastCheckedAt を更新して 1 回だけ永続化し、
+                // ラウンドロビンを前進させる(失敗作品も後ろへ回し、特定作品で詰まらせない)。
+                novel.LastCheckedAt = DateTime.UtcNow.ToString("o");
                 await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
             }
 

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -104,10 +104,11 @@ public class UpdateCheckService
                             updates.Add((novel, newEpisodes.Count));
 
                             // Enqueue newly-added episodes for background prefetch (Wi-Fi gated)
+                            // InsertAllAsync は AutoIncrement の Id を newEpisodes へ採番済みのため、
+                            // 全件再クエリ(GetByNovelIdAsync)で取り直さず、そのまま enqueue する。
                             if (_jobQueue is not null)
                             {
-                                var inserted = await _episodeRepo.GetByNovelIdAsync(novel.Id).ConfigureAwait(false);
-                                foreach (var ep in inserted.Where(e => e.EpisodeNo > currentMaxEpisode))
+                                foreach (var ep in newEpisodes)
                                 {
                                     await _jobQueue.EnqueueAsync(new PrefetchEpisodeJob
                                     {

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -51,6 +51,8 @@ public class UpdateCheckService
                 // 通知は notificationId=novel.Id で上書き表示されるため重複通知にはならない。
 
                 var cancelled = false;
+                var hadError = novel.HasCheckError;
+                var hasNewEpisodes = false;
                 try
                 {
                     var service = _serviceFactory.GetService((SiteType)novel.SiteType);
@@ -71,6 +73,7 @@ public class UpdateCheckService
                         {
                             await _episodeRepo.InsertAllAsync(newEpisodes).ConfigureAwait(false);
 
+                            hasNewEpisodes = true;
                             novel.TotalEpisodes = totalEpisodes;
                             novel.LastUpdatedAt = lastUpdatedAt ?? DateTime.UtcNow.ToString("o");
                             novel.HasUnconfirmedUpdate = true;
@@ -103,7 +106,7 @@ public class UpdateCheckService
 
                     novel.HasCheckError = false; // 成功時はエラーフラグを解除
                 }
-                catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+                catch (Exception ex)
                 {
                     if (ct.IsCancellationRequested)
                     {
@@ -113,6 +116,10 @@ public class UpdateCheckService
                     }
                     else
                     {
+                        // ネットワーク/パース/DB 等、その作品固有のあらゆる失敗を握りつぶして次へ進む。
+                        // ここを HttpRequestException 系に限定すると、想定外の例外で foreach 全体が脱出し
+                        // LastCheckedAt が前進しないため、巡回の先頭(最古)に居座る poison 作品が
+                        // 全作品のチェックを永久に止めてしまう。広く捕捉して必ず巡回を前進させる。
                         MessageService.Warn($"Failed to check {novel.Title}: {ex.Message}");
                         novel.HasCheckError = true;
                     }
@@ -123,7 +130,16 @@ public class UpdateCheckService
                 // 成功・失敗いずれも LastCheckedAt を更新して 1 回だけ永続化し、
                 // ラウンドロビンを前進させる(失敗作品も後ろへ回し、特定作品で詰まらせない)。
                 novel.LastCheckedAt = DateTime.UtcNow.ToString("o");
-                await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
+                if (hasNewEpisodes || novel.HasCheckError != hadError)
+                {
+                    // 本文(話数/著者等)やエラーフラグに変化があったときだけ全カラム更新。
+                    await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
+                }
+                else
+                {
+                    // 変化が無い大多数の作品は last_checked_at 列のみ更新し、毎チェックの書き込み量を抑える。
+                    await _novelRepo.UpdateLastCheckedAtAsync(novel.Id, novel.LastCheckedAt).ConfigureAwait(false);
+                }
             }
 
             return updates;

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -1,6 +1,8 @@
+using LanobeReader.Helpers;
 using LanobeReader.Models;
 using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
+using Microsoft.Maui.Storage;
 using TBird.Core;
 using TBird.Maui.Background;
 
@@ -141,6 +143,14 @@ public class UpdateCheckService
                     await _novelRepo.UpdateLastCheckedAtAsync(novel.Id, novel.LastCheckedAt).ConfigureAwait(false);
                 }
             }
+
+            // いずれの経路(起動時/手動更新/WorkManager/前面サービス)でも、CheckAll を完遂したら
+            // 完了時刻(epoch ms)を記録する。アラームの冗長発火ゲート
+            // (UpdateAlarmScheduler.ShouldSkipRedundantCheck)が直近完了を参照し、健全運用時は
+            // アラームをバックストップに留める。記録を各呼び出し側に散らさず、全経路の唯一の合流点で
+            // ある CheckAllAsync に置くことで、新しい呼び出し経路でも記録漏れが起きない。
+            // (セマフォ獲得失敗時は早期 return しており、ここには到達しない=実チェック時のみ記録)。
+            Preferences.Set(SettingsKeys.LAST_CHECK_COMPLETED_MS, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
             return updates;
         }

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Messaging;
 using LanobeReader.Helpers;
 using LanobeReader.Models;
 using LanobeReader.Services.Background;
@@ -43,10 +44,13 @@ public class UpdateCheckService
             // 等で打ち切られても、次回が続きから拾える (ラウンドロビン) ようにするため。
             var novels = await _novelRepo.GetAllForCheckAsync().ConfigureAwait(false);
             var updates = new List<(Novel, int)>();
+            // 全作品を回りきったかどうか。打ち切り(キャンセル/3分上限)で抜けた場合は false とし、
+            // 完了時刻の記録(=アラームのバックストップ抑止)を行わない。
+            var completedFullSweep = true;
 
             foreach (var novel in novels)
             {
-                if (ct.IsCancellationRequested) break;
+                if (ct.IsCancellationRequested) { completedFullSweep = false; break; }
 
                 // 取得自体は常に行う。HasUnconfirmedUpdate=true の小説をスキップすると、
                 // ユーザがアプリを開かない限り更新追跡から脱落する問題があったため (H-2)。
@@ -127,7 +131,7 @@ public class UpdateCheckService
                     }
                 }
 
-                if (cancelled) break;
+                if (cancelled) { completedFullSweep = false; break; }
 
                 // 成功・失敗いずれも LastCheckedAt を更新して 1 回だけ永続化し、
                 // ラウンドロビンを前進させる(失敗作品も後ろへ回し、特定作品で詰まらせない)。
@@ -144,13 +148,26 @@ public class UpdateCheckService
                 }
             }
 
-            // いずれの経路(起動時/手動更新/WorkManager/前面サービス)でも、CheckAll を完遂したら
-            // 完了時刻(epoch ms)を記録する。アラームの冗長発火ゲート
+            // いずれの経路(起動時/手動更新/WorkManager/前面サービス)でも、CheckAll を「全作品まで
+            // 完遂したら」完了時刻(epoch ms)を記録する。アラームの冗長発火ゲート
             // (UpdateAlarmScheduler.ShouldSkipRedundantCheck)が直近完了を参照し、健全運用時は
             // アラームをバックストップに留める。記録を各呼び出し側に散らさず、全経路の唯一の合流点で
             // ある CheckAllAsync に置くことで、新しい呼び出し経路でも記録漏れが起きない。
             // (セマフォ獲得失敗時は早期 return しており、ここには到達しない=実チェック時のみ記録)。
-            Preferences.Set(SettingsKeys.LAST_CHECK_COMPLETED_MS, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            // 打ち切り(3分上限/キャンセル)で未巡回分が残る場合は記録しない。完了済みと誤記録すると
+            // 次回アラームが冗長判定でスキップされ、未巡回作品の通知が最大 interval/2 遅延するため。
+            if (completedFullSweep)
+            {
+                Preferences.Set(SettingsKeys.LAST_CHECK_COMPLETED_MS, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            }
+
+            // 新着を検出したら、前面に居る一覧画面へ即時再読込を促す。背面検出はシステム通知で気づけるが、
+            // 前面時は通知が抑止される(CancelAll 競合回避)ため、ここで通知しないと手動更新まで NEW が
+            // 見えない窓が残る。受信側は弱参照のため購読解除不要。手動更新中は受信側が IsLoading で抑止する。
+            if (updates.Count > 0)
+            {
+                WeakReferenceMessenger.Default.Send(new UpdatesDetectedMessage(updates.Count));
+            }
 
             return updates;
         }

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -47,6 +47,9 @@ public class UpdateCheckService
             // 全作品を回りきったかどうか。打ち切り(キャンセル/3分上限)で抜けた場合は false とし、
             // 完了時刻の記録(=アラームのバックストップ抑止)を行わない。
             var completedFullSweep = true;
+            // 1件以上を実際にチェックできたか。全件失敗(ネット断等)や空テーブルでの「完了」記録による
+            // アラーム冗長ゲートの無用な抑止を避けるため、完了時刻記録の条件に用いる。
+            var anySuccess = false;
 
             foreach (var novel in novels)
             {
@@ -58,7 +61,7 @@ public class UpdateCheckService
 
                 var cancelled = false;
                 var hadError = novel.HasCheckError;
-                var hasNewEpisodes = false;
+                var persisted = false;
                 try
                 {
                     var service = _serviceFactory.GetService((SiteType)novel.SiteType);
@@ -79,7 +82,6 @@ public class UpdateCheckService
                         {
                             await _episodeRepo.InsertAllAsync(newEpisodes).ConfigureAwait(false);
 
-                            hasNewEpisodes = true;
                             novel.TotalEpisodes = totalEpisodes;
                             novel.LastUpdatedAt = lastUpdatedAt ?? DateTime.UtcNow.ToString("o");
                             novel.HasUnconfirmedUpdate = true;
@@ -88,6 +90,16 @@ public class UpdateCheckService
                             {
                                 novel.Author = author;
                             }
+                            novel.HasCheckError = false;
+
+                            // 挿入した episodes と novel メタデータ(HasUnconfirmedUpdate/TotalEpisodes 等)は
+                            // 一括で確定させる。永続化を後続(プリフェッチ enqueue / ループ末尾)へ遅延すると、
+                            // その窓でプロセスが kill / 3分上限で打ち切られた場合に episodes だけ commit され
+                            // novel 行が古いまま残り、次回 GetMaxEpisodeNoAsync が新 max を返すため新着が
+                            // 二度と再検出されない(NEW 喪失)。挿入直後に永続化して窓を最小化する。
+                            novel.LastCheckedAt = DateTime.UtcNow.ToString("o");
+                            await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
+                            persisted = true;
 
                             updates.Add((novel, newEpisodes.Count));
 
@@ -133,19 +145,25 @@ public class UpdateCheckService
 
                 if (cancelled) { completedFullSweep = false; break; }
 
-                // 成功・失敗いずれも LastCheckedAt を更新して 1 回だけ永続化し、
-                // ラウンドロビンを前進させる(失敗作品も後ろへ回し、特定作品で詰まらせない)。
-                novel.LastCheckedAt = DateTime.UtcNow.ToString("o");
-                if (hasNewEpisodes || novel.HasCheckError != hadError)
+                if (!persisted)
                 {
-                    // 本文(話数/著者等)やエラーフラグに変化があったときだけ全カラム更新。
-                    await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
+                    // 新着なし作品。成功・失敗いずれも LastCheckedAt を更新して 1 回だけ永続化し、
+                    // ラウンドロビンを前進させる(失敗作品も後ろへ回し、特定作品で詰まらせない)。
+                    // (新着あり作品は挿入直後に LastCheckedAt 込みで永続化済み = NEW 喪失防止)
+                    novel.LastCheckedAt = DateTime.UtcNow.ToString("o");
+                    if (novel.HasCheckError != hadError)
+                    {
+                        // エラーフラグに変化があったときだけ全カラム更新。
+                        await _novelRepo.UpdateAsync(novel).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // 変化が無い大多数の作品は last_checked_at 列のみ更新し、毎チェックの書き込み量を抑える。
+                        await _novelRepo.UpdateLastCheckedAtAsync(novel.Id, novel.LastCheckedAt).ConfigureAwait(false);
+                    }
                 }
-                else
-                {
-                    // 変化が無い大多数の作品は last_checked_at 列のみ更新し、毎チェックの書き込み量を抑える。
-                    await _novelRepo.UpdateLastCheckedAtAsync(novel.Id, novel.LastCheckedAt).ConfigureAwait(false);
-                }
+
+                if (!novel.HasCheckError) anySuccess = true;
             }
 
             // いずれの経路(起動時/手動更新/WorkManager/前面サービス)でも、CheckAll を「全作品まで
@@ -156,7 +174,9 @@ public class UpdateCheckService
             // (セマフォ獲得失敗時は早期 return しており、ここには到達しない=実チェック時のみ記録)。
             // 打ち切り(3分上限/キャンセル)で未巡回分が残る場合は記録しない。完了済みと誤記録すると
             // 次回アラームが冗長判定でスキップされ、未巡回作品の通知が最大 interval/2 遅延するため。
-            if (completedFullSweep)
+            // さらに、全件失敗(ネット断等)や空テーブルで「完了」を記録すると、何も検証していないのに
+            // バックストップを抑止してしまう。実際に1件以上チェックできた(anySuccess)場合のみ記録する。
+            if (completedFullSweep && anySuccess)
             {
                 Preferences.Set(SettingsKeys.LAST_CHECK_COMPLETED_MS, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
             }

--- a/_Apps/LanobeReader/Services/UpdatesDetectedMessage.cs
+++ b/_Apps/LanobeReader/Services/UpdatesDetectedMessage.cs
@@ -1,0 +1,13 @@
+namespace LanobeReader.Services;
+
+/// <summary>
+/// いずれかの経路(起動時/手動更新/WorkManager/前面サービス)の更新チェックで新着を検出したことを
+/// 通知するメッセージ。前面に居る一覧画面が受け取り、システム通知が抑止される前面時でも
+/// アプリ内一覧を即時に再読込して NEW 表示を反映するために使う。
+/// <para>
+/// 全経路の合流点 <see cref="UpdateCheckService"/> から WeakReferenceMessenger 経由で送る。
+/// 受信側は弱参照で保持されるため明示的な購読解除は不要(画面破棄時に自動回収)。
+/// </para>
+/// </summary>
+/// <param name="DetectedCount">新着が検出された小説数。</param>
+public sealed record UpdatesDetectedMessage(int DetectedCount);

--- a/_Apps/LanobeReader/ViewModels/NovelListViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/NovelListViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using LanobeReader.Helpers;
 using LanobeReader.Platforms.Android;
 using LanobeReader.Services;
@@ -31,6 +32,21 @@ public partial class NovelListViewModel : ErrorAwareViewModel
         _settingsRepo = settingsRepo;
         _updateCheckService = updateCheckService;
         _notificationPermission = notificationPermission;
+
+        // 背面チェックが前面滞在中に新着を検出した場合、システム通知は抑止されるため、ここで一覧を
+        // 再読込して NEW 表示へ即時反映する。WeakReferenceMessenger は弱参照のため画面破棄時に
+        // 自動回収され、購読解除は不要。手動更新中(IsLoading)は RefreshAsync 側が再読込するため抑止する。
+        WeakReferenceMessenger.Default.Register<UpdatesDetectedMessage>(this, (_, _) =>
+        {
+            if (IsLoading) return;
+            // Send は背面スレッドから呼ばれうるため UI スレッドへ戻す。
+            MainThread.BeginInvokeOnMainThread(async () =>
+            {
+                if (IsLoading) return;
+                try { await LoadNovelsAsync(); }
+                catch (Exception ex) { MessageService.Warn($"Auto-reload on updates failed: {ex.Message}"); }
+            });
+        });
     }
 
     [ObservableProperty]
@@ -132,8 +148,11 @@ public partial class NovelListViewModel : ErrorAwareViewModel
             await _updateCheckService.CheckAllAsync();
             await LoadNovelsAsync();
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        catch (Exception ex)
         {
+            // CheckAllAsync は作品単位のネットワーク/パース例外を内部で握りつぶすため、ここへ来るのは
+            // DB エラー等の中断級。HttpRequestException 系に絞ると DB 例外が async コマンドから
+            // 未観測のまま抜けてしまうため、全例外を捕捉してユーザへ通知する。
             MessageService.Warn($"Refresh failed: {ex.Message}");
             SetError("更新チェックに失敗しました");
         }

--- a/_Apps/LanobeReader/ViewModels/NovelListViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/NovelListViewModel.cs
@@ -32,14 +32,23 @@ public partial class NovelListViewModel : ErrorAwareViewModel
         _settingsRepo = settingsRepo;
         _updateCheckService = updateCheckService;
         _notificationPermission = notificationPermission;
+    }
 
-        // 背面チェックが前面滞在中に新着を検出した場合、システム通知は抑止されるため、ここで一覧を
-        // 再読込して NEW 表示へ即時反映する。WeakReferenceMessenger は弱参照のため画面破棄時に
-        // 自動回収され、購読解除は不要。手動更新中(IsLoading)は RefreshAsync 側が再読込するため抑止する。
+    /// <summary>
+    /// 背面チェックが前面滞在中に新着を検出した場合、システム通知は抑止されるため、一覧を再読込して
+    /// NEW 表示へ即時反映する購読を開始する。購読は画面の表示中のみ有効化する(NovelListPage の
+    /// OnAppearing/OnDisappearing で Subscribe/Unsubscribe)。この VM は AddTransient のため、購読を
+    /// コンストラクタに置くと画面遷移のたびにハンドラが積み上がり、非表示の旧 VM まで再読込してしまう。
+    /// </summary>
+    public void SubscribeToUpdates()
+    {
+        // OnAppearing が複数回呼ばれても二重登録例外にならないよう、登録前に必ず解除する。
+        WeakReferenceMessenger.Default.Unregister<UpdatesDetectedMessage>(this);
         WeakReferenceMessenger.Default.Register<UpdatesDetectedMessage>(this, (_, _) =>
         {
             if (IsLoading) return;
-            // Send は背面スレッドから呼ばれうるため UI スレッドへ戻す。
+            // Send は背面スレッドから呼ばれうるため UI スレッドへ戻す。手動更新中(IsLoading)は
+            // RefreshAsync 側が再読込するため抑止する。
             MainThread.BeginInvokeOnMainThread(async () =>
             {
                 if (IsLoading) return;
@@ -48,6 +57,10 @@ public partial class NovelListViewModel : ErrorAwareViewModel
             });
         });
     }
+
+    /// <summary>画面非表示時に購読を解除する(非表示中は次回 OnAppearing の再読込が NEW を反映する)。</summary>
+    public void UnsubscribeFromUpdates()
+        => WeakReferenceMessenger.Default.Unregister<UpdatesDetectedMessage>(this);
 
     [ObservableProperty]
     private ObservableCollection<NovelCardViewModel> _novels = [];

--- a/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
@@ -152,7 +152,7 @@ public partial class SettingsViewModel : ErrorAwareViewModel
             // MainActivity の差分チェックと整合させ、次回起動時の二重スケジュールを防ぐ。
             await _settingsRepo.SetValueAsync(SettingsKeys.LAST_SCHEDULED_HOURS, value.ToString()).ConfigureAwait(false);
             MessageService.Info($"Rescheduled update check to {value}h from settings");
-        });
+        }, "更新間隔の反映に失敗しました");
     }
 
     partial void OnFontSizeSpChanged(int value)        => DebounceSave(SettingsKeys.FONT_SIZE_SP, value.ToString());

--- a/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
@@ -143,11 +143,14 @@ public partial class SettingsViewModel : ErrorAwareViewModel
 
     partial void OnUpdateIntervalHoursChanged(int value)
     {
-        DebounceSave(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString());
-        // 間隔変更を即時に WorkManager / アラームへ反映する。従来は次回アプリ起動時の差分チェック
-        // (MainActivity) まで反映されず「設定を変えても効かない」状態だった。
-        Debounce("__reschedule_interval", async () =>
+        // 1 ユーザ操作 = 1 原子的処理として、単一デバウンス(同一キー)で逐次に
+        // 「間隔保存 → スケジュール反映 → LAST_SCHEDULED_HOURS 保存」を行う。
+        // 別キーの二重デバウンスにすると保存とスケジュールが順不同で競合し、永続値と実スケジュールが
+        // 一時的に食い違いうるため統合する。間隔変更は即時に WorkManager / アラームへ反映する
+        // (従来は次回起動の差分チェック(MainActivity)まで反映されなかった)。
+        Debounce(SettingsKeys.UPDATE_INTERVAL_HOURS, async () =>
         {
+            await _settingsRepo.SetValueAsync(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString()).ConfigureAwait(false);
             _scheduler.Schedule(value);
             // MainActivity の差分チェックと整合させ、次回起動時の二重スケジュールを防ぐ。
             await _settingsRepo.SetValueAsync(SettingsKeys.LAST_SCHEDULED_HOURS, value.ToString()).ConfigureAwait(false);

--- a/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using LanobeReader.Helpers;
 using TBird.Core;
 using TBird.Maui.ViewModels;
+using LanobeReader.Services;
 using LanobeReader.Services.Database;
 
 namespace LanobeReader.ViewModels;
@@ -11,12 +12,14 @@ public partial class SettingsViewModel : ErrorAwareViewModel
 {
     private readonly AppSettingsRepository _settingsRepo;
     private readonly EpisodeCacheRepository _cacheRepo;
+    private readonly IUpdateScheduler _scheduler;
     private bool _isInitializing;
 
-    public SettingsViewModel(AppSettingsRepository settingsRepo, EpisodeCacheRepository cacheRepo)
+    public SettingsViewModel(AppSettingsRepository settingsRepo, EpisodeCacheRepository cacheRepo, IUpdateScheduler scheduler)
     {
         _settingsRepo = settingsRepo;
         _cacheRepo = cacheRepo;
+        _scheduler = scheduler;
     }
 
     [ObservableProperty]
@@ -75,38 +78,83 @@ public partial class SettingsViewModel : ErrorAwareViewModel
     }
 
     private readonly Dictionary<string, CancellationTokenSource> _debounceCts = new();
+    private readonly object _debounceLock = new();
     private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(400);
 
-    private void DebounceSave(string key, string value)
+    /// <summary>
+    /// キーごとに最新の操作のみを <see cref="DebounceDelay"/> 後に実行する共通デバウンス。
+    /// 各 CancellationTokenSource は「待機中トークンと競合する Cancel 直後の Dispose」を避けるため、
+    /// 自身の継続(finally)でのみ破棄する。辞書アクセスは _debounceLock で直列化(スレッド安全)。
+    /// </summary>
+    /// <param name="userErrorMessage">非 null のとき、失敗時に UI へエラー表示する。</param>
+    private void Debounce(string key, Func<Task> action, string? userErrorMessage = null)
     {
         if (_isInitializing) return;
-        if (_debounceCts.TryGetValue(key, out var oldCts))
+
+        CancellationTokenSource cts;
+        lock (_debounceLock)
         {
-            oldCts.Cancel();
-            oldCts.Dispose();
+            if (_debounceCts.TryGetValue(key, out var oldCts))
+            {
+                oldCts.Cancel();
+            }
+            cts = new CancellationTokenSource();
+            _debounceCts[key] = cts;
         }
-        var cts = new CancellationTokenSource();
-        _debounceCts[key] = cts;
+
         _ = Task.Run(async () =>
         {
             try
             {
                 await Task.Delay(DebounceDelay, cts.Token).ConfigureAwait(false);
-                await _settingsRepo.SetValueAsync(key, value).ConfigureAwait(false);
+                await action().ConfigureAwait(false);
             }
-            catch (TaskCanceledException) { /* 新しい変更が来た */ }
+            catch (OperationCanceledException) { /* 新しい変更が来た */ }
             catch (Exception ex)
             {
-                MessageService.Warn($"DebounceSave failed: {ex.Message}");
-                // Task.Run 経由のためバインディング更新は UI スレッドへ戻す
-                MainThread.BeginInvokeOnMainThread(() =>
-                    SetError($"設定の保存に失敗しました: {ex.Message}"));
+                MessageService.Warn($"Debounce[{key}] failed: {ex.Message}");
+                if (userErrorMessage is not null)
+                {
+                    // Task.Run 経由のためバインディング更新は UI スレッドへ戻す
+                    MainThread.BeginInvokeOnMainThread(() =>
+                        SetError($"{userErrorMessage}: {ex.Message}"));
+                }
+            }
+            finally
+            {
+                lock (_debounceLock)
+                {
+                    // 自分がまだ最新エントリなら辞書から外す(以後この破棄済み CTS への Cancel を防ぐ)。
+                    // 既に置き換え済みなら最新を残す。どちらでも自分自身の破棄は安全。
+                    if (_debounceCts.TryGetValue(key, out var cur) && ReferenceEquals(cur, cts))
+                    {
+                        _debounceCts.Remove(key);
+                    }
+                }
+                cts.Dispose();
             }
         });
     }
 
+    private void DebounceSave(string key, string value)
+        => Debounce(key, () => _settingsRepo.SetValueAsync(key, value), "設定の保存に失敗しました");
+
     partial void OnCacheMonthsChanged(int value)       => DebounceSave(SettingsKeys.CACHE_MONTHS, value.ToString());
-    partial void OnUpdateIntervalHoursChanged(int value) => DebounceSave(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString());
+
+    partial void OnUpdateIntervalHoursChanged(int value)
+    {
+        DebounceSave(SettingsKeys.UPDATE_INTERVAL_HOURS, value.ToString());
+        // 間隔変更を即時に WorkManager / アラームへ反映する。従来は次回アプリ起動時の差分チェック
+        // (MainActivity) まで反映されず「設定を変えても効かない」状態だった。
+        Debounce("__reschedule_interval", async () =>
+        {
+            _scheduler.Schedule(value);
+            // MainActivity の差分チェックと整合させ、次回起動時の二重スケジュールを防ぐ。
+            await _settingsRepo.SetValueAsync(SettingsKeys.LAST_SCHEDULED_HOURS, value.ToString()).ConfigureAwait(false);
+            MessageService.Info($"Rescheduled update check to {value}h from settings");
+        });
+    }
+
     partial void OnFontSizeSpChanged(int value)        => DebounceSave(SettingsKeys.FONT_SIZE_SP, value.ToString());
     partial void OnBackgroundThemeChanged(int value)   => DebounceSave(SettingsKeys.BACKGROUND_THEME, value.ToString());
     partial void OnLineSpacingChanged(int value)       => DebounceSave(SettingsKeys.LINE_SPACING, value.ToString());

--- a/_Apps/LanobeReader/Views/NovelListPage.xaml.cs
+++ b/_Apps/LanobeReader/Views/NovelListPage.xaml.cs
@@ -6,6 +6,14 @@ public partial class NovelListPage : ContentPage
 {
     private readonly NovelListViewModel _viewModel;
 
+    /// <summary>
+    /// 一覧(本棚)ページが現在表示中か。表示中はアプリ内 NEW 表示が新着を直接見せるため、
+    /// 背面チェックのシステム通知を抑止してよい(<see cref="Platforms.Android.UpdateNotificationService"/>)。
+    /// 他ページ滞在中(本棚が非表示)は通知を出す。購読(SubscribeToUpdates)のライフサイクルと一致する。
+    /// (名称は VisualElement.IsVisible との衝突を避けるため IsShowing とする)
+    /// </summary>
+    public static bool IsShowing { get; private set; }
+
     public NovelListPage(NovelListViewModel viewModel)
     {
         InitializeComponent();
@@ -15,6 +23,7 @@ public partial class NovelListPage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
+        IsShowing = true;
         // 表示中だけ新着メッセージを購読し、非表示時に解除する(VM は Transient のため購読を
         // ライフサイクルに束ねないと旧 VM が積み上がり、非表示ページまで再読込してしまう)。
         _viewModel.SubscribeToUpdates();
@@ -24,6 +33,7 @@ public partial class NovelListPage : ContentPage
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
+        IsShowing = false;
         _viewModel.UnsubscribeFromUpdates();
     }
 }

--- a/_Apps/LanobeReader/Views/NovelListPage.xaml.cs
+++ b/_Apps/LanobeReader/Views/NovelListPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using LanobeReader.ViewModels;
 
 namespace LanobeReader.Views;
@@ -11,8 +12,12 @@ public partial class NovelListPage : ContentPage
     /// 背面チェックのシステム通知を抑止してよい(<see cref="Platforms.Android.UpdateNotificationService"/>)。
     /// 他ページ滞在中(本棚が非表示)は通知を出す。購読(SubscribeToUpdates)のライフサイクルと一致する。
     /// (名称は VisualElement.IsVisible との衝突を避けるため IsShowing とする)
+    /// 書込は UI スレッド(OnAppearing/OnDisappearing)、読取は WorkManager/FGS の背面スレッド
+    /// (UpdateNotificationService)のため、メモリ可視性を担保する volatile とする
+    /// (対になる AppForegroundTracker.IsForeground が Volatile.Read を使うのと同じ理由)。
     /// </summary>
-    public static bool IsShowing { get; private set; }
+    public static bool IsShowing => Volatile.Read(ref _isShowing);
+    private static bool _isShowing;
 
     public NovelListPage(NovelListViewModel viewModel)
     {
@@ -23,7 +28,7 @@ public partial class NovelListPage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
-        IsShowing = true;
+        Volatile.Write(ref _isShowing, true);
         // 表示中だけ新着メッセージを購読し、非表示時に解除する(VM は Transient のため購読を
         // ライフサイクルに束ねないと旧 VM が積み上がり、非表示ページまで再読込してしまう)。
         _viewModel.SubscribeToUpdates();
@@ -33,7 +38,7 @@ public partial class NovelListPage : ContentPage
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
-        IsShowing = false;
+        Volatile.Write(ref _isShowing, false);
         _viewModel.UnsubscribeFromUpdates();
     }
 }

--- a/_Apps/LanobeReader/Views/NovelListPage.xaml.cs
+++ b/_Apps/LanobeReader/Views/NovelListPage.xaml.cs
@@ -15,6 +15,15 @@ public partial class NovelListPage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
+        // 表示中だけ新着メッセージを購読し、非表示時に解除する(VM は Transient のため購読を
+        // ライフサイクルに束ねないと旧 VM が積み上がり、非表示ページまで再読込してしまう)。
+        _viewModel.SubscribeToUpdates();
         await _viewModel.InitializeAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _viewModel.UnsubscribeFromUpdates();
     }
 }


### PR DESCRIPTION
## 背景 / 課題
- バックグラウンドの新着検出が OEM 実機や Doze 中に届かない（WorkManager 定期がネットワーク制約 + Doze で延期される）。
- アプリ起動時の検出が新着を DB に取り込むだけで通知されず「黙って消費」される。
- 更新間隔の設定変更が次回起動まで反映されない。
- 再起動でアラームが消える / 電池最適化で動かない。

## 方針
WorkManager 定期（WiFi 前提の省電力ベースライン）はそのまま残し、**Doze 貫通の補助経路**として
exact アラーム → 前面サービスを追加。通知ロジックは 1 箇所に集約して全経路で同一挙動にする。

## 主な変更
### 通知経路の統合
- `IUpdateNotificationService` / `UpdateNotificationService` に集約。フォアグラウンド(`App.xaml.cs`)・
  バックグラウンド(`UpdateCheckWorker`)・前面サービスの全経路で同じ通知を出す。
- 実処理は `UpdateCheckRunner` に一元化し Worker / FGS で共有（重複排除）。

### Doze 貫通（電池除外に依存しない）
- `UpdateAlarmScheduler`: 可能なら `setExactAndAllowWhileIdle`。exact は Android 12+ で
  「背面からの前面サービス起動」が許可される条件に該当（`ALARM_MANAGER_WHILE_IDLE`）。
- `UpdateCheckForegroundService`(shortService): アラーム発火時にその場でチェックを完遂。
  WorkManager のネットワーク制約による Doze 延期を回避。背面起動拒否時は WorkManager にフォールバック。
  3 分上限は `OnTimeout` で安全停止。

### 二機構の協調 / 自己修復
- `UpdateSchedulingCoordinator`: WorkManager 定期 + アラームを常に同一間隔でペア武装し、間隔ドリフトを防止。
- Worker / 起動時に DB 値で Preferences ミラーを是正（自己修復）。
- `BootReceiver`: 再起動後にアラーム再武装。`BatteryOptimizationHelper`: 電池最適化除外を一度だけ依頼。

### 設定即時反映
- `IUpdateScheduler` / `AndroidUpdateScheduler`: 更新間隔の変更を WorkManager / アラームへ即時反映。
- `SettingsViewModel`: デバウンスを共通化しスレッド安全に（ロック + CTS の自己破棄）。

### ラウンドロビン（3 分上限の取りこぼし対策）
- `novels.last_checked_at` 列を追加（`EnsureColumnAsync`、スキーマ版上げ不要）。
- `NovelRepository.GetAllForCheckAsync()`: 古い順（未チェック=NULL 優先）で巡回。
- `UpdateCheckService.CheckAllAsync`: 各作品処理後に `last_checked_at` を更新。打ち切り時は
  進行中作品を未更新のまま残し、次回その作品から再開 → 全作品を順繰りにカバー。

### その他
- 通知バッジ（未確認更新数）、通知タップのディープリンク・フォールバック（未読解決不可なら話一覧へ）。

## テスト（エミュレータ API35）
- `Update alarm (exact) scheduled` … exact 武装を確認。
- **電池最適化の除外を外した状態**で `Background started FGS: Allowed, code:ALARM_MANAGER_WHILE_IDLE`
  を確認 → ①(電池除外)に依存せず②(exact+FGS)で背面起動できることを実証。
- チェック完遂・自己停止・無クラッシュ・「更新を確認中」常駐通知の表示・drift 自己修復を確認。
- 手順書: `_Apps/LanobeReader/Features/notify_reliability_testing.md`。
- `DebugSchedulingConfig.AlarmOverrideMinutes = 0`（本番無効）に戻済み。ビルド 0 warning / 0 error。

## 既知のトレードオフ / フォローアップ候補
- FGS の仕様上、チェックのたびに数秒「更新を確認中」のサイレント常駐通知が出る（Doze 貫通の代償）。
- `MainActivity.OnResume` の `CancelAll` は前面化のたびに全通知をクリアする（仕様。複数小説の通知も一括クリア）。
- 前面中(`AppForegroundTracker.IsForeground`)はシステム通知を抑止。アプリ内一覧の NEW 表示で代替する設計。
- shortService の約 3 分上限は通常のチェックでは到達しないが、超過時はラウンドロビンで次回継続。
