### PR TITLE
fix(maui.db): 初期化失敗時にEnsureInitializedAsyncを再試行可能にする

### DIFF
--- a/TBird.Maui.DB/SqliteDatabaseBase.cs
+++ b/TBird.Maui.DB/SqliteDatabaseBase.cs
@@ -44,12 +44,22 @@ public abstract class SqliteDatabaseBase
     /// <summary>
     /// 初回のみ実際の初期化を行う。複数箇所から呼ばれても 1 回しか走らない。
     /// クエリ実行前に必ず呼び出すこと。
+    /// 前回が失敗(faulted/canceled)していた場合は次回呼び出しで再試行する。
     /// </summary>
     public Task EnsureInitializedAsync()
     {
         lock (_initLock)
         {
-            return _initTask ??= InitializeInternalAsync();
+            // 初回、または前回の初期化が失敗(faulted/canceled)していれば(再)実行する。
+            // faulted な Task をそのままキャッシュし続けると、起動時の一時ロック("database is locked")
+            // 等で 1 度初期化に失敗しただけで、以後すべてのクエリが同じ例外を投げ続け(プロセス
+            // 再起動まで回復しない)てしまう。CreateTables/Seed/migration は冪等規約のため再実行は安全。
+            // 進行中(未完了)の Task はそのまま共有し、二重初期化を防ぐ。
+            if (_initTask is null || _initTask.IsFaulted || _initTask.IsCanceled)
+            {
+                _initTask = InitializeInternalAsync();
+            }
+            return _initTask;
         }
     }
 


### PR DESCRIPTION
## 背景
`SqliteDatabaseBase.EnsureInitializedAsync` は初期化 Task を `_initTask ??= InitializeInternalAsync()` でキャッシュする。しかし `CreateTablesAsync` / `SeedAsync` がマイグレーション用 try/catch の**外**で実行されるため、起動時の一時的な `database is locked`（別接続が WAL を保持中など）で例外になると、**faulted な Task が恒久的にキャッシュ**される。

結果、以後すべての Repository クエリが `await EnsureInitializedAsync()` で同じ例外を再スローし続け、**プロセスを再起動するまで UI も背景更新チェックも回復しない**。

LanobeReader のコードレビューで発見（共有ライブラリ TBird.Maui.DB の問題のため master へ別 PR として切り出し）。

## 変更
`EnsureInitializedAsync` を、キャッシュ済み Task が `IsFaulted` / `IsCanceled` の場合は次回呼び出しで**再実行**するよう修正。

- `CreateTablesAsync` / `SeedAsync` / migration はいずれも冪等規約（`CREATE TABLE`/`CREATE INDEX IF NOT EXISTS` / `FindAsync` 存在チェック後 Insert）のため、再実行は安全。
- 進行中（未完了）の Task は引き続き共有し、二重初期化は防ぐ。
- `_initLock` 下での判定のためスレッドセーフ。

## 影響範囲
`SqliteDatabaseBase` を継承する全 DB（LanobeReader の `DatabaseService` ほか app-* ブランチの DB 実装）。挙動変化は「初期化に失敗したときだけ次回再試行する」のみで、成功時の挙動は不変。

## テスト
`dotnet build TBird.Maui.DB/TBird.Maui.DB.csproj` 成功（0 警告 / 0 エラー）。

## 関連
このトリガ（最初の DDL が一時ロックで失敗）は、LanobeReader 側で `PRAGMA busy_timeout` を `journal_mode=WAL` より先に設定する修正（fix/lanobereader-review-followups）により大幅に低減済み。本 PR はその根本（faulted 固着）を基底クラスで塞ぐもの。