### PR TITLE
fix(lanobereader): Kakuyomu本文取得を位置依存からサイト話IDへ移行（誤話表示の是正）

### DIFF
--- a/_Apps/LanobeReader/Models/Episode.cs
+++ b/_Apps/LanobeReader/Models/Episode.cs
@@ -36,4 +36,10 @@ public class Episode
 
     [Column("favorited_at")]
     public string? FavoritedAt { get; set; }
+
+    // サイト側の不透明なエピソード ID（例: Kakuyomu の TableOfContentsChapter 配下 Episode の ID）。
+    // 本文取得を episode_no の位置依存解決ではなくこの安定 ID で行うことで、序盤話の削除/並べ替えで
+    // 目次がずれても誤った話を表示しなくなる。Narou は URL に episode_no を直接使うため null のまま。
+    [Column("site_episode_id")]
+    public string? SiteEpisodeId { get; set; }
 }

--- a/_Apps/LanobeReader/Services/Background/BackgroundJobQueue.cs
+++ b/_Apps/LanobeReader/Services/Background/BackgroundJobQueue.cs
@@ -36,7 +36,11 @@ public class BackgroundJobQueue
                 if (cached is not null) return;
 
                 var service = serviceFactory.GetService((SiteType)job.SiteType);
-                var content = await service.FetchEpisodeContentAsync(job.SiteNovelId, job.EpisodeNo, job.SiteEpisodeId, ct).ConfigureAwait(false);
+                var (content, cacheable) = await service.FetchEpisodeContentAsync(job.SiteNovelId, job.EpisodeNo, job.SiteEpisodeId, ct).ConfigureAwait(false);
+
+                // 位置依存フォールバックで取得した本文は誤話の可能性があり訂正経路も無いため先読みキャッシュ
+                // しない(誤話キャッシュの恒久化を防止)。次回ユーザが開いた時に都度取得し直させる。
+                if (!cacheable) return;
 
                 await cacheRepo.InsertAsync(new EpisodeCache
                 {

--- a/_Apps/LanobeReader/Services/Background/BackgroundJobQueue.cs
+++ b/_Apps/LanobeReader/Services/Background/BackgroundJobQueue.cs
@@ -36,7 +36,7 @@ public class BackgroundJobQueue
                 if (cached is not null) return;
 
                 var service = serviceFactory.GetService((SiteType)job.SiteType);
-                var content = await service.FetchEpisodeContentAsync(job.SiteNovelId, job.EpisodeNo, ct).ConfigureAwait(false);
+                var content = await service.FetchEpisodeContentAsync(job.SiteNovelId, job.EpisodeNo, job.SiteEpisodeId, ct).ConfigureAwait(false);
 
                 await cacheRepo.InsertAsync(new EpisodeCache
                 {

--- a/_Apps/LanobeReader/Services/Background/PrefetchEpisodeJob.cs
+++ b/_Apps/LanobeReader/Services/Background/PrefetchEpisodeJob.cs
@@ -12,6 +12,8 @@ public class PrefetchEpisodeJob : BackgroundJobBase
     public int SiteType { get; init; }
     public string SiteNovelId { get; init; } = string.Empty;
     public int EpisodeNo { get; init; }
+    // サイト側エピソード ID(あれば)。本文取得の位置依存解決を避けるため API へ渡す。
+    public string? SiteEpisodeId { get; init; }
 
     public override string Description => $"Prefetch novel={NovelDbId} ep={EpisodeNo}";
 }

--- a/_Apps/LanobeReader/Services/Background/PrefetchService.cs
+++ b/_Apps/LanobeReader/Services/Background/PrefetchService.cs
@@ -49,6 +49,7 @@ public class PrefetchService
                 EpisodeNo = ep.EpisodeNo,
                 SiteType = novel.SiteType,
                 SiteNovelId = novel.NovelId,
+                SiteEpisodeId = ep.SiteEpisodeId,
             }, (highPriority || novel.IsFavorite) ? JobPriority.High : JobPriority.Normal).ConfigureAwait(false);
             enqueued++;
         }
@@ -79,6 +80,7 @@ public class PrefetchService
                     EpisodeNo = ep.EpisodeNo,
                     SiteType = novel.SiteType,
                     SiteNovelId = novel.NovelId,
+                    SiteEpisodeId = ep.SiteEpisodeId,
                 }, novel.IsFavorite ? JobPriority.High : JobPriority.Normal).ConfigureAwait(false);
             }
         }

--- a/_Apps/LanobeReader/Services/Database/DatabaseService.cs
+++ b/_Apps/LanobeReader/Services/Database/DatabaseService.cs
@@ -37,6 +37,9 @@ public class DatabaseService : SqliteDatabaseBase
         await EnsureColumnAsync(conn, "novels", "last_checked_at", "TEXT NULL").ConfigureAwait(false);
         await EnsureColumnAsync(conn, "episodes", "is_favorite", "INTEGER NOT NULL DEFAULT 0").ConfigureAwait(false);
         await EnsureColumnAsync(conn, "episodes", "favorited_at", "TEXT NULL").ConfigureAwait(false);
+        // サイト側エピソード ID（Kakuyomu の本文取得を位置依存解決から安定 ID へ移行するため）。
+        // 列追加は EnsureColumnAsync で冪等。新規インストールは CreateTableAsync<Episode> が含めて作成する。
+        await EnsureColumnAsync(conn, "episodes", "site_episode_id", "TEXT NULL").ConfigureAwait(false);
 
         // 3. novels の UNIQUE 制約（v1 時点で既に整備済みなので再適用するだけ）
         await conn.ExecuteAsync(

--- a/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
@@ -16,6 +16,12 @@ public class EpisodeRepository
 
     private Task EnsureAsync() => _dbService.EnsureInitializedAsync();
 
+    // 複数の raw SQL クエリで使う episodes の列リスト。列追加時の更新漏れ(列順・列セットのズレ)を
+    // 防ぐため一元化する。Episode のプロパティ([Column] 属性)へ列名でマップされる。
+    private const string EpisodeColumns =
+        "id, novel_id, episode_no, chapter_name, title, " +
+        "is_read, read_at, published_at, is_favorite, favorited_at, site_episode_id";
+
     public async Task<List<Episode>> GetByNovelIdAsync(int novelId)
     {
         await EnsureAsync().ConfigureAwait(false);
@@ -23,8 +29,7 @@ public class EpisodeRepository
         // オーバーヘッドが乗るため、長尺小説 (1500+ 話) では raw SQL が体感で速い。
         // GetPagedByNovelIdAsync と同じ列順 / 列セットを維持。
         return await _db.QueryAsync<Episode>(
-            "SELECT id, novel_id, episode_no, chapter_name, title, " +
-            "is_read, read_at, published_at, is_favorite, favorited_at " +
+            $"SELECT {EpisodeColumns} " +
             "FROM episodes WHERE novel_id = ? ORDER BY episode_no",
             novelId).ConfigureAwait(false);
     }
@@ -34,8 +39,7 @@ public class EpisodeRepository
         await EnsureAsync().ConfigureAwait(false);
         int offset = (page - 1) * pageSize;
         return await _db.QueryAsync<Episode>(
-            "SELECT id, novel_id, episode_no, chapter_name, title, " +
-            "is_read, read_at, published_at, is_favorite, favorited_at " +
+            $"SELECT {EpisodeColumns} " +
             "FROM episodes WHERE novel_id = ? ORDER BY episode_no LIMIT ? OFFSET ?",
             novelId, pageSize, offset).ConfigureAwait(false);
     }
@@ -63,8 +67,7 @@ public class EpisodeRepository
     {
         await EnsureAsync().ConfigureAwait(false);
         var results = await _db.QueryAsync<Episode>(
-            "SELECT id, novel_id, episode_no, chapter_name, title, " +
-            "is_read, read_at, published_at, is_favorite, favorited_at " +
+            $"SELECT {EpisodeColumns} " +
             "FROM episodes WHERE novel_id = ? AND episode_no < ? " +
             "ORDER BY episode_no DESC LIMIT 1",
             novelId, currentEpisodeNo).ConfigureAwait(false);
@@ -75,8 +78,7 @@ public class EpisodeRepository
     {
         await EnsureAsync().ConfigureAwait(false);
         var results = await _db.QueryAsync<Episode>(
-            "SELECT id, novel_id, episode_no, chapter_name, title, " +
-            "is_read, read_at, published_at, is_favorite, favorited_at " +
+            $"SELECT {EpisodeColumns} " +
             "FROM episodes WHERE novel_id = ? AND episode_no > ? " +
             "ORDER BY episode_no ASC LIMIT 1",
             novelId, currentEpisodeNo).ConfigureAwait(false);
@@ -175,6 +177,43 @@ public class EpisodeRepository
     {
         await EnsureAsync().ConfigureAwait(false);
         await _db.InsertAllAsync(episodes).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// site_episode_id が未設定の既存話(列追加前に保存された旧データ)へ、新鮮な TOC から導出した
+    /// サイト話 ID を補完する。ドリフト(序盤話の削除/並べ替え)後の誤補完を避けるため、同一 episode_no の
+    /// <b>タイトルが一致する話だけ</b>更新する(不一致=ドリフト疑い→触らない)。既に設定済みの話は更新しない。
+    /// SiteEpisodeId を持つ話が新鮮リストに無い場合(Narou 等)は何もしない。best-effort。
+    /// </summary>
+    public async Task BackfillSiteEpisodeIdsAsync(int novelId, IReadOnlyList<Episode> freshEpisodes)
+    {
+        if (freshEpisodes.Count == 0 || freshEpisodes.All(e => string.IsNullOrEmpty(e.SiteEpisodeId))) return;
+        await EnsureAsync().ConfigureAwait(false);
+
+        var existing = await GetByNovelIdAsync(novelId).ConfigureAwait(false);
+        var byNo = existing
+            .Where(e => string.IsNullOrEmpty(e.SiteEpisodeId)) // 未補完の話のみ対象
+            .ToDictionary(e => e.EpisodeNo);
+
+        var updates = new List<(string siteId, int id)>();
+        foreach (var fresh in freshEpisodes)
+        {
+            if (string.IsNullOrEmpty(fresh.SiteEpisodeId)) continue;
+            if (!byNo.TryGetValue(fresh.EpisodeNo, out var db)) continue;
+            if (db.Title != fresh.Title) continue; // タイトル不一致=ドリフト疑い→誤補完しない
+            updates.Add((fresh.SiteEpisodeId!, db.Id));
+        }
+        if (updates.Count == 0) return;
+
+        await _db.RunInTransactionAsync(conn =>
+        {
+            foreach (var (siteId, id) in updates)
+            {
+                conn.Execute(
+                    "UPDATE episodes SET site_episode_id = ? WHERE id = ? AND site_episode_id IS NULL",
+                    siteId, id);
+            }
+        }).ConfigureAwait(false);
     }
 
     public async Task<int> UpdateAsync(Episode episode)

--- a/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
+++ b/_Apps/LanobeReader/Services/Database/EpisodeRepository.cs
@@ -98,6 +98,19 @@ public class EpisodeRepository
             "SELECT COALESCE(MAX(episode_no), 0) FROM episodes WHERE novel_id = ?", novelId).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// 当該小説に site_episode_id を持つ話が 1 件でも存在するか(安価な EXISTS 判定)。
+    /// false かつ episodes が存在する Kakuyomu 作品 = 列追加前の旧データで未移行、の判定に使う。
+    /// </summary>
+    public async Task<bool> HasAnySiteEpisodeIdAsync(int novelId)
+    {
+        await EnsureAsync().ConfigureAwait(false);
+        var count = await _db.ExecuteScalarAsync<int>(
+            "SELECT EXISTS(SELECT 1 FROM episodes WHERE novel_id = ? AND site_episode_id IS NOT NULL)",
+            novelId).ConfigureAwait(false);
+        return count != 0;
+    }
+
     public async Task<Episode?> GetLastReadEpisodeAsync(int novelId)
     {
         await EnsureAsync().ConfigureAwait(false);
@@ -190,10 +203,14 @@ public class EpisodeRepository
         if (freshEpisodes.Count == 0 || freshEpisodes.All(e => string.IsNullOrEmpty(e.SiteEpisodeId))) return;
         await EnsureAsync().ConfigureAwait(false);
 
-        var existing = await GetByNovelIdAsync(novelId).ConfigureAwait(false);
-        var byNo = existing
-            .Where(e => string.IsNullOrEmpty(e.SiteEpisodeId)) // 未補完の話のみ対象
-            .ToDictionary(e => e.EpisodeNo);
+        // 未補完(site_episode_id IS NULL)の話だけを SQL で絞り込む。全話フルロード+C# フィルタだと
+        // 初回補完後は更新ゼロでも更新チェックの度に O(話数) のコストを払う(長尺×お気に入りで無駄が累積)。
+        // 後段 UPDATE のガードも IS NULL のため、書き込み対象は本クエリと完全一致(空文字行は元々非対象)。
+        var pending = await _db.QueryAsync<Episode>(
+            $"SELECT {EpisodeColumns} FROM episodes WHERE novel_id = ? AND site_episode_id IS NULL",
+            novelId).ConfigureAwait(false);
+        if (pending.Count == 0) return;
+        var byNo = pending.ToDictionary(e => e.EpisodeNo);
 
         var updates = new List<(string siteId, int id)>();
         foreach (var fresh in freshEpisodes)
@@ -209,9 +226,16 @@ public class EpisodeRepository
         {
             foreach (var (siteId, id) in updates)
             {
-                conn.Execute(
+                var n = conn.Execute(
                     "UPDATE episodes SET site_episode_id = ? WHERE id = ? AND site_episode_id IS NULL",
                     siteId, id);
+                if (n > 0)
+                {
+                    // 補完前の窓で位置依存フォールバック(episodeIds[episodeNo-1])により取得・キャッシュ
+                    // された本文は、TOC ドリフト時に誤話の可能性がある。安定 ID を確定したこの時点で当該
+                    // キャッシュを破棄し、次回読み込みで安定 ID により取得し直させる(誤話キャッシュの是正)。
+                    conn.Execute("DELETE FROM episode_cache WHERE episode_id = ?", id);
+                }
             }
         }).ConfigureAwait(false);
     }

--- a/_Apps/LanobeReader/Services/INovelService.cs
+++ b/_Apps/LanobeReader/Services/INovelService.cs
@@ -9,6 +9,9 @@ public interface INovelService
     Task<List<Episode>> FetchEpisodeListAsync(string novelId, CancellationToken ct = default);
     // siteEpisodeId: DB に永続化されたサイト側エピソード ID(あれば)。位置依存解決を避けるために使う。
     // 未保存(旧データ)や episode_no で直接 URL を組めるサイト(Narou)では null/未使用でよい。
-    Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default);
+    // 戻り値 cacheable: 取得本文を永続キャッシュ(episode_cache)してよいか。安定 ID が陳腐化して位置依存
+    // フォールバックで取得した本文はドリフトで誤話の可能性があり、かつ安定 ID が残置されるため backfill の
+    // キャッシュ破棄でも訂正されない。これを恒久キャッシュしないよう false を返す(呼び出し側はキャッシュを抑止)。
+    Task<(string content, bool cacheable)> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default);
     Task<(int totalEpisodes, string? lastUpdatedAt, bool isCompleted, string? author)> FetchNovelInfoAsync(string novelId, CancellationToken ct = default);
 }

--- a/_Apps/LanobeReader/Services/INovelService.cs
+++ b/_Apps/LanobeReader/Services/INovelService.cs
@@ -7,6 +7,8 @@ public interface INovelService
     SiteType SiteType { get; }
     Task<List<SearchResult>> SearchAsync(string keyword, CancellationToken ct = default);
     Task<List<Episode>> FetchEpisodeListAsync(string novelId, CancellationToken ct = default);
-    Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default);
+    // siteEpisodeId: DB に永続化されたサイト側エピソード ID(あれば)。位置依存解決を避けるために使う。
+    // 未保存(旧データ)や episode_no で直接 URL を組めるサイト(Narou)では null/未使用でよい。
+    Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default);
     Task<(int totalEpisodes, string? lastUpdatedAt, bool isCompleted, string? author)> FetchNovelInfoAsync(string novelId, CancellationToken ct = default);
 }

--- a/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
@@ -236,7 +236,8 @@ public class KakuyomuApiService : INovelService
                 // __ref も含まれ、判定前に追加すると episodeIds が実話数(episodes)とズレる:
                 //   (a) FetchEpisodeContentAsync の episodeIds[episodeNo-1] 索引がズレて誤話/404
                 //   (b) totalEpisodes(=episodeIds.Count)が水増しされ UpdateCheckService が毎回再取得
-                ids.Add(refKey.Substring(colonIdx + 1));
+                var siteEpisodeId = refKey.Substring(colonIdx + 1);
+                ids.Add(siteEpisodeId);
 
                 var title = episodeEntry.TryGetProperty("title", out var titleProp)
                     ? titleProp.GetString() ?? ""
@@ -248,6 +249,9 @@ public class KakuyomuApiService : INovelService
                     EpisodeNo = episodeNo,
                     Title = title,
                     ChapterName = chapterTitle,
+                    // 本文取得を位置依存(episodeIds[episodeNo-1])から安定 ID へ移行するため、各話に
+                    // サイト側エピソード ID を持たせて永続化する(序盤話の削除/並べ替えでの誤話表示を防ぐ)。
+                    SiteEpisodeId = siteEpisodeId,
                 });
             }
         }
@@ -255,19 +259,31 @@ public class KakuyomuApiService : INovelService
         return (ids, episodes);
     }
 
-    public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default)
+    public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(20));
 
-        var episodeIds = await GetEpisodeIdsAsync(novelId, cts.Token).ConfigureAwait(false);
-
-        if (episodeNo < 1 || episodeNo > episodeIds.Count)
+        string episodeId;
+        if (!string.IsNullOrEmpty(siteEpisodeId))
         {
-            throw new InvalidOperationException($"エピソード {episodeNo} が見つかりません");
+            // DB に永続化済みの安定したサイト話 ID を直接使う。生 TOC の位置依存解決(序盤話の削除/
+            // 並べ替えで episodeIds がシフトし誤話/404 になる)を回避する本命パス。
+            episodeId = siteEpisodeId;
+        }
+        else
+        {
+            // 旧データ(site_episode_id 列追加前に保存された話)向けフォールバック: 生 TOC から位置で解決する。
+            // 新規取得分は SiteEpisodeId を持つためこの経路には来ない。BackfillSiteEpisodeIdsAsync が
+            // 旧データにも順次補完するため、フォールバック該当は時間とともに縮小する。
+            var episodeIds = await GetEpisodeIdsAsync(novelId, cts.Token).ConfigureAwait(false);
+            if (episodeNo < 1 || episodeNo > episodeIds.Count)
+            {
+                throw new InvalidOperationException($"エピソード {episodeNo} が見つかりません");
+            }
+            episodeId = episodeIds[episodeNo - 1];
         }
 
-        var episodeId = episodeIds[episodeNo - 1];
         var episodeHref = $"{BASE_URL}/works/{novelId}/episodes/{episodeId}";
 
         var episodeHtml = await _network.GetStringAsync(SiteType.Kakuyomu, episodeHref, cts.Token).ConfigureAwait(false);

--- a/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using LanobeReader.Models;
 using LanobeReader.Services.Network;
+using TBird.Core;
 using TBird.Maui.Web;
 
 namespace LanobeReader.Services.Kakuyomu;
@@ -264,31 +265,42 @@ public class KakuyomuApiService : INovelService
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(20));
 
-        string episodeId;
         if (!string.IsNullOrEmpty(siteEpisodeId))
         {
-            // DB に永続化済みの安定したサイト話 ID を直接使う。生 TOC の位置依存解決(序盤話の削除/
-            // 並べ替えで episodeIds がシフトし誤話/404 になる)を回避する本命パス。
-            episodeId = siteEpisodeId;
-        }
-        else
-        {
-            // 旧データ(site_episode_id 列追加前に保存された話)向けフォールバック: 生 TOC から位置で解決する。
-            // 新規取得分は SiteEpisodeId を持つためこの経路には来ない。BackfillSiteEpisodeIdsAsync が
-            // 旧データにも順次補完するため、フォールバック該当は時間とともに縮小する。
-            var episodeIds = await GetEpisodeIdsAsync(novelId, cts.Token).ConfigureAwait(false);
-            if (episodeNo < 1 || episodeNo > episodeIds.Count)
+            // DB に永続化済みの安定したサイト話 ID を直接使う本命パス。生 TOC の位置依存解決(序盤話の
+            // 削除/並べ替えで episodeIds がシフトし誤話/404 になる)を回避する。
+            try
             {
-                throw new InvalidOperationException($"エピソード {episodeNo} が見つかりません");
+                return await FetchContentByEpisodeIdAsync(novelId, siteEpisodeId, cts.Token).ConfigureAwait(false);
             }
-            episodeId = episodeIds[episodeNo - 1];
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // (U3) 安定 ID での取得失敗(404/本文欠落=削除・改稿で ID が陳腐化)時は、生 TOC の位置依存
+                // 解決で 1 度だけ自己修復を試みる。位置依存はドリフトで誤話になりうるが、移行前の挙動と
+                // 同等であり「読めない」確定よりは可読性を優先する方針(ユーザ承認済み U3-A)。なお訂正後の
+                // ID 永続化は API サービスへ DB 依存を持ち込まない設計方針のため行わない(読み取り都度の
+                // 再解決は 5 分 TOC キャッシュにより軽微)。
+                MessageService.Warn($"安定IDでの本文取得に失敗、位置依存解決で再試行: works/{novelId} ep={episodeNo}: {ex.Message}");
+            }
         }
 
+        // 旧データ(site_episode_id 列追加前に保存された話)、または上の安定 ID パスが失敗した場合の
+        // フォールバック: 生 TOC から位置で解決する。
+        var episodeIds = await GetEpisodeIdsAsync(novelId, cts.Token).ConfigureAwait(false);
+        if (episodeNo < 1 || episodeNo > episodeIds.Count)
+        {
+            throw new InvalidOperationException($"エピソード {episodeNo} が見つかりません");
+        }
+        return await FetchContentByEpisodeIdAsync(novelId, episodeIds[episodeNo - 1], cts.Token).ConfigureAwait(false);
+    }
+
+    private async Task<string> FetchContentByEpisodeIdAsync(string novelId, string episodeId, CancellationToken ct)
+    {
         var episodeHref = $"{BASE_URL}/works/{novelId}/episodes/{episodeId}";
 
-        var episodeHtml = await _network.GetStringAsync(SiteType.Kakuyomu, episodeHref, cts.Token).ConfigureAwait(false);
+        var episodeHtml = await _network.GetStringAsync(SiteType.Kakuyomu, episodeHref, ct).ConfigureAwait(false);
 
-        var episodeDoc = await AngleSharpHelper.ParseAsync(episodeHtml, cts.Token).ConfigureAwait(false);
+        var episodeDoc = await AngleSharpHelper.ParseAsync(episodeHtml, ct).ConfigureAwait(false);
 
         // CSS3 の [class~='X'] は「スペース区切り単語の完全一致」のため、
         // EpisodeBodyHeader 等の連結クラス名にはマッチしない（過剰マッチ回避）。

--- a/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
@@ -260,18 +260,19 @@ public class KakuyomuApiService : INovelService
         return (ids, episodes);
     }
 
-    public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default)
+    public async Task<(string content, bool cacheable)> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(20));
 
+        var selfHealing = false;
         if (!string.IsNullOrEmpty(siteEpisodeId))
         {
             // DB に永続化済みの安定したサイト話 ID を直接使う本命パス。生 TOC の位置依存解決(序盤話の
             // 削除/並べ替えで episodeIds がシフトし誤話/404 になる)を回避する。
             try
             {
-                return await FetchContentByEpisodeIdAsync(novelId, siteEpisodeId, cts.Token).ConfigureAwait(false);
+                return (await FetchContentByEpisodeIdAsync(novelId, siteEpisodeId, cts.Token).ConfigureAwait(false), true);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -281,6 +282,7 @@ public class KakuyomuApiService : INovelService
                 // ID 永続化は API サービスへ DB 依存を持ち込まない設計方針のため行わない(読み取り都度の
                 // 再解決は 5 分 TOC キャッシュにより軽微)。
                 MessageService.Warn($"安定IDでの本文取得に失敗、位置依存解決で再試行: works/{novelId} ep={episodeNo}: {ex.Message}");
+                selfHealing = true;
             }
         }
 
@@ -291,7 +293,12 @@ public class KakuyomuApiService : INovelService
         {
             throw new InvalidOperationException($"エピソード {episodeNo} が見つかりません");
         }
-        return await FetchContentByEpisodeIdAsync(novelId, episodeIds[episodeNo - 1], cts.Token).ConfigureAwait(false);
+        var content = await FetchContentByEpisodeIdAsync(novelId, episodeIds[episodeNo - 1], cts.Token).ConfigureAwait(false);
+        // 自己修復フォールバック(陳腐化した安定 ID の代替)で取得した本文はドリフトで誤話の可能性があり、
+        // かつ安定 ID が残置されるため backfill のキャッシュ破棄でも訂正されない。恒久キャッシュ(誤話キャッシュの
+        // 恒久化)を避けるため cacheable=false で返す。旧データ(siteEpisodeId 無し)の位置解決は移行 backfill
+        // 時にキャッシュ破棄で訂正されるため従来どおりキャッシュ可。
+        return (content, cacheable: !selfHealing);
     }
 
     private async Task<string> FetchContentByEpisodeIdAsync(string novelId, string episodeId, CancellationToken ct)

--- a/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
@@ -282,10 +282,12 @@ public class KakuyomuApiService : INovelService
             // エラーは SiteRateLimiter 内で既にリトライ済みで、ここまで来たら一過性の通信障害とみなし再送出して
             // 上位リトライに委ねる(正しい安定 ID を一過性失敗で捨ててキャッシュ無効化+誤話リスクを負わない)。
             // 404 等の非 transient な HttpRequestException(クライアントエラー=削除/改稿で ID 失効)と本文欠落
-            // (InvalidOperationException)のみ位置依存フォールバックへ降格させる。
+            // (InvalidOperationException)のみ位置依存フォールバックへ降格させる。予期せぬ例外(NRE/JsonException/
+            // HTTP に包まれない IOException 等)はここで握らず再送出し、上位(ReaderViewModel)でエラー表示させる
+            // (承認外の文脈で位置依存降格=誤話リスクを負わないため、対象を陳腐化失敗の 2 種に厳密化)。
             catch (Exception ex) when (
-                ex is not OperationCanceledException
-                && !(ex is HttpRequestException hre && TransientHttpErrorHelper.IsTransient(hre)))
+                (ex is HttpRequestException hre && !TransientHttpErrorHelper.IsTransient(hre))
+                || ex is InvalidOperationException)
             {
                 // (U3) 安定 ID での取得失敗(404/本文欠落=削除・改稿で ID が陳腐化)時は、生 TOC の位置依存
                 // 解決で 1 度だけ自己修復を試みる。位置依存はドリフトで誤話になりうるが、移行前の挙動と

--- a/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
+++ b/_Apps/LanobeReader/Services/Kakuyomu/KakuyomuApiService.cs
@@ -135,7 +135,11 @@ public class KakuyomuApiService : INovelService
         var url = $"{BASE_URL}/works/{novelId}";
         var html = await _network.GetStringAsync(SiteType.Kakuyomu, url, cts.Token).ConfigureAwait(false);
 
-        return ParseApolloState(html).episodes;
+        // 解析済み episodeIds を TOC キャッシュへ温める。直後に同一作品の本文を位置依存/自己修復で読む際、
+        // GetEpisodeIdsAsync が同一 /works/{novelId} を再取得するのを避ける(FetchNovelInfoAsync と同方針)。
+        var (episodeIds, episodes) = ParseApolloState(html);
+        _episodeIdCache[novelId] = (DateTime.UtcNow, episodeIds);
+        return episodes;
     }
 
     private void SweepExpiredEpisodeIdCache()
@@ -274,7 +278,14 @@ public class KakuyomuApiService : INovelService
             {
                 return (await FetchContentByEpisodeIdAsync(novelId, siteEpisodeId, cts.Token).ConfigureAwait(false), true);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            // (U2) 自己修復は「安定 ID の陳腐化を示す失敗」に限定する。5xx/408/429/通信断などの transient
+            // エラーは SiteRateLimiter 内で既にリトライ済みで、ここまで来たら一過性の通信障害とみなし再送出して
+            // 上位リトライに委ねる(正しい安定 ID を一過性失敗で捨ててキャッシュ無効化+誤話リスクを負わない)。
+            // 404 等の非 transient な HttpRequestException(クライアントエラー=削除/改稿で ID 失効)と本文欠落
+            // (InvalidOperationException)のみ位置依存フォールバックへ降格させる。
+            catch (Exception ex) when (
+                ex is not OperationCanceledException
+                && !(ex is HttpRequestException hre && TransientHttpErrorHelper.IsTransient(hre)))
             {
                 // (U3) 安定 ID での取得失敗(404/本文欠落=削除・改稿で ID が陳腐化)時は、生 TOC の位置依存
                 // 解決で 1 度だけ自己修復を試みる。位置依存はドリフトで誤話になりうるが、移行前の挙動と

--- a/_Apps/LanobeReader/Services/Narou/NarouApiService.cs
+++ b/_Apps/LanobeReader/Services/Narou/NarouApiService.cs
@@ -158,7 +158,8 @@ public class NarouApiService : INovelService
     }
 
     // Narou は本文 URL を episode_no で直接組めるため siteEpisodeId は使用しない(INovelService 共通シグネチャ)。
-    public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default)
+    // 位置依存フォールバックを持たず誤話リスクが無いため、本文は常にキャッシュ可(cacheable=true)。
+    public async Task<(string content, bool cacheable)> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(10));
@@ -176,7 +177,7 @@ public class NarouApiService : INovelService
 
         var paragraphs = honbun.QuerySelectorAll("p");
         var lines = paragraphs.Select(p => p.TextContent);
-        return string.Join("\n", lines).Trim();
+        return (string.Join("\n", lines).Trim(), true);
     }
 
     public async Task<(int totalEpisodes, string? lastUpdatedAt, bool isCompleted, string? author)> FetchNovelInfoAsync(string novelId, CancellationToken ct = default)

--- a/_Apps/LanobeReader/Services/Narou/NarouApiService.cs
+++ b/_Apps/LanobeReader/Services/Narou/NarouApiService.cs
@@ -157,7 +157,8 @@ public class NarouApiService : INovelService
         return episodes;
     }
 
-    public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, CancellationToken ct = default)
+    // Narou は本文 URL を episode_no で直接組めるため siteEpisodeId は使用しない(INovelService 共通シグネチャ)。
+    public async Task<string> FetchEpisodeContentAsync(string novelId, int episodeNo, string? siteEpisodeId, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(10));

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -4,6 +4,7 @@ using LanobeReader.Helpers;
 using LanobeReader.Models;
 using LanobeReader.Services.Background;
 using LanobeReader.Services.Database;
+using LanobeReader.Services.Network;
 using Microsoft.Maui.Storage;
 using TBird.Core;
 using TBird.Maui.Background;
@@ -17,17 +18,26 @@ public class UpdateCheckService
     private readonly NovelRepository _novelRepo;
     private readonly EpisodeRepository _episodeRepo;
     private readonly INovelServiceFactory _serviceFactory;
+    private readonly NetworkPolicyService _networkPolicy;
     private readonly BackgroundJobQueue? _jobQueue;
+
+    // 移行補完(フル TOC 取得 + backfill)を本プロセスで試行済みの作品 Id。全話がタイトル不一致(改題/ドリフト)で
+    // backfill が 0 件更新だと site_episode_id は付かず HasAnySiteEpisodeIdAsync が false のまま残る。マーカーが
+    // 無いと巡回の度にフル TOC を再取得し続け migrationBudget を浪費し他の旧作品の移行も阻害する。本サービスは
+    // Singleton のためプロセス存続中は保持される(再起動後に 1 度だけ再試行されるのは許容範囲)。
+    private readonly HashSet<int> _migrationAttempted = new();
 
     public UpdateCheckService(
         NovelRepository novelRepo,
         EpisodeRepository episodeRepo,
         INovelServiceFactory serviceFactory,
+        NetworkPolicyService networkPolicy,
         BackgroundJobQueue? jobQueue = null)
     {
         _novelRepo = novelRepo;
         _episodeRepo = episodeRepo;
         _serviceFactory = serviceFactory;
+        _networkPolicy = networkPolicy;
         _jobQueue = jobQueue;
     }
 
@@ -111,15 +121,7 @@ public class UpdateCheckService
                         // 旧データ(site_episode_id 未保存の既存話)に、いま取得した新鮮な TOC のサイト話 ID を
                         // 補完する(Kakuyomu の本文取得を位置依存からの脱却=誤話表示の是正)。タイトル一致時のみ
                         // 更新するためドリフト誤補完は避けられる。Narou は SiteEpisodeId を持たず no-op。
-                        // best-effort: 失敗しても更新検出処理は続行する。
-                        try
-                        {
-                            await _episodeRepo.BackfillSiteEpisodeIdsAsync(novel.Id, allEpisodes).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageService.Warn($"Backfill site_episode_id failed for {novel.Title}: {ex.Message}");
-                        }
+                        await TryBackfillSiteEpisodeIdsAsync(novel, allEpisodes).ConfigureAwait(false);
 
                         var newEpisodes = allEpisodes
                             .Where(e => e.EpisodeNo > currentMaxEpisode)
@@ -193,12 +195,18 @@ public class UpdateCheckService
                     }
                     else if (migrationBudget > 0
                         && (SiteType)novel.SiteType == SiteType.Kakuyomu
-                        && currentMaxEpisode > 0)
+                        && currentMaxEpisode > 0
+                        && !_migrationAttempted.Contains(novel.Id)
+                        && _networkPolicy.IsWifiConnected)
                     {
                         // (U2) 完結/安定済みの旧 Kakuyomu 作品は新着検出枝に入らず site_episode_id が永久に
                         // 未補完のまま残る(本文取得が位置依存=誤話リスク)。サイト話 ID を 1 件も持たない
                         // Kakuyomu 作品(=列追加前の旧データ)に限り、低頻度(1巡で migrationBudget 件まで)で
                         // フル TOC を取得して移行補完する。補完後は非 NULL 行が生じ再該当しないため概ね初回限り。
+                        // 機会的なバルク取得のため Wi-Fi 接続時のみ実行し従量制通信を避ける(プリフェッチと同方針。
+                        // 更新情報取得自体は機能上必須のためゲートしないが、移行補完は遅延可能なので Wi-Fi 限定)。
+                        // 全話ドリフト(0 件補完で HasAny が false のまま)の作品は _migrationAttempted で再取得を抑止し、
+                        // 巡回の度のフル TOC 再取得と budget 浪費を防ぐ。
                         // best-effort: 失敗しても巡回(LastCheckedAt 前進)は継続する。EXISTS 判定やフル TOC
                         // 取得の失敗を outer catch へ波及させると、更新チェック自体は成功しているのに
                         // HasCheckError=true となり完了記録を阻害するため、判定ごと try で握りつぶす。
@@ -208,7 +216,10 @@ public class UpdateCheckService
                             {
                                 migrationBudget--;
                                 var allEpisodes = await service.FetchEpisodeListAsync(novel.NovelId, ct).ConfigureAwait(false);
-                                await _episodeRepo.BackfillSiteEpisodeIdsAsync(novel.Id, allEpisodes).ConfigureAwait(false);
+                                await TryBackfillSiteEpisodeIdsAsync(novel, allEpisodes).ConfigureAwait(false);
+                                // フル TOC 取得まで到達した作品は試行済みとして記録(全話ドリフトでの毎巡再取得を防ぐ)。
+                                // 取得が例外で失敗した場合はここに到達せず未記録のまま=次回(Wi-Fi 時)に再試行される。
+                                _migrationAttempted.Add(novel.Id);
                             }
                         }
                         catch (Exception ex)
@@ -304,6 +315,23 @@ public class UpdateCheckService
         finally
         {
             _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// 新鮮な TOC から site_episode_id を best-effort で補完する。新着検出枝と移行補完枝の両方から呼ぶ共通処理で、
+    /// 警告メッセージ書式と例外握り潰し(失敗しても更新検出/巡回は継続)を一元化する。Narou は SiteEpisodeId を
+    /// 持たず BackfillSiteEpisodeIdsAsync 側の早期 return で no-op。
+    /// </summary>
+    private async Task TryBackfillSiteEpisodeIdsAsync(Novel novel, IReadOnlyList<Episode> allEpisodes)
+    {
+        try
+        {
+            await _episodeRepo.BackfillSiteEpisodeIdsAsync(novel.Id, allEpisodes).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            MessageService.Warn($"Backfill site_episode_id failed for {novel.Title}: {ex.Message}");
         }
     }
 

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -59,6 +59,10 @@ public class UpdateCheckService
             // 1件以上を実際にチェックできたか。全件失敗(ネット断等)や空テーブルでの「完了」記録による
             // アラーム冗長ゲートの無用な抑止を避けるため、完了時刻記録の条件に用いる。
             var anySuccess = false;
+            // (U2) 1 巡で「移行補完」(フル TOC 取得+backfill)を試みる旧 Kakuyomu 作品の上限。完結/安定済みで
+            // 新着検出枝に入らない作品も site_episode_id へ移行できるようにしつつ、1 巡の追加ネットワーク
+            // コストを抑える。round-robin(last_checked_at 昇順)で巡回するため複数巡で全旧作品を順に拾える。
+            var migrationBudget = 3;
 
             foreach (var novel in novels)
             {
@@ -185,6 +189,31 @@ public class UpdateCheckService
                             novel.TotalEpisodes = totalEpisodes;
                             if (lastUpdatedAt is not null) novel.LastUpdatedAt = lastUpdatedAt;
                             metadataChanged = true;
+                        }
+                    }
+                    else if (migrationBudget > 0
+                        && (SiteType)novel.SiteType == SiteType.Kakuyomu
+                        && currentMaxEpisode > 0)
+                    {
+                        // (U2) 完結/安定済みの旧 Kakuyomu 作品は新着検出枝に入らず site_episode_id が永久に
+                        // 未補完のまま残る(本文取得が位置依存=誤話リスク)。サイト話 ID を 1 件も持たない
+                        // Kakuyomu 作品(=列追加前の旧データ)に限り、低頻度(1巡で migrationBudget 件まで)で
+                        // フル TOC を取得して移行補完する。補完後は非 NULL 行が生じ再該当しないため概ね初回限り。
+                        // best-effort: 失敗しても巡回(LastCheckedAt 前進)は継続する。EXISTS 判定やフル TOC
+                        // 取得の失敗を outer catch へ波及させると、更新チェック自体は成功しているのに
+                        // HasCheckError=true となり完了記録を阻害するため、判定ごと try で握りつぶす。
+                        try
+                        {
+                            if (!await _episodeRepo.HasAnySiteEpisodeIdAsync(novel.Id).ConfigureAwait(false))
+                            {
+                                migrationBudget--;
+                                var allEpisodes = await service.FetchEpisodeListAsync(novel.NovelId, ct).ConfigureAwait(false);
+                                await _episodeRepo.BackfillSiteEpisodeIdsAsync(novel.Id, allEpisodes).ConfigureAwait(false);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageService.Warn($"Migration backfill failed for {novel.Title}: {ex.Message}");
                         }
                     }
                 }

--- a/_Apps/LanobeReader/Services/UpdateCheckService.cs
+++ b/_Apps/LanobeReader/Services/UpdateCheckService.cs
@@ -103,6 +103,20 @@ public class UpdateCheckService
                     {
                         // Fetch new episodes
                         var allEpisodes = await service.FetchEpisodeListAsync(novel.NovelId, ct).ConfigureAwait(false);
+
+                        // 旧データ(site_episode_id 未保存の既存話)に、いま取得した新鮮な TOC のサイト話 ID を
+                        // 補完する(Kakuyomu の本文取得を位置依存からの脱却=誤話表示の是正)。タイトル一致時のみ
+                        // 更新するためドリフト誤補完は避けられる。Narou は SiteEpisodeId を持たず no-op。
+                        // best-effort: 失敗しても更新検出処理は続行する。
+                        try
+                        {
+                            await _episodeRepo.BackfillSiteEpisodeIdsAsync(novel.Id, allEpisodes).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageService.Warn($"Backfill site_episode_id failed for {novel.Title}: {ex.Message}");
+                        }
+
                         var newEpisodes = allEpisodes
                             .Where(e => e.EpisodeNo > currentMaxEpisode)
                             .Select(e => { e.NovelId = novel.Id; return e; })
@@ -152,6 +166,7 @@ public class UpdateCheckService
                                             EpisodeNo = ep.EpisodeNo,
                                             SiteType = novel.SiteType,
                                             SiteNovelId = novel.NovelId,
+                                            SiteEpisodeId = ep.SiteEpisodeId,
                                         }, novel.IsFavorite ? JobPriority.High : JobPriority.Normal).ConfigureAwait(false);
                                     }
                                 }

--- a/_Apps/LanobeReader/ViewModels/ReaderViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/ReaderViewModel.cs
@@ -205,14 +205,20 @@ public partial class ReaderViewModel : ErrorAwareViewModel, IQueryAttributable
                 }
 
                 var service = _serviceFactory.GetService((SiteType)_siteType);
-                content = await service.FetchEpisodeContentAsync(_siteNovelId, _episode.EpisodeNo, _episode.SiteEpisodeId);
+                var (fetched, cacheable) = await service.FetchEpisodeContentAsync(_siteNovelId, _episode.EpisodeNo, _episode.SiteEpisodeId);
+                content = fetched;
 
-                await _cacheRepo.InsertAsync(new EpisodeCache
+                // 位置依存フォールバック(陳腐化した安定 ID の自己修復)で取得した本文は誤話の可能性があり、
+                // 訂正経路も無いため恒久キャッシュしない(誤話キャッシュの恒久化を防止)。表示はそのまま行う。
+                if (cacheable)
                 {
-                    EpisodeId = episodeId,
-                    Content = content,
-                    CachedAt = DateTime.UtcNow.ToString("o"),
-                });
+                    await _cacheRepo.InsertAsync(new EpisodeCache
+                    {
+                        EpisodeId = episodeId,
+                        Content = content,
+                        CachedAt = DateTime.UtcNow.ToString("o"),
+                    });
+                }
             }
 
             EpisodeTitle = _episode.Title;

--- a/_Apps/LanobeReader/ViewModels/ReaderViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/ReaderViewModel.cs
@@ -205,7 +205,7 @@ public partial class ReaderViewModel : ErrorAwareViewModel, IQueryAttributable
                 }
 
                 var service = _serviceFactory.GetService((SiteType)_siteType);
-                content = await service.FetchEpisodeContentAsync(_siteNovelId, _episode.EpisodeNo);
+                content = await service.FetchEpisodeContentAsync(_siteNovelId, _episode.EpisodeNo, _episode.SiteEpisodeId);
 
                 await _cacheRepo.InsertAsync(new EpisodeCache
                 {


### PR DESCRIPTION
## 背景（バグ）
`KakuyomuApiService.FetchEpisodeContentAsync` は DB の `episode_no` を使って、その場で取得した生 TOC を**位置参照**していた（`episodeIds[episodeNo - 1]`）。

```
本来: DB episode_no=40  →  サイトの40話目
```

しかし作者が**序盤の話を削除/並べ替え**すると、生 TOC のエントリ位置が 1 つずれ、`episodeIds[39]` が実際には 41 話目を指す。結果、エラーも出さずに**別の話の本文を表示**してしまう（コードレビューの最重要指摘）。

`episode_no` が URL に乗る Narou は影響なし（`/{ncode}/{episode_no}/` で安定）。Kakuyomu のみ、不透明な episode ID を経由するためこの問題が起きる。

## 方針
サイト側の**安定したエピソード ID を DB に永続化**し、本文取得をその ID で行う（位置依存をやめる）。

## 変更点
- **スキーマ**: `episodes.site_episode_id`(TEXT NULL) を追加。`EnsureColumnAsync` で冪等付与（既存 `is_favorite` 等と同方式、スキーマバージョン非依存）。新規インストールは `CreateTableAsync<Episode>` が作成。
- **KakuyomuApiService**: `ParseApolloState` で各話に `SiteEpisodeId`（`Episode:<id>` の id 部）を設定。`FetchEpisodeContentAsync` は `siteEpisodeId` があれば直接 `/works/{novelId}/episodes/{siteEpisodeId}` を叩き、無ければ従来の位置解決へフォールバック。
- **INovelService**: `FetchEpisodeContentAsync(novelId, episodeNo, siteEpisodeId, ct)` に引数追加。Narou は未使用。
- **伝搬**: Reader / Prefetch（`PrefetchEpisodeJob` / `BackgroundJobQueue` / `PrefetchService`）/ `UpdateCheckService` の本文取得・enqueue 経路へ `SiteEpisodeId` を流す。登録（SearchViewModel）と更新検出はいずれも `InsertAllAsync` 経由のため新規取得分は最初から保存される。
- **旧データ補完（バックフィル）**: `UpdateCheckService` の再取得時に `EpisodeRepository.BackfillSiteEpisodeIdsAsync` を呼び、列追加前から存在する話へ、新鮮な TOC のサイト ID を補完する。**同一 episode_no のタイトルが一致する話だけ**更新する（不一致＝ドリフト疑い→誤補完を回避）。Narou は no-op。
- **クリーンアップ**: `EpisodeRepository` の 4 つの raw クエリで重複していた列リストを `EpisodeColumns` 定数へ集約（レビュー指摘済みの重複）。

## 既知の制限
列追加前から存在し、かつ**一度も再取得されない静的作品**の旧話は、`site_episode_id` が NULL のままフォールバック解決を使う（＝従来挙動）。新規取得分・更新のある作品は補完される。完全なバックフィルには全作品の TOC 再取得が必要なため、リスク（ドリフト後の誤補完・通信コスト）を避け本 PR では見送り。

## ベースブランチ
このバグ対象ファイルは現状 `fix/lanobereader-review-followups` のみに存在するため、同ブランチを base にしている（リポジトリの Git ワークフロー規約）。

## テスト
`dotnet build _Apps/App.sln` 成功（0 警告 / 0 エラー）。