### PR TITLE
chore(lanobereader): LanobeReader を .NET 10 へ移行

### DIFF
--- a/_Apps/LanobeReader/Features/requirements_lanovereader.md
+++ b/_Apps/LanobeReader/Features/requirements_lanovereader.md
@@ -68,10 +68,10 @@
 | sqlite-net-pcl | 最新安定版 | SQLiteアクセス（ORM） |
 | SQLitePCLRaw.bundle_green | 最新安定版 | sqlite-net-pclの依存ライブラリ |
 | AngleSharp | 最新安定版 | HTMLパース（スクレイピング） |
-| Microsoft.Extensions.DependencyInjection | .NET9同梱 | DIコンテナ |
-| System.Text.Json | .NET9同梱 | JSONパース（カクヨムAPI等） |
+| Microsoft.Extensions.DependencyInjection | .NET10同梱 | DIコンテナ |
+| System.Text.Json | .NET10同梱 | JSONパース（カクヨムAPI等） |
 
-> HttpClientは.NET9標準のものを使用。NuGet追加不要。
+> HttpClientは.NET10標準のものを使用。NuGet追加不要。
 
 ### 2.3 ソリューション構成
 ```

--- a/_Apps/LanobeReader/LanobeReader.csproj
+++ b/_Apps/LanobeReader/LanobeReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFramework>net10.0-android</TargetFramework>
     <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <RootNamespace>LanobeReader</RootNamespace>
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.*" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.*" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
     <PackageReference Include="sqlite-net-pcl" Version="1.*" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.*" />

--- a/_Apps/LanobeReader/Platforms/Android/BatteryOptimizationHelper.cs
+++ b/_Apps/LanobeReader/Platforms/Android/BatteryOptimizationHelper.cs
@@ -39,7 +39,7 @@ public static class BatteryOptimizationHelper
 				if (Preferences.Get(AskedKey, false)) return;
 				Preferences.Set(AskedKey, true);
 
-				var ok = await Shell.Current.DisplayAlert(
+				var ok = await Shell.Current.DisplayAlertAsync(
 					"バックグラウンド更新の許可",
 					"新着をバックグラウンドで確実に通知するため、電池の最適化を無効にすることを推奨します。設定画面を開きますか？",
 					"設定を開く", "後で");

--- a/_Apps/LanobeReader/ViewModels/EpisodeListViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/EpisodeListViewModel.cs
@@ -611,7 +611,7 @@ public partial class EpisodeListViewModel : AutoReloadViewModel, IQueryAttributa
     {
         if (_novel is null) return;
         var enqueued = await _prefetch.EnqueueNovelAsync(_novelDbId, highPriority: true);
-        await Shell.Current.DisplayAlert("一括ダウンロード",
+        await Shell.Current.DisplayAlertAsync("一括ダウンロード",
             enqueued > 0
                 ? $"{enqueued}話をバックグラウンドで取得します（Wi-Fi接続時のみ）"
                 : "新規取得する話はありません",

--- a/_Apps/LanobeReader/ViewModels/NovelListViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/NovelListViewModel.cs
@@ -115,7 +115,7 @@ public partial class NovelListViewModel : AutoReloadViewModel
             "未読話数（多い順）",
             "お気に入り優先",
         };
-        var selected = await Shell.Current.DisplayActionSheet("並び順", "キャンセル", null, options);
+        var selected = await Shell.Current.DisplayActionSheetAsync("並び順", "キャンセル", null, options);
         if (string.IsNullOrEmpty(selected) || selected == "キャンセル") return;
 
         SortKey = selected switch
@@ -191,7 +191,7 @@ public partial class NovelListViewModel : AutoReloadViewModel
     [RelayCommand]
     private async Task DeleteCache(NovelCardViewModel card)
     {
-        bool confirm = await Shell.Current.DisplayAlert(
+        bool confirm = await Shell.Current.DisplayAlertAsync(
             "確認", "キャッシュを削除しますか？", "OK", "キャンセル");
 
         if (confirm)
@@ -203,7 +203,7 @@ public partial class NovelListViewModel : AutoReloadViewModel
     [RelayCommand]
     private async Task DeleteNovel(NovelCardViewModel card)
     {
-        bool confirm = await Shell.Current.DisplayAlert(
+        bool confirm = await Shell.Current.DisplayAlertAsync(
             "確認", "タイトルを削除しますか？この操作は元に戻せません。", "OK", "キャンセル");
 
         if (confirm)

--- a/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
+++ b/_Apps/LanobeReader/ViewModels/SettingsViewModel.cs
@@ -174,7 +174,7 @@ public partial class SettingsViewModel : ErrorAwareViewModel
     [RelayCommand]
     private async Task ClearCacheAsync()
     {
-        bool confirm = await Shell.Current.DisplayAlert(
+        bool confirm = await Shell.Current.DisplayAlertAsync(
             "確認", "すべてのキャッシュを削除しますか？", "OK", "キャンセル");
 
         if (!confirm) return;
@@ -184,7 +184,7 @@ public partial class SettingsViewModel : ErrorAwareViewModel
         {
             await _cacheRepo.DeleteAllAsync();
             // Snackbar-like notification
-            await Shell.Current.DisplayAlert("完了", "クリアしました", "OK");
+            await Shell.Current.DisplayAlertAsync("完了", "クリアしました", "OK");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## 概要
ラノベリーダ (LanobeReader) を net9.0-android から net10.0-android へ移行する。共有ライブラリ群の移行は master 向け PR #171。

## 変更
- TFM: `net9.0-android` → **`net10.0-android`**
- MAUI パッケージ参照 `9.0.*` → `10.0.*` (Microsoft.Maui.Controls / Controls.Compatibility)
- CS0618 対応 (.NET 10 で非推奨化した同期 API を Async へ):
  - `DisplayAlert` → `DisplayAlertAsync`: SettingsViewModel(×2) / NovelListViewModel(×2) / EpisodeListViewModel / Platforms/Android/BatteryOptimizationHelper
  - `DisplayActionSheet` → `DisplayActionSheetAsync`: NovelListViewModel
- `Features/requirements_lanovereader.md` の .NET9 記述を .NET10 へ更新

## 既知の警告 (本 PR では未対応)
- NU1903: `SQLitePCLRaw.lib.e_sqlite3.android` 2.1.11 の SQLite 脆弱性。**修正版が未公開** (advisory の first_patched=None、.android は 3.x 未リリース)。自前ローカル DB のみ使用で攻撃面ほぼ無のため据え置き。

## ビルド/マージ依存
- 要 .NET 10 SDK (10.0.301) + maui-android (10.0.20) + Android API 36、**Visual Studio 2026 (18.x)**。
- **本 PR 単体ではビルド不可**: 参照する net10 ライブラリ群が app-novelviewer にまだ無いため。先に PR #171 を master へマージし、master を app-novelviewer に取り込んでから本 PR をマージするとビルドが通る。
- ローカルでは PR #171 のライブラリ変更込みで App.sln を `dotnet build` 0 エラー確認済み。