### PR TITLE
fix(lanobereader): 行を返す PRAGMA を ExecuteScalarAsync で実行し起動クラッシュを解消

### DIFF
--- a/_Apps/LanobeReader/Services/Database/DatabaseService.cs
+++ b/_Apps/LanobeReader/Services/Database/DatabaseService.cs
@@ -22,8 +22,12 @@ public class DatabaseService : SqliteDatabaseBase
         //    続く WAL 切替 PRAGMA 自体も競合時に最大 5 秒待機できるようにする(起動時の一時ロックで
         //    最初の DDL が即失敗→初期化 Task が faulted で固着するのを防ぐ)。WAL は DB ファイルに
         //    永続化され読取と書込の並行性を上げる。冪等(毎起動の再適用は無害)。
-        await conn.ExecuteAsync("PRAGMA busy_timeout=5000").ConfigureAwait(false);
-        await conn.ExecuteAsync("PRAGMA journal_mode=WAL").ConfigureAwait(false);
+        // これらの PRAGMA は「設定後の値」を結果行として返すため、行を読まない ExecuteAsync
+        // (=ExecuteNonQuery) で実行すると Step() が Row(100) を返し、sqlite-net が無条件 throw する
+        // ("not an error" = SQLITE_OK の errmsg)。結果行を読む ExecuteScalarAsync<T> を使う
+        // (journal_mode=WAL の有効化は sqlite-net 公式もこの呼び方)。
+        await conn.ExecuteScalarAsync<int>("PRAGMA busy_timeout=5000").ConfigureAwait(false);
+        await conn.ExecuteScalarAsync<string>("PRAGMA journal_mode=WAL").ConfigureAwait(false);
 
         // 1. CreateTable は冪等。v0 の新規インストール時の初期化も兼ねる。
         await conn.CreateTableAsync<Novel>().ConfigureAwait(false);


### PR DESCRIPTION
## 概要
LanobeReader 起動時、初回 DB アクセスで `SQLite.SQLiteException: "not an error"` が発生しアプリがクラッシュしていた問題を修正する。

## 症状
`NovelListPage.OnAppearing` → `AppSettingsRepository` → `DatabaseService.CreateTablesAsync`（`DatabaseService.cs:25`）でクラッシュ。logcat 上は `android.runtime.JavaProxyThrowable: [SQLite.SQLiteException]: not an error`。

## 原因（IL レベルで確定）
`CreateTablesAsync` 冒頭の以下 2 文を `ExecuteAsync`（中身は `SQLiteCommand.ExecuteNonQuery`）で実行していた。
- `PRAGMA busy_timeout=5000`
- `PRAGMA journal_mode=WAL`

両 PRAGMA は「設定後の値」を**結果行として 1 行返す**。`ExecuteNonQuery` は単発 `Step()` のみで、戻り値が `Done(101)`／`Error(1)`／`Constraint(19)` 以外（= `Row(100)` を含む）は末尾で**無条件に `throw SQLiteException.New(r, GetErrmsg())`**（`SQLite-net.dll` 1.9.172 の IL で確認）。このとき DB に実エラーは無いため `sqlite3_errmsg` は `SQLITE_OK` の文字列 `"not an error"` を返す。

`ExecuteScalar<T>` は `Row` で列を読み `Done` で default を返し、真のエラー時のみ throw（IL で確認）。

## 修正
`_Apps/LanobeReader/Services/Database/DatabaseService.cs:25-26` を `ExecuteScalarAsync<T>` に変更。
- `ExecuteScalarAsync<int>("PRAGMA busy_timeout=5000")`
- `ExecuteScalarAsync<string>("PRAGMA journal_mode=WAL")`（WAL 有効化は sqlite-net 公式もこの呼び方）

意図（busy_timeout を先に設定 → WAL 切替も待機できる、冪等）と実行順は維持。

## 調査メモ
- sqlite-net のバージョン非依存の罠で **.NET 10 移行とは無関係**。`sqlite-net-pcl 1.9.172` / `SQLitePCLRaw 2.1.11` は移行前後で不変（復元バージョンで確認）。クリーン再インストールで初回 cold-init 経路を初めて踏み顕在化したもの。
- リポジトリ全体を走査し、行を返す文を `ExecuteAsync` する箇所は他に無いことを確認（DDL/DML は問題なし、`PRAGMA table_info` は `QueryAsync` 使用）。
- 同じ `TBird.Maui.DB`(`SqliteDatabaseBase`) 基底を使う他アプリの `CreateTablesAsync` でも再発しうる罠。

## 確認
- 実機で起動・動作を確認済み（クラッシュ解消）。
