### PR TITLE
fix(trade-analyzer): EDINET DocId 衝突で run-today がクラッシュする不具合を修正

### DIFF
--- a/_Apps/TradeAnalyzer.Core/Ingest/IngestService.cs
+++ b/_Apps/TradeAnalyzer.Core/Ingest/IngestService.cs
@@ -145,7 +145,10 @@ public class IngestService
                 continue;
             }
 
-            var targets = docs
+            // EDINET は同一 docID を同日一覧内でも再掲しうるため重複排除（targets 抽出・スキップ数算出の基準）。
+            var distinct = docs.DistinctBy(x => x.DocId).ToList();
+
+            var targets = distinct
                 .Where(x => x.DocTypeCode != null && TargetDocTypeCodes.Contains(x.DocTypeCode))
                 .Where(x => x.CsvFlag == "1")
                 .Where(x => x.NormalizedCode != null && MatchesKnown(x.NormalizedCode, codeSet))
@@ -157,23 +160,11 @@ public class IngestService
                 targets = targets.Take(lim).ToList();
             }
 
-            // 書類メタを保存。EDINET は同一 docID を複数のファイル日付一覧に返す（提出処理日＋書類情報修正日＋
-            // 開示不開示区分変更日。公式仕様 ESE140206.pdf の date 注記）。PK は DocId 単独のため、SubmitDate 単位の
-            // delete-insert だけでは「他日に既存の同一 DocId」と UNIQUE 衝突する。対策として、同日分は置換（冪等維持）
-            // しつつ、他日に既に存在する DocId はスキップして衝突を避ける（既存メタ行を書き換えない）。
-            var ids = docs.Select(x => x.DocId).ToList();
-            await _db.EdinetDocuments.Where(x => x.SubmitDate == d).ExecuteDeleteAsync(ct).ConfigureAwait(false);
-            // 重要（順序の不変条件）: existingIds は上の同日 delete の「後」に取得する。ExecuteDeleteAsync は即時
-            // 実行なので、この時点で ids に一致して残るのは他日 SubmitDate の既存行のみ。この照会を delete より前へ
-            // 動かす／delete を外すと、当日 DocId まで existingIds に入り toInsert から落ちて当日メタが二度と挿入
-            // されなくなる（同日再取得でデータ消失）。順序を変えないこと。
-            var existingIds = (await _db.EdinetDocuments.Where(x => ids.Contains(x.DocId))
-                    .Select(x => x.DocId).ToListAsync(ct).ConfigureAwait(false))
-                .ToHashSet(StringComparer.Ordinal);
-            var toInsert = docs.DistinctBy(x => x.DocId).Where(x => !existingIds.Contains(x.DocId)).ToList();
-            _db.EdinetDocuments.AddRange(toInsert);
-            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
-            _logger.LogInformation("EDINET {Date}: 一覧 {Listed} 件・新規 {New} 件", d, docs.Count, toInsert.Count);
+            // 書類メタを保存（衝突回避コアは SaveEdinetMetaAsync に抽出）。生の docs を渡す（メソッド内で dedup）。
+            var toInsert = await SaveEdinetMetaAsync(_db, docs, d, ct).ConfigureAwait(false);
+            var skippedExisting = distinct.Count - toInsert.Count;
+            _logger.LogInformation("EDINET {Date}: 一覧 {Listed} 件（実 {Distinct} 件）・新規 {New} 件・他日既存スキップ {Skipped} 件",
+                d, docs.Count, distinct.Count, toInsert.Count, skippedExisting);
 
             foreach (var doc in targets)
             {
@@ -198,6 +189,35 @@ public class IngestService
             if (targets.Count > 0)
                 _logger.LogInformation("EDINET {Date}: 対象 {Count} 件解析", d, targets.Count);
         }
+    }
+
+    /// <summary>
+    /// EDINET 書類メタの衝突回避保存コア。EDINET は同一 docID を複数のファイル日付一覧に返す（提出処理日＋
+    /// 書類情報修正日＋開示不開示区分変更日。公式仕様 ESE140206.pdf の date 注記）。PK は
+    /// <see cref="EdinetDocument.DocId"/> 単独のため、<paramref name="d"/> 単位の delete-insert だけでは
+    /// 「他日に既存の同一 DocId」と UNIQUE 衝突する。対策として同日分は置換（冪等維持）しつつ、他日
+    /// <see cref="EdinetDocument.SubmitDate"/> に既存の DocId はスキップして衝突を避ける（既存メタ行を書き換えない）。
+    /// <c>SubmitDate != d</c> でフィルタするため delete と照会の実行順に依存しない。引数 <paramref name="docs"/> は
+    /// 同一 DocID の再掲を含みうる生の一覧でよい（メソッド内で DocId 重複排除するため呼び出し側の dedup 規律に
+    /// 依存しない＝misuse-proof）。SelfTest（別アセンブリ TradeAnalyzer.Worker）から in-memory DB で検証するため public。
+    /// </summary>
+    /// <returns>実際に挿入した（他日既存でスキップされなかった）メタ行。</returns>
+    public static async Task<List<EdinetDocument>> SaveEdinetMetaAsync(
+        AppDbContext db, IReadOnlyList<EdinetDocument> docs, DateOnly d, CancellationToken ct)
+    {
+        // 防御的 dedup: 生 docs 混入（同日重複 DocId）でも AddRange の identity-resolution 衝突
+        // （InvalidOperationException）を招かない（PR #181 が根絶した構造的クラッシュ免疫を維持）。
+        var deduped = docs.DistinctBy(x => x.DocId).ToList();
+        await db.EdinetDocuments.Where(x => x.SubmitDate == d).ExecuteDeleteAsync(ct).ConfigureAwait(false);
+        var ids = deduped.Select(x => x.DocId).ToList();
+        var otherDayIds = (await db.EdinetDocuments
+                .Where(x => ids.Contains(x.DocId) && x.SubmitDate != d)
+                .Select(x => x.DocId).ToListAsync(ct).ConfigureAwait(false))
+            .ToHashSet(StringComparer.Ordinal);
+        var toInsert = deduped.Where(x => !otherDayIds.Contains(x.DocId)).ToList();
+        db.EdinetDocuments.AddRange(toInsert);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        return toInsert;
     }
 
     /// <summary>EDINET 正規化コード（4桁）が J-Quants Code 集合（4桁/5桁）に一致するか。</summary>

--- a/_Apps/TradeAnalyzer.Core/Ingest/IngestService.cs
+++ b/_Apps/TradeAnalyzer.Core/Ingest/IngestService.cs
@@ -157,10 +157,23 @@ public class IngestService
                 targets = targets.Take(lim).ToList();
             }
 
-            // 書類メタを保存（delete-insert by submit date）。
+            // 書類メタを保存。EDINET は同一 docID を複数のファイル日付一覧に返す（提出処理日＋書類情報修正日＋
+            // 開示不開示区分変更日。公式仕様 ESE140206.pdf の date 注記）。PK は DocId 単独のため、SubmitDate 単位の
+            // delete-insert だけでは「他日に既存の同一 DocId」と UNIQUE 衝突する。対策として、同日分は置換（冪等維持）
+            // しつつ、他日に既に存在する DocId はスキップして衝突を避ける（既存メタ行を書き換えない）。
+            var ids = docs.Select(x => x.DocId).ToList();
             await _db.EdinetDocuments.Where(x => x.SubmitDate == d).ExecuteDeleteAsync(ct).ConfigureAwait(false);
-            _db.EdinetDocuments.AddRange(docs);
+            // 重要（順序の不変条件）: existingIds は上の同日 delete の「後」に取得する。ExecuteDeleteAsync は即時
+            // 実行なので、この時点で ids に一致して残るのは他日 SubmitDate の既存行のみ。この照会を delete より前へ
+            // 動かす／delete を外すと、当日 DocId まで existingIds に入り toInsert から落ちて当日メタが二度と挿入
+            // されなくなる（同日再取得でデータ消失）。順序を変えないこと。
+            var existingIds = (await _db.EdinetDocuments.Where(x => ids.Contains(x.DocId))
+                    .Select(x => x.DocId).ToListAsync(ct).ConfigureAwait(false))
+                .ToHashSet(StringComparer.Ordinal);
+            var toInsert = docs.DistinctBy(x => x.DocId).Where(x => !existingIds.Contains(x.DocId)).ToList();
+            _db.EdinetDocuments.AddRange(toInsert);
             await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogInformation("EDINET {Date}: 一覧 {Listed} 件・新規 {New} 件", d, docs.Count, toInsert.Count);
 
             foreach (var doc in targets)
             {

--- a/_Apps/TradeAnalyzer.Data/Entities/EdinetEntities.cs
+++ b/_Apps/TradeAnalyzer.Data/Entities/EdinetEntities.cs
@@ -33,7 +33,9 @@ public class EdinetDocument
     /// <summary>様式コード（`formCode`）。</summary>
     public string? FormCode { get; set; }
 
-    /// <summary>提出日（一覧取得対象日）。先読み防止の基準日に使用。</summary>
+    /// <summary>提出日（一覧取得対象日）。※現状 look-ahead ゲートには未使用（ゲートは DailyBar.Date 側で実装）。
+    /// 再掲 docID は最初に取り込んだ一覧日（取込順依存で最小とは限らない）になるため、将来 look-ahead に使うなら
+    /// submitDateTime 導入 or 最小提出日保持が必要。</summary>
     public DateOnly SubmitDate { get; set; }
 
     /// <summary>対象期間開始（`periodStart`）。</summary>
@@ -89,6 +91,8 @@ public class EdinetFinFact
     /// <summary>単位（`unitRef` 等。JPY/円/千円/百万円/Pure 等）。<see cref="Value"/> の換算係数の根拠。</summary>
     public string? Unit { get; set; }
 
-    /// <summary>対象期間終了日（先読み防止の参考。提出日でガードするのが主）。</summary>
+    /// <summary>対象期間終了日。※現状 look-ahead ゲートには未使用（ゲートは DailyBar.Date 側で実装）。
+    /// 由来 docID が再掲の場合は取込順依存の日付になりうるため、将来 look-ahead に使うなら submitDateTime 導入
+    /// or 最小提出日保持が必要。</summary>
     public DateOnly? PeriodEnd { get; set; }
 }

--- a/_Apps/TradeAnalyzer.Data/Entities/EdinetEntities.cs
+++ b/_Apps/TradeAnalyzer.Data/Entities/EdinetEntities.cs
@@ -4,7 +4,10 @@ namespace TradeAnalyzer.Data.Entities;
 /// EDINET 書類一覧の1件（GET /documents.json?type=2 の results[]）。
 /// <para>
 /// 保存方針: 当日提出の全書類メタを保存する（段階2で <c>TargetDocTypeCodes</c> を四半期/半期へ
-/// 拡張する際の検出に有用なため絞り込まない）。したがって本テーブルには対象外の書類も
+/// 拡張する際の検出に有用なため絞り込まない）。同一 docID が複数のファイル日付一覧に再掲された場合
+/// （提出処理日＋書類情報修正日＋開示不開示区分変更日）は、PK=<see cref="DocId"/> 単独ゆえ最初に取り込んだ
+/// 一覧の <see cref="SubmitDate"/>（取込順依存で最小日付とは限らない）の行のみ保持し、再掲日の再挿入はスキップする（IngestEdinetAsync 参照）。
+/// したがって本テーブルには対象外の書類も
 /// <see cref="Parsed"/>=false / <see cref="NormalizedCode"/>=null で多数含まれる。
 /// <b>消費契約</b>: 財務事実として利用する側は必ず <see cref="Parsed"/>==true かつ
 /// <see cref="NormalizedCode"/>!=null の行のみを対象とすること（全行件数を母集団に使わない）。

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using TradeAnalyzer.Core.Indicators;
+using TradeAnalyzer.Core.Ingest;
 using TradeAnalyzer.Core.Rules;
 using TradeAnalyzer.Data;
 using TradeAnalyzer.Data.Entities;
@@ -43,6 +44,7 @@ public static class SelfTest
         failed += await RunBacktestMissingDaysTestAsync();
         failed += RunSelectTopPicksTests();
         failed += await RunAsNoTrackingReflectsUpdateTestAsync();
+        failed += await RunEdinetMetaCollisionTestAsync();
         failed += RunResolveTodayJstTests();
 
         if (failed == 0) Console.WriteLine("SelfTest: 全テスト PASS");
@@ -593,6 +595,91 @@ public static class SelfTest
             f += Assert("AsNoTracking 罠: AsNoTracking は UPDATE 後の 0.42 を反映", noTrack.Single().MlScore == 0.42);
         }
         finally { conn.Dispose(); }
+        return f;
+    }
+
+    /// <summary>
+    /// PR #181 回帰: EDINET 同一 docID 再掲による PK(DocId 単独) UNIQUE 衝突クラッシュを固定する。
+    /// <see cref="IngestService.SaveEdinetMetaAsync"/> を in-memory SQLite（実 EF 挙動）で直接検証する。
+    /// ケース1: 別 SubmitDate 再掲でも例外なし・最初の行のみ保持。ケース2: 同日2回で冪等（行数不変）。
+    /// ケース3: 他日既存 DocId はスキップし既存行の SubmitDate を上書きしない。ケース4: 同一リスト内の
+    /// 重複 DocId でも防御 dedup で例外なし・1行。revert 判定は otherDayIds フィルタ除去（ケース1/3 FAIL）と
+    /// メソッド内 DistinctBy 除去（ケース4 FAIL）の2軸。
+    /// </summary>
+    private static async Task<int> RunEdinetMetaCollisionTestAsync()
+    {
+        int f = 0;
+        static EdinetDocument Doc(string id, DateOnly submit) => new() { DocId = id, SubmitDate = submit };
+
+        // ケース1: 同一 DocId=X を別 SubmitDate で保存 → 例外なし・行数1・最初の行(d1)を保持。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                var d1 = new DateOnly(2025, 6, 20);
+                var d2 = new DateOnly(2025, 6, 21);
+                await IngestService.SaveEdinetMetaAsync(db, new[] { Doc("X", d1) }, d1, default);
+                db.ChangeTracker.Clear();
+                await IngestService.SaveEdinetMetaAsync(db, new[] { Doc("X", d2) }, d2, default);
+                var rows = await db.EdinetDocuments.AsNoTracking().ToListAsync();
+                f += Assert("SaveEdinetMeta 衝突: 再掲でも例外なし・行数1", rows.Count == 1);
+                f += Assert("SaveEdinetMeta 衝突: 最初の一覧日(d1)を保持", rows.Single().SubmitDate == d1);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // ケース2（冪等）: DocId で dedup 済みの同一リストを同日 d で2回呼ぶ → 例外なし・行数不変。
+        // cross-call の追跡衝突（same key already tracked）を避けるため呼び出し間に ChangeTracker.Clear()。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                var d = new DateOnly(2025, 6, 20);
+                var list = new[] { Doc("X", d), Doc("Y", d) };
+                await IngestService.SaveEdinetMetaAsync(db, list, d, default);
+                db.ChangeTracker.Clear();
+                await IngestService.SaveEdinetMetaAsync(db, list, d, default);
+                f += Assert("SaveEdinetMeta 冪等: 同日2回で例外なし・行数不変(2)",
+                    await db.EdinetDocuments.CountAsync() == 2);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // ケース3（他日既存スキップ）: Y を他日 d_prev で事前投入 → 当日 d の一覧(X 新規 + Y 他日既存)を渡す
+        // → 戻りに X を含み Y を含まない・Y 行の SubmitDate は d_prev のまま。事前投入と本命の間に Clear()。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                var dPrev = new DateOnly(2025, 6, 19);
+                var d = new DateOnly(2025, 6, 20);
+                await IngestService.SaveEdinetMetaAsync(db, new[] { Doc("Y", dPrev) }, dPrev, default);
+                db.ChangeTracker.Clear();
+                var toInsert = await IngestService.SaveEdinetMetaAsync(
+                    db, new[] { Doc("X", d), Doc("Y", d) }, d, default);
+                f += Assert("SaveEdinetMeta 他日スキップ: 戻りに X を含む", toInsert.Any(x => x.DocId == "X"));
+                f += Assert("SaveEdinetMeta 他日スキップ: 戻りに Y を含まない", toInsert.All(x => x.DocId != "Y"));
+                var yRow = await db.EdinetDocuments.AsNoTracking().SingleAsync(x => x.DocId == "Y");
+                f += Assert("SaveEdinetMeta 他日スキップ: Y の SubmitDate は d_prev のまま(上書きしない)",
+                    yRow.SubmitDate == dPrev);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // ケース4（防御的 dedup）: 1回の呼び出しに同一 DocId=X を2件含む生リスト → 例外なし・行数1
+        // （メソッド内 DistinctBy 除去なら AddRange の identity-resolution 衝突で FAIL＝防御を固定）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                var d = new DateOnly(2025, 6, 20);
+                await IngestService.SaveEdinetMetaAsync(db, new[] { Doc("X", d), Doc("X", d) }, d, default);
+                f += Assert("SaveEdinetMeta 防御dedup: 同日重複でも例外なし・行数1",
+                    await db.EdinetDocuments.CountAsync() == 1);
+            }
+            finally { conn.Dispose(); }
+        }
+
         return f;
     }
 


### PR DESCRIPTION
## 背景

段階3a 日次オーケストレータ `run-today` の EDINET メタ保存で、`EdinetDocuments.DocId` の UNIQUE 制約違反により ExitCode=1 でクラッシュしうる不具合を修正する。実際に 2026-06-30 のメタ欠損補完 ingest が `UNIQUE constraint failed: EdinetDocuments.DocId` で全ロールバックした。

## 根本原因（EDINET 公式仕様で確定）

公式 API 仕様書 `ESE140206.pdf` の `date`（ファイル日付）注記より、`date=X` の一覧には以下が含まれる:
1. X日に提出処理された書類
2. X日に登録された**書類情報修正**（`docInfoEditStatus`）
3. X日の**開示不開示区分変更**（`withdrawalStatus`）

`docID` は不変なので、**同一 docID が「提出日の一覧」と「後日の修正日の一覧」の両方に出る**。

- 現行はメタを `SubmitDate == d` 単位で delete-insert していた。
- テーブル PK は **`DocId` 単独**。
- → 既に別ファイル日付で保存済みの `DocId` が別日の一覧にも現れ `SubmitDate` 違いで挿入されると、delete で消えない既存行と **PK 衝突**（`SqliteException 19`）。

`run-today` は `edinet-limit=0` でも同じ delete-insert を無条件に通るため、翌日一覧に前日と重複する `DocId`（書類情報修正など）が1件でもあればクラッシュする。書類情報修正は日常的に発生するため近日クラッシュは時間の問題だった。

## 却下案

**案C（`submitDateTime` を真の提出日として採用する大改修）**は却下。`_Apps` 全体を調査した結果、業務ロジック（RuleEngine / 特徴量生成 / バックテスト / run-today）での `SubmitDate` 参照はゼロ。DTO/エンティティ変更＋既存データ再 ingest 移行コストに見合わない。将来 EDINET ファクトを提出日で厳密に扱う段階が来たら別途検討。

## 採用方針（クラッシュ根絶・副作用最小）

`IngestEdinetAsync` のメタ保存を **DocId 単位の衝突回避**へ変更:

1. 同一ファイル日付（`SubmitDate == d`）の既存は従来どおり delete（同日再取得の冪等性を維持）。
2. **他日に既存の同一 `DocId` はスキップ**（既存メタ行を書き換えず UNIQUE 衝突を回避）。
3. `docs` を `DistinctBy(DocId)` で正規化（同一レスポンス内重複への防御）。
4. **観測性ログを1行追加**（一覧件数・新規件数）。200 空振り／未実行の区別がログだけで付く。

`EdinetEntities.cs` は DocId 単位保持の不変条件を XML doc に追記（コード非変更）。

不変条件: 同一 `DocId` は最初に取り込んだ一覧の `SubmitDate` の行のみ保持（取込順依存で最小日付とは限らない）。真に当日提出の新規 `DocId` は全て保存される。

## 検証結果

| 検証 | 結果 |
|------|------|
| ビルド（App.sln） | 0警告0エラー |
| 06-30 メタ＋ファクト補完 ingest | ExitCode=0・`一覧 909 件・新規 908 件`（衝突1件をスキップ）・`対象 33 件解析` |
| DB 確認 | 06-30 メタ 0→908・07-01 メタ 109 維持・06-30 facts 258・直近 SubmitDate に 06-30 復活 |
| 回帰（同日2回連続 ingest） | UNIQUE 衝突なし・ExitCode=0 |
| selftest | 全 PASS |

## スコープ外 / 将来検討

- `submitDateTime`（真の提出日時）を DTO・エンティティに追加し提出日を正確化（現状は下流未使用で不要）。
- 有報 CSV 解析ループを当日挿入分に絞る最適化（再解析が冪等かつ下流未使用のため機能影響なし・任意）。
