### PR TITLE
chore: root .gitignore にアプリ成果物の無視ルールを集約

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,12 @@ ServiceFabricBackup/
 *.ldf
 *.ndf
 
+# SQLite runtime DBs (app data)
+*.db
+*.db-wal
+*.db-shm
+*.db-journal
+
 # Business Intelligence projects
 *.rdl.data
 *.bim.layout
@@ -306,6 +312,11 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+.pytest_cache/
+
+# App ML artifacts: virtualenv & trained models (sources are tracked)
+.venv/
+_Apps/ml/models/
 
 # Cake - Uncomment if you are using it
 # tools/**


### PR DESCRIPTION
## 背景・目的

`app-*` ブランチは `_Apps/` 配下でアプリが切り替わる構成。TradeAnalyzer 関連の無視ルール（`*.db`, `_Apps/ml/.venv/`, `_Apps/ml/models/`）は現状 `app-trade-analyzer` の root `.gitignore` にのみ追記されており、`master` には無い。

このため以下の問題がある:

- **ブランチ切替時の誤追跡リスク**: `app-trade-analyzer` で生成された `_Apps/ml/.venv/` や `trade.db` 等の成果物は物理的に作業ツリーに残るが、他ブランチ（`master` や別 `app-*`）の `.gitignore` はこれらを無視しないため、未追跡として露出し誤って `git add` される恐れがある。
- **pytest キャッシュ未カバー**: `_Apps/ml/.pytest_cache/` は pytest 自動生成の内側 `.gitignore` に依存しており、root では無視されていなかった。

## 変更内容

全ブランチが継承する `master` の root `.gitignore` にアプリ成果物の無視ルールを集約する（`.gitignore` を1個に保つ方針）。

| 追加ルール | 対象 |
|---|---|
| `.pytest_cache/` | pytest キャッシュ |
| `*.db` / `*.db-wal` / `*.db-shm` / `*.db-journal` | SQLite ランタイム DB |
| `.venv/` | Python 仮想環境 |
| `_Apps/ml/models/` | 学習済みモデル実体（ソースは追跡） |

差分は 11 行の追加のみ（master の LF 改行を維持）。

## 影響・補足

- `master` 上では該当パスが存在しないため完全な **no-op**。害はない。
- `app-trade-analyzer` の root `.gitignore` には既に一部重複する行があるが無害。将来 `master` をマージすれば収束する（別途整理も可能）。
- `.venv/` は `_Apps/ml/.venv/` より汎用化し、将来の他 `app-*` ブランチの仮想環境もカバーする。
