### PR TITLE
refactor(trade-analyzer): RunPythonAsync の Process 堅牢コアを ProcessRunner へ抽出

### DIFF
--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -289,9 +288,10 @@ public static class Commands
 
     /// <summary>
     /// uv run python &lt;script&gt; &lt;args...&gt; を Python:MlDir を作業ディレクトリに起動し、ExitCode≠0 なら
-    /// stderr を添えて throw する小ヘルパ。stdout/stderr を逐次ログ、タイムアウト（既定10分）超過で kill＋throw。
-    /// double.MinValue 等での黙殺は禁止（段階2 silent fallback 禁止方針を Process 境界にも適用）。
-    /// run-today と将来の 3b が共有する Python 起動点。設定は型付き <see cref="PythonOptions"/> から受ける。
+    /// stderr を添えて throw する小ヘルパ。Process 起動の堅牢化（逐次ログ/timeout kill/EOF flush/起動失敗の
+    /// 包み込み）は共有起動点 <see cref="ProcessRunner.RunAsync"/> へ委譲し、本メソッドは psi 構築と
+    /// fail-fast 判断のみ持つ。double.MinValue 等での黙殺は禁止（段階2 silent fallback 禁止方針を Process
+    /// 境界にも適用）。設定は型付き <see cref="PythonOptions"/> から受ける。
     /// </summary>
     private static async Task RunPythonAsync(
         PythonOptions opt, ILogger logger, string scriptPath,
@@ -309,9 +309,7 @@ public static class Commands
         {
             FileName = uvPath,
             WorkingDirectory = mlDir,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
+            // Redirect*/UseShellExecute は ProcessRunner.RunAsync が強制する（ここでは設定しない）。
             // Python の print は日本語を含む。Windows 既定 console は cp932 のため、双方を UTF-8 に固定して
             // ログ文字化けを防ぐ（PYTHONUTF8=1 で Python が UTF-8 出力、Standard*Encoding で C# が UTF-8 読取）。
             StandardOutputEncoding = Encoding.UTF8,
@@ -327,98 +325,13 @@ public static class Commands
             psi.ArgumentList.Add(value);
         }
 
-        var stderr = new StringBuilder();
-        // stderr(StringBuilder=非スレッドセーフ) を ErrorDataReceived の append と全読取（timeout/ExitCode 両経路）で保護する。
-        // StringBuilder インスタンス自身を lock 対象にする公開ロックを避け、専用オブジェクトを用意する。
-        object stderrLock = new();
-        using var proc = new Process { StartInfo = psi };
-        proc.OutputDataReceived += (_, e) => { if (e.Data != null) logger.LogInformation("[python] {Line}", e.Data); };
-        proc.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data == null) return;
-            lock (stderrLock) { stderr.AppendLine(e.Data); }
-            logger.LogWarning("[python:err] {Line}", e.Data);
-        };
-
-        logger.LogInformation("Python 起動: {Uv} run python {Script} {Args} (cwd={Cwd})",
-            uvPath, scriptPath, string.Join(' ', options.Select(o => $"{o.key} {o.value}")), mlDir);
-
-        // UseShellExecute=false の Process.Start() は実行ファイル不在時 false を返さず Win32Exception を
-        // throw する（旧 `if (!proc.Start())` の親切メッセージは dead-code だった）。例外を捕捉し原因明示で包む。
-        try
-        {
-            proc.Start();
-        }
-        catch (Win32Exception ex)
-        {
+        var result = await ProcessRunner.RunAsync(psi, logger, timeoutMinutes, stdin: null,
+            stdoutLogPrefix: "[python]", stderrLogPrefix: "[python:err]",
+            displayName: $"Python 実行: {scriptPath}", ct: ct);
+        // Python 経路は stdout を捨てる（DB 書戻しが結果）。ExitCode≠0 の fail-fast 判断は呼び手＝ここに残す。
+        if (result.ExitCode != 0)
             throw new InvalidOperationException(
-                $"Python プロセスを起動できません: {uvPath}（Python:UvPath を確認）。", ex);
-        }
-        proc.BeginOutputReadLine();
-        proc.BeginErrorReadLine();
-
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(TimeSpan.FromMinutes(timeoutMinutes));
-        // BeginOutput/ErrorReadLine と CancelOutput/ErrorRead をペア化し購読寿命を明示する。
-        // 正常終了経路では下の引数なし WaitForExit() の flush 完了までにハンドラが発火し切る。
-        // timeout の bounded-drain false 経路（孫プロセス未終了で引数なし WaitForExit() を意図的にスキップ）では
-        // 読取がアクティブなまま本 finally の Cancel で明示停止する。post-EOF/Kill 後でも _output/_error は
-        // using Dispose まで非 null ゆえ Cancel は throw せず、伝播中の例外を握り潰さない。
-        // ハンドラが参照する logger は DI 管理で本メソッドより寿命が長い。
-        try
-        {
-            try
-            {
-                await proc.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
-            {
-                // Kill 後、受信済み stderr を診断として例外へ添付する（ExitCode≠0 経路と対称化＝Python トレースバック保持）。
-                // 単に {stderr} を読むと Kill 後も発火しうる ErrorDataReceived ハンドラと並行 read になり torn read を招くため、
-                // 非同期リーダを bounded に flush してから locked snapshot を読む。drain 失敗でも throw を保証するよう try/catch で囲む。
-                // Kill/flush の例外は握り潰さず TimeoutException の innerException に連鎖させる（Win32Exception 等の原因を保持）。
-                Exception? killEx = null;
-                try
-                {
-                    proc.Kill(entireProcessTree: true);
-                    // WaitForExit(TimeSpan) は非同期 ErrorDataReceived の flush を保証しない（MS docs: WaitForExit(Int32) の
-                    // Remarks。true を受けた後に引数なし WaitForExit() を呼べ）。5 秒内に終了済(true)のときだけ続けて引数なし
-                    // WaitForExit() で EOF flush を完了させる（終了済みなので即 return＝bounded 意図と両立）。false（孫プロセス
-                    // wedge で 5 秒内に未終了）なら無限ブロック回避のため引数なし呼出を避け、受信済み分のみ添付する。
-                    if (proc.WaitForExit(TimeSpan.FromSeconds(5)))
-                        proc.WaitForExit();
-                }
-                catch (Exception ex) { killEx = ex; logger.LogWarning(ex, "Python プロセス kill/flush 失敗（既に終了済みの可能性）。"); }
-                string tail;
-                lock (stderrLock) { tail = stderr.ToString(); }
-                throw new TimeoutException(
-                    $"Python 実行が {timeoutMinutes} 分でタイムアウトしました: {scriptPath}\nstderr(タイムアウトまで):\n{tail}",
-                    killEx);
-            }
-
-            // WaitForExitAsync は非同期 stdout/stderr リーダの EOF flush を保証しない（ExitCode≠0 時に throw する
-            // stderr 末尾＝Python トレースバック最重要行が欠落しうる）。引数なし同期 WaitForExit() を1回呼び、
-            // 非同期バッファを完全 flush してから ExitCode/stderr を参照する（正常終了済みなので即時 return）。
-            proc.WaitForExit();
-
-            if (proc.ExitCode != 0)
-            {
-                // 直前の引数なし WaitForExit() が非同期イベント処理の完了を保証するため並行 writer は不在だが、
-                // 読取作法を timeout 経路と統一して locked snapshot で読む。
-                string tail;
-                lock (stderrLock) { tail = stderr.ToString(); }
-                throw new InvalidOperationException(
-                    $"Python が ExitCode={proc.ExitCode} で失敗しました: {scriptPath}\nstderr:\n{tail}");
-            }
-        }
-        finally
-        {
-            // Begin/Cancel をペア化し購読寿命を明示。post-EOF/Kill 後でも _output/_error は using Dispose まで
-            // 非 null（BeginOutput/ErrorReadLine は Start 後・proc.Start の Win32Exception catch が Begin 前に return）
-            // ゆえ Cancel は throw せず、伝播中の TimeoutException/InvalidOperationException を握り潰さない。
-            proc.CancelOutputRead();
-            proc.CancelErrorRead();
-        }
+                $"Python が ExitCode={result.ExitCode} で失敗しました: {scriptPath}\nstderr:\n{result.Stderr}");
     }
 
     /// <summary>

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -303,7 +303,6 @@ public static class Commands
         string mlDir = string.IsNullOrWhiteSpace(opt.MlDir)
             ? AppPaths.MlScriptsDir
             : Path.GetFullPath(opt.MlDir, AppPaths.RepoRoot);
-        int timeoutMinutes = opt.TimeoutMinutes > 0 ? opt.TimeoutMinutes : 10;
 
         var psi = new ProcessStartInfo
         {
@@ -325,9 +324,10 @@ public static class Commands
             psi.ArgumentList.Add(value);
         }
 
-        var result = await ProcessRunner.RunAsync(psi, logger, timeoutMinutes, stdin: null,
+        // TimeoutMinutes の非正値クランプはしない（RunAsync が ArgumentOutOfRangeException で fail-fast＝設定ミスの顕在化）。
+        var result = await ProcessRunner.RunAsync(psi, logger, TimeSpan.FromMinutes(opt.TimeoutMinutes), stdin: null,
             stdoutLogPrefix: "[python]", stderrLogPrefix: "[python:err]",
-            displayName: $"Python 実行: {scriptPath}", ct: ct);
+            displayName: $"Python 実行: {scriptPath}", startErrorHint: "Python:UvPath を確認", ct: ct);
         // Python 経路は stdout を捨てる（DB 書戻しが結果）。ExitCode≠0 の fail-fast 判断は呼び手＝ここに残す。
         if (result.ExitCode != 0)
             throw new InvalidOperationException(

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -226,6 +226,9 @@ public static class Commands
         //    3a は新規マイグレーションを導入しないため。空/未マイグレーション DB だと ingest 内の
         //    ExecuteDeleteAsync が no such table で停止する（run-today.ps1 冒頭に「要 migrate 済み DB」明記）。
         ValidateIngestConfig(sp, skipJQuants);
+        // Python 設定は数分の ingest/analyze が完走した後の Python 段で汎用 AOORE として死ぬ前に、
+        // 起動直後に config キー名つきで fail-fast する（run-today 専用＝Python を使わない ingest 単体には課さない）。
+        ValidatePythonConfig(pythonOptions.Value);
         // 当日は JST 固定で導出する（ホストローカル日付に依存させない＝非 JST ホスト移植でも1日ズレない）。
         // TimeProvider は既存 JQuantsRateLimiter と同じ「DI 未登録時は TimeProvider.System」方針で入手する。
         var timeProvider = sp.GetService<TimeProvider>() ?? TimeProvider.System;
@@ -366,6 +369,21 @@ public static class Commands
                 "  dotnet user-secrets set \"JQuants:ApiKey\" <key>\n" +
                 "  dotnet user-secrets set \"Edinet:SubscriptionKey\" <key>");
         }
+    }
+
+    /// <summary>
+    /// run-today 専用の Python 設定検証。RunAsync の timeout ガードは最終防衛線として残る（paramName=timeout の
+    /// 汎用文言でしか語れない）ため、設定境界では config キー名（Python:TimeoutMinutes）つきで診断する。
+    /// 上限は <see cref="ProcessRunner.MaxTimeout"/> からの導出（生リテラルの再エンコードはドリフト源のためしない）。
+    /// 共有 ValidateIngestConfig には入れない — Python を使わない ingest 単体実行が無関係な誤設定で
+    /// 偽 fail-fast する結合を避けるため。
+    /// </summary>
+    private static void ValidatePythonConfig(PythonOptions py)
+    {
+        int maxMinutes = (int)ProcessRunner.MaxTimeout.TotalMinutes;
+        if (py.TimeoutMinutes <= 0 || py.TimeoutMinutes > maxMinutes)
+            throw new InvalidOperationException(
+                $"Python:TimeoutMinutes は 1〜{maxMinutes} の範囲で指定してください（現在値: {py.TimeoutMinutes}）。");
     }
 
     // --- 引数パース ---

--- a/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
+++ b/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
@@ -9,35 +9,50 @@ namespace TradeAnalyzer.Worker;
 internal readonly record struct ProcessResult(int ExitCode, string Stdout, string Stderr);
 
 /// <summary>
-/// 外部プロセスを起動し stdout/stderr を捕捉、stdin 供給・timeout kill・非同期リーダ EOF flush を一元化する
-/// 共有起動点。ExitCode≠0 は throw せず <see cref="ProcessResult"/> で返す（致命/非致命ポリシーは各消費者に置く）。
-/// throw するのは「プロセスがそもそも完了しなかった」場合のみ＝起動失敗（<see cref="InvalidOperationException"/>）・
-/// timeout（<see cref="TimeoutException"/>）・外部 ct キャンセル（<see cref="OperationCanceledException"/> 再スロー）。
-/// いずれも子プロセスを停止させてから throw する（孤児化回避）。run-today(uv run python) と 3b(claude -p) が共有する。
+/// 外部プロセスを起動し stdout/stderr を捕捉、stdin 供給・timeout kill・bounded EOF drain（grace 超過時は
+/// 受信済み分＋警告で続行＝出力末尾が欠落しうる）を一元化する共有起動点。ExitCode≠0 は throw せず
+/// <see cref="ProcessResult"/> で返す（致命/非致命ポリシーは各消費者に置く）。
+/// throw するのは次の場合のみ: 不正 timeout 引数（<see cref="ArgumentOutOfRangeException"/>＝プロセス起動前の
+/// fail-fast、停止すべき子プロセスなし）・起動失敗（<see cref="InvalidOperationException"/>）・
+/// timeout（<see cref="TimeoutException"/>）・外部 ct キャンセル（<see cref="OperationCanceledException"/> 再スロー。
+/// ただし子プロセス正常終了後の grace 窓での ct 発火は OCE を投げず完了済み ProcessResult を返す＝kill 経路のみ再スロー）。
+/// 起動後の throw はいずれも子プロセスを停止させてから行う（孤児化回避）。run-today(uv run python) と 3b(claude -p) が共有する。
 /// Redirect*/UseShellExecute は本クラスが強制し、FileName/ArgumentList/WorkingDirectory/Encoding/Environment は
 /// 呼び手が psi に設定する（例: Python 経路の PYTHONUTF8=1、3b の StandardInputEncoding=UTF-8）。
 /// </summary>
 internal static class ProcessRunner
 {
+    // EOF drain の上限。magic number の散在はドリフト源のため名前付き定数に集約する。
+    // 正常終了後: 子が handle を継承した孫プロセスを残すと EOF が来ず、成功した実行が timeout まで停滞して
+    // 誤失敗化するのを防ぐ上限。
+    private static readonly TimeSpan NormalExitEofGrace = TimeSpan.FromSeconds(15);
+    // kill 後: Kill(entireProcessTree) を逃れた（double-fork/再親付けの）孫が EOF を握るケースの上限
+    //（旧実装の WaitForExit(5秒) を踏襲）。
+    private static readonly TimeSpan KilledEofGrace = TimeSpan.FromSeconds(5);
+
     public static async Task<ProcessResult> RunAsync(
         ProcessStartInfo psi,
         ILogger logger,
-        int timeoutMinutes,
+        TimeSpan timeout,
         string? stdin = null,
         string stdoutLogPrefix = "[proc]",
         string stderrLogPrefix = "[proc:err]",
         string displayName = "プロセス",
+        bool captureStdout = false,
+        string? startErrorHint = null,
         CancellationToken ct = default)
     {
+        // 非正 timeout は「0=無制限」等の誤解や設定ミスを黙って既定値へ書き換えず fail-fast で顕在化する
+        //（silent-fallback 禁止方針）。psi の変異より前に検証し、引数不正時は psi を無傷のまま throw する。
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout,
+                "タイムアウトは正の値を指定してください（非正値の黙示フォールバックはしない）。");
+
         // redirect 設定は呼び手が忘れないようここで強制する。
         psi.RedirectStandardOutput = true;
         psi.RedirectStandardError = true;
         psi.UseShellExecute = false;
         psi.RedirectStandardInput = stdin != null;
-
-        // 実効タイムアウト。≤0 は 10 分にフォールバックし、CancelAfter と TimeoutException メッセージの双方で
-        // 同じ値を使う（生の timeoutMinutes を表示すると ≤0 渡し時に「0 分でタイムアウト」等と誤報するため）。
-        int effMin = timeoutMinutes > 0 ? timeoutMinutes : 10;
 
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
@@ -47,17 +62,32 @@ internal static class ProcessRunner
         object stdoutLock = new();
         object stderrLock = new();
         using var proc = new Process { StartInfo = psi };
+
+        // exit 待ちと EOF 待ちを分離する: net10 の WaitForExitAsync はプロセス終了の await 後に redirected 出力の
+        // EOF を ct bound で内包待機するため（WaitUntilOutputEOF）、孫プロセスがパイプを握ると成功した実行が
+        // full-timeout 停滞→TimeoutException に化ける。exit は Exited イベント→TCS で待ち、EOF は *DataReceived の
+        // e.Data==null（最終発火）→TCS を grace 上限付きで待つ。Start() より前に購読・設定することで取りこぼし
+        // レースを排除する。完了は TrySetResult（実務上各 1 回発火だが、二重完了で SetResult が throw しない防御の定石）。
+        var exitTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stdoutEofTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stderrEofTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        proc.EnableRaisingEvents = true;
+        proc.Exited += (_, _) => exitTcs.TrySetResult();
+
         // ログレベルは stdout=Information / stderr=Warning で固定（現行 RunPythonAsync のレベルを保存）。
         // prefix は必ずテンプレ引数として渡す（文字列連結でメッセージテンプレートを動的化しない）。
+        // EOF シグナル（e.Data==null → TCS 完了）と逐次ログは captureStdout に関わらず常時実行し、条件化するのは
+        // 蓄積（AppendLine）のみ（EOF シグナルまで条件化すると captureStdout=false で毎回 grace 満了まで待つ退行になる）。
         proc.OutputDataReceived += (_, e) =>
         {
-            if (e.Data == null) return;
-            lock (stdoutLock) { stdout.AppendLine(e.Data); }
+            if (e.Data == null) { stdoutEofTcs.TrySetResult(); return; }
+            if (captureStdout) { lock (stdoutLock) { stdout.AppendLine(e.Data); } }
             logger.LogInformation("{Prefix} {Line}", stdoutLogPrefix, e.Data);
         };
         proc.ErrorDataReceived += (_, e) =>
         {
-            if (e.Data == null) return;
+            // stderr は例外添付（timeout 時の診断）に必要なため captureStdout に関わらず常時蓄積する。
+            if (e.Data == null) { stderrEofTcs.TrySetResult(); return; }
             lock (stderrLock) { stderr.AppendLine(e.Data); }
             logger.LogWarning("{Prefix} {Line}", stderrLogPrefix, e.Data);
         };
@@ -67,7 +97,9 @@ internal static class ProcessRunner
             displayName, psi.FileName, string.Join(' ', psi.ArgumentList), psi.WorkingDirectory);
 
         // UseShellExecute=false の Process.Start() は実行ファイル不在時 false を返さず Win32Exception を
-        // throw する（false 判定は dead-code）。例外を捕捉し原因明示で包む。
+        // throw する（false 判定は dead-code）。例外を捕捉し原因明示で包む。修正手がかりは呼び手が
+        // startErrorHint で注入する（例: "Python:UvPath を確認"）。未指定時は displayName ベースの汎用ヒントへ
+        // フォールバックし、hint を渡し忘れた消費者でも診断が劣化しないようにする。
         try
         {
             proc.Start();
@@ -75,27 +107,46 @@ internal static class ProcessRunner
         catch (Win32Exception ex)
         {
             throw new InvalidOperationException(
-                $"プロセスを起動できません: {psi.FileName}（{displayName} の実行ファイルパスを確認）。", ex);
+                $"プロセスを起動できません: {psi.FileName}（{startErrorHint ?? $"{displayName} の実行ファイルパスを確認"}）。", ex);
         }
         proc.BeginOutputReadLine();
         proc.BeginErrorReadLine();
 
+        // stdout/stderr の EOF（*DataReceived の最終発火）を grace 上限付きで待つ共通ヘルパ（正常経路/kill 経路で共用）。
+        // EOF 未達のまま grace 満了（または外部 ct 発火＝即打ち切り扱い）なら受信済み分で続行し、黙殺せず警告する。
+        // Task.Delay のトークンは「外部 ct のみ」とリンクした CTS から作る — timeoutCts とリンクすると timeout kill
+        // 経路では catch 到達時点で Cancel 済みのため drain が 0 秒に潰れ、診断のため drain を保持したい経路が死ぬ。
+        // linked CTS は using で確実に Dispose し（外部 ct への callback 登録のリーク防止）、EOF 先着時は Cancel して
+        // timer を回収する。
+        async Task DrainOutputsAsync(TimeSpan grace)
+        {
+            var eof = Task.WhenAll(stdoutEofTcs.Task, stderrEofTcs.Task);
+            if (eof.IsCompleted) return;
+            using var graceCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var delay = Task.Delay(grace, graceCts.Token);
+            await Task.WhenAny(eof, delay).ConfigureAwait(false);
+            if (eof.IsCompleted) { graceCts.Cancel(); return; }
+            // grace 満了 or 外部 ct 発火（cancel 起因と孫プロセス保持起因の区別は必須でないため文言は共通）。
+            logger.LogWarning(
+                "{Name}: stdout/stderr の EOF 待ちを {Grace:0.#} 秒で打ち切りました。孫プロセスが stdout/stderr を保持している可能性があり、出力末尾が欠落しえます（受信済み分で続行）。",
+                displayName, grace.TotalSeconds);
+        }
+
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(TimeSpan.FromMinutes(effMin));
+        timeoutCts.CancelAfter(timeout);
         // BeginOutput/ErrorReadLine と CancelOutput/ErrorRead をペア化し購読寿命を明示する（finally）。
-        // 正常終了経路では下の引数なし WaitForExit() の flush 完了までにハンドラが発火し切る。
-        // timeout の bounded-drain false 経路（孫プロセス未終了で引数なし WaitForExit() を意図的にスキップ）では
-        // 読取がアクティブなまま本 finally の Cancel で明示停止する。post-EOF/Kill 後でも _output/_error は
-        // using Dispose まで非 null ゆえ Cancel は throw せず、伝播中の例外を握り潰さない。
+        // 正常経路/kill 経路とも bounded EOF drain の完了（EOF 先着 or grace 満了/ct 打ち切り）後に Cancel が走る。
+        // grace 打ち切り時は読取がアクティブなまま本 finally の Cancel で明示停止する。post-EOF/Kill 後でも
+        // _output/_error は using Dispose まで非 null ゆえ Cancel は throw せず、伝播中の例外を握り潰さない。
         // ハンドラが参照する logger は DI 管理で本メソッドより寿命が長い。
         try
         {
             try
             {
-                // stdin write は WaitForExitAsync と同じ try・同じ timeout スコープに置く: パイプ満杯で write が
-                // ハングしても timeout で解除され、下の catch(OCE) が兼ねて kill＋TimeoutException 化まで到達する
-                //（outer try 内に置くことで finally の Cancel*Read も必ず通る）。プロンプトは通常 < 64KB パイプ
-                // バッファなので実際は即完了する。
+                // stdin write は exit-only 待ち（Exited TCS）と同じ try・同じ timeout スコープに置く: パイプ満杯で
+                // write がハングしても timeout で解除され、下の catch(OCE) が兼ねて kill＋TimeoutException 化まで
+                // 到達する（outer try 内に置くことで finally の Cancel*Read も必ず通る）。プロンプトは通常 < 64KB
+                // パイプバッファなので実際は即完了する。
                 if (stdin != null)
                 {
                     try
@@ -105,30 +156,30 @@ internal static class ProcessRunner
                     }
                     catch (IOException ex)
                     {
-                        // broken pipe: 子が stdin を読まず先に終了したケース。write を放棄して WaitForExit へ進み
+                        // broken pipe: 子が stdin を読まず先に終了したケース。write を放棄して exit-only 待ちへ進み
                         // ExitCode を取得する（プロセスは完了済みゆえここでは throw しない）。
                         logger.LogWarning(ex, "{Name}: stdin 書込みに失敗（子プロセスが先に終了した可能性）。", displayName);
                     }
                 }
-                await proc.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+                // exit のみを待つ（EOF drain は含めない）。timeout/外部 ct は WaitAsync の OCE として下の catch へ
+                //（旧 WaitForExitAsync 呼出と同じ例外セマンティクス）。ExitCode は exit 確定後に読む。
+                await exitTcs.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 // フィルタなしで捕捉し、原因（timeout/外部 ct/理論上の spurious OCE）を問わずまず子を確実に停止する
-                //（孤児化回避）。kill/flush の例外は握り潰さず innerException に連鎖させる（no-swallow）。
+                //（孤児化回避）。kill の例外は握り潰さず innerException に連鎖させる（no-swallow）。
                 Exception? killEx = null;
                 try
                 {
                     proc.Kill(entireProcessTree: true);
-                    // WaitForExit(TimeSpan) は非同期 ErrorDataReceived の flush を保証しない（MS docs: WaitForExit(Int32)
-                    // の Remarks。true を受けた後に引数なし WaitForExit() を呼べ）。5 秒内に終了済(true)のときだけ続けて
-                    // 引数なし WaitForExit() で EOF flush を完了させる（終了済みなので即 return＝bounded 意図と両立）。
-                    // false（孫プロセス wedge で 5 秒内に未終了）なら無限ブロック回避のため引数なし呼出を避け、
-                    // 受信済み分のみ添付する。
-                    if (proc.WaitForExit(TimeSpan.FromSeconds(5)))
-                        proc.WaitForExit();
                 }
-                catch (Exception ex) { killEx = ex; logger.LogWarning(ex, "{Name}: 子プロセス kill/flush 失敗（既に終了済みの可能性）。", displayName); }
+                catch (Exception ex) { killEx = ex; logger.LogWarning(ex, "{Name}: 子プロセス kill 失敗（既に終了済みの可能性）。", displayName); }
+
+                // kill で子ツリーのパイプは通常すぐ閉じ EOF が来る。Kill(entireProcessTree) を逃れた孫が write handle を
+                // 握るケースに備え KilledEofGrace で bounded に drain し、無限待ちを排除する。外部 ct 由来なら ct 発火済み
+                // のため drain は即 0 秒＝キャンセル即応答を優先する意図的仕様（代償: 末尾 stderr 診断が失われうる）。
+                await DrainOutputsAsync(KilledEofGrace).ConfigureAwait(false);
 
                 if (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
                 {
@@ -136,7 +187,7 @@ internal static class ProcessRunner
                     string tail;
                     lock (stderrLock) { tail = stderr.ToString(); }
                     throw new TimeoutException(
-                        $"{displayName} が {effMin} 分でタイムアウトしました\nstderr(タイムアウトまで):\n{tail}", killEx);
+                        $"{displayName} が {timeout.TotalMinutes:0.##} 分でタイムアウトしました\nstderr(タイムアウトまで):\n{tail}", killEx);
                 }
                 // それ以外＝実運用では外部 ct 由来（timeoutCts は linked ゆえ ct キャンセルでも発火する）。子は kill 済み。
                 // kill 失敗は innerException 連鎖で顕在化させ、成功時は元 OCE を再スローしキャンセルを honor する。
@@ -146,15 +197,17 @@ internal static class ProcessRunner
                 throw;
             }
 
-            // WaitForExitAsync は非同期 stdout/stderr リーダの EOF flush を保証しない（stderr 末尾＝トレースバック
-            // 最重要行が欠落しうる）。引数なし同期 WaitForExit() を1回呼び、非同期バッファを完全 flush してから
-            // ExitCode/出力を参照する（正常終了済みなので即時 return）。
-            proc.WaitForExit();
+            // 子は正常終了済み。WaitForExitAsync は EOF drain を timeout まで内包してしまうため exit-only 待ちに分離し、
+            // EOF はここで NormalExitEofGrace を上限に bounded に待つ。grace 超過（または外部 ct 発火）でも完了済みの
+            // 実行結果は破棄せず、警告のうえ受信済み分の ProcessResult を返す（新規の OCE は投げない契約）。
+            await DrainOutputsAsync(NormalExitEofGrace).ConfigureAwait(false);
 
-            // 直前の引数なし WaitForExit() が非同期イベント処理の完了を保証するため並行 writer は不在だが、
-            // 読取作法を timeout 経路と統一して locked snapshot で読む。
-            string stdoutSnap, stderrSnap;
-            lock (stdoutLock) { stdoutSnap = stdout.ToString(); }
+            // EOF 到達済みなら並行 writer は不在だが、grace 打ち切り時はハンドラが遅延発火しうるため
+            // 読取作法を kill 経路と統一して locked snapshot で読む。captureStdout=false は蓄積自体を
+            // していないため Stdout は空文字列を返す契約（ToString の materialize もスキップ）。
+            string stdoutSnap = "";
+            if (captureStdout) { lock (stdoutLock) { stdoutSnap = stdout.ToString(); } }
+            string stderrSnap;
             lock (stderrLock) { stderrSnap = stderr.ToString(); }
             return new ProcessResult(proc.ExitCode, stdoutSnap, stderrSnap);
         }

--- a/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
+++ b/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
@@ -13,22 +13,29 @@ internal readonly record struct ProcessResult(int ExitCode, string Stdout, strin
 /// 受信済み分＋警告で続行＝出力末尾が欠落しうる）を一元化する共有起動点。ExitCode≠0 は throw せず
 /// <see cref="ProcessResult"/> で返す（致命/非致命ポリシーは各消費者に置く）。
 /// throw するのは次の場合のみ: 不正 timeout 引数（<see cref="ArgumentOutOfRangeException"/>＝プロセス起動前の
-/// fail-fast、停止すべき子プロセスなし）・起動失敗（<see cref="InvalidOperationException"/>）・
+/// fail-fast、停止すべき子プロセスなし）・stdin なしでの StandardInputEncoding 設定（<see cref="ArgumentException"/>＝
+/// 同じく起動前 fail-fast）・起動失敗（<see cref="InvalidOperationException"/>）・
 /// timeout（<see cref="TimeoutException"/>）・外部 ct キャンセル（<see cref="OperationCanceledException"/> 再スロー。
 /// ただし子プロセス正常終了後の grace 窓での ct 発火は OCE を投げず完了済み ProcessResult を返す＝kill 経路のみ再スロー）。
 /// 起動後の throw はいずれも子プロセスを停止させてから行う（孤児化回避）。run-today(uv run python) と 3b(claude -p) が共有する。
-/// Redirect*/UseShellExecute は本クラスが強制し、FileName/ArgumentList/WorkingDirectory/Encoding/Environment は
-/// 呼び手が psi に設定する（例: Python 経路の PYTHONUTF8=1、3b の StandardInputEncoding=UTF-8）。
+/// Redirect*/UseShellExecute は本クラスが強制し、stdin 供給時の StandardInputEncoding は本クラスが BOM なし UTF-8 を
+/// 既定適用する（呼び手明示があれば尊重）。FileName/ArgumentList/WorkingDirectory/stdout・stderr の Encoding/
+/// Environment は呼び手が psi に設定する（例: Python 経路の PYTHONUTF8=1）。
 /// </summary>
 internal static class ProcessRunner
 {
     // EOF drain の上限。magic number の散在はドリフト源のため名前付き定数に集約する。
     // 正常終了後: 子が handle を継承した孫プロセスを残すと EOF が来ず、成功した実行が timeout まで停滞して
-    // 誤失敗化するのを防ぐ上限。
-    private static readonly TimeSpan NormalExitEofGrace = TimeSpan.FromSeconds(15);
+    // 誤失敗化するのを防ぐ上限。internal は SelfTest がケース (7)(8) の時間境界を導出参照するため
+    //（生リテラル再エンコードによる grace 調整時のドリフト防止）。
+    internal static readonly TimeSpan NormalExitEofGrace = TimeSpan.FromSeconds(15);
     // kill 後: Kill(entireProcessTree) を逃れた（double-fork/再親付けの）孫が EOF を握るケースの上限
     //（旧実装の WaitForExit(5秒) を踏襲）。
     private static readonly TimeSpan KilledEofGrace = TimeSpan.FromSeconds(5);
+    // timeout の上限: CancelAfter が受理する最大遅延（net10 の Timer.MaxSupportedTimeout=0xFFFFFFFE ms ≈ 49.7 日）。
+    // 超過は冒頭ガードで起動前に fail-fast する（超過値が CancelAfter まで届くと起動後・try/finally 外の
+    // AOORE で子プロセスが孤児化する）。internal は Commands の設定境界検証が上限導出に参照するため。
+    internal static readonly TimeSpan MaxTimeout = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
 
     public static async Task<ProcessResult> RunAsync(
         ProcessStartInfo psi,
@@ -42,17 +49,33 @@ internal static class ProcessRunner
         string? startErrorHint = null,
         CancellationToken ct = default)
     {
-        // 非正 timeout は「0=無制限」等の誤解や設定ミスを黙って既定値へ書き換えず fail-fast で顕在化する
+        // 非正/上限超過 timeout は「0=無制限」等の誤解や設定ミスを黙って既定値へ書き換えず fail-fast で顕在化する
         //（silent-fallback 禁止方針）。psi の変異より前に検証し、引数不正時は psi を無傷のまま throw する。
-        if (timeout <= TimeSpan.Zero)
+        if (timeout <= TimeSpan.Zero || timeout > MaxTimeout)
             throw new ArgumentOutOfRangeException(nameof(timeout), timeout,
-                "タイムアウトは正の値を指定してください（非正値の黙示フォールバックはしない）。");
+                $"タイムアウトは正の値かつ {MaxTimeout} 以下を指定してください（範囲外の黙示フォールバックはしない）。");
+
+        // stdin なしでの StandardInputEncoding 設定は stdin の渡し忘れの可能性が高く、silent に null リセットすると
+        // 呼び手バグを隠蔽するため fail-fast で顕在化する（放置すると下の RedirectStandardInput=false 強制と
+        // ProcessStartInfo の整合検査が衝突し、Start() が startErrorHint 包装外の生 InvalidOperationException を投げる）。
+        // timeout ガードと同じく psi の変異より前・起動前に検証する。
+        if (stdin == null && psi.StandardInputEncoding != null)
+            throw new ArgumentException(
+                "stdin なしで StandardInputEncoding が設定されています（stdin の渡し忘れの可能性。黙示リセットはしない）。",
+                nameof(stdin));
 
         // redirect 設定は呼び手が忘れないようここで強制する。
         psi.RedirectStandardOutput = true;
         psi.RedirectStandardError = true;
         psi.UseShellExecute = false;
         psi.RedirectStandardInput = stdin != null;
+        // stdin 供給時の StandardInputEncoding は未指定なら BOM なし UTF-8 を既定適用する（呼び手明示があれば尊重。
+        // Redirect* 強制と同型パターン）。既定化しないと Windows 実装は GetConsoleCP()（日本語環境で cp932）を使い、
+        // 非 ASCII プロンプトが silent に文字化けする。Encoding.UTF8（BOM 付き）は不可: 明示指定は
+        // ConsoleEncoding（preamble 抑止）包装を経ず StreamWriter へ素通しされ、非シーク pipe への初回書込みで
+        // BOM（EF BB BF）が子プロセス stdin の先頭に silent 混入する。
+        if (stdin != null)
+            psi.StandardInputEncoding ??= new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
@@ -113,23 +136,24 @@ internal static class ProcessRunner
         proc.BeginErrorReadLine();
 
         // stdout/stderr の EOF（*DataReceived の最終発火）を grace 上限付きで待つ共通ヘルパ（正常経路/kill 経路で共用）。
-        // EOF 未達のまま grace 満了（または外部 ct 発火＝即打ち切り扱い）なら受信済み分で続行し、黙殺せず警告する。
-        // Task.Delay のトークンは「外部 ct のみ」とリンクした CTS から作る — timeoutCts とリンクすると timeout kill
-        // 経路では catch 到達時点で Cancel 済みのため drain が 0 秒に潰れ、診断のため drain を保持したい経路が死ぬ。
-        // linked CTS は using で確実に Dispose し（外部 ct への callback 登録のリーク防止）、EOF 先着時は Cancel して
-        // timer を回収する。
+        // EOF 未達のまま grace 満了（TimeoutException）または外部 ct 発火（TaskCanceledException＝即打ち切り扱い）なら
+        // 受信済み分で続行し、黙殺せず警告する。TCS は TrySetResult のみで fault しないため WhenAll は成功完了のみ＝
+        // 下の catch フィルタが予期せぬ例外を握り潰すことはない。
         async Task DrainOutputsAsync(TimeSpan grace)
         {
-            var eof = Task.WhenAll(stdoutEofTcs.Task, stderrEofTcs.Task);
-            if (eof.IsCompleted) return;
-            using var graceCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            var delay = Task.Delay(grace, graceCts.Token);
-            await Task.WhenAny(eof, delay).ConfigureAwait(false);
-            if (eof.IsCompleted) { graceCts.Cancel(); return; }
-            // grace 満了 or 外部 ct 発火（cancel 起因と孫プロセス保持起因の区別は必須でないため文言は共通）。
-            logger.LogWarning(
-                "{Name}: stdout/stderr の EOF 待ちを {Grace:0.#} 秒で打ち切りました。孫プロセスが stdout/stderr を保持している可能性があり、出力末尾が欠落しえます（受信済み分で続行）。",
-                displayName, grace.TotalSeconds);
+            try
+            {
+                // 打ち切りトークンは「外部 ct のみ」— timeoutCts を使うと timeout kill 経路では catch 到達時点で
+                // 既発火のため drain が 0 秒に潰れ、TimeoutException へ添付する末尾 stderr 診断が失われる。
+                await Task.WhenAll(stdoutEofTcs.Task, stderrEofTcs.Task).WaitAsync(grace, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is TimeoutException or OperationCanceledException)
+            {
+                // grace 満了 or 外部 ct 発火（cancel 起因と孫プロセス保持起因の区別は必須でないため文言は共通）。
+                logger.LogWarning(
+                    "{Name}: stdout/stderr の EOF 待ちを {Grace:0.#} 秒で打ち切りました。孫プロセスが stdout/stderr を保持している可能性があり、出力末尾が欠落しえます（受信済み分で続行）。",
+                    displayName, grace.TotalSeconds);
+            }
         }
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -167,6 +191,10 @@ internal static class ProcessRunner
             }
             catch (OperationCanceledException)
             {
+                // 分類（timeout か外部 ct か）は catch 冒頭＝throw 伝播直後に固定する。Kill＋最大 5 秒の drain の
+                // 後に評価すると、真正 timeout の直後にホスト shutdown 等で外部 ct が発火した場合に素の OCE へ
+                // 誤分類され TimeoutException＋stderr 診断が失われる（旧 exception filter の throw 時点評価を復元）。
+                bool isTimeout = timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested;
                 // フィルタなしで捕捉し、原因（timeout/外部 ct/理論上の spurious OCE）を問わずまず子を確実に停止する
                 //（孤児化回避）。kill の例外は握り潰さず innerException に連鎖させる（no-swallow）。
                 Exception? killEx = null;
@@ -181,7 +209,7 @@ internal static class ProcessRunner
                 // のため drain は即 0 秒＝キャンセル即応答を優先する意図的仕様（代償: 末尾 stderr 診断が失われうる）。
                 await DrainOutputsAsync(KilledEofGrace).ConfigureAwait(false);
 
-                if (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+                if (isTimeout)
                 {
                     // timeout 由来。受信済み stderr を診断として例外へ添付する（トレースバック等の保持）。
                     string tail;

--- a/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
+++ b/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
@@ -16,7 +16,8 @@ internal readonly record struct ProcessResult(int ExitCode, string Stdout, strin
 /// fail-fast、停止すべき子プロセスなし）・stdin なしでの StandardInputEncoding 設定（<see cref="ArgumentException"/>＝
 /// 同じく起動前 fail-fast）・起動失敗（<see cref="InvalidOperationException"/>）・
 /// timeout（<see cref="TimeoutException"/>）・外部 ct キャンセル（<see cref="OperationCanceledException"/> 再スロー。
-/// ただし子プロセス正常終了後の grace 窓での ct 発火は OCE を投げず完了済み ProcessResult を返す＝kill 経路のみ再スロー）。
+/// ただし子プロセス正常終了後の grace 窓での ct 発火は OCE を投げず完了済み ProcessResult を返し、timeout/ct の
+/// catch 到達時に子が既に終了済み（HasExited）の場合も kill 経路へ入らず完了済み ProcessResult を返す＝kill 経路のみ再スロー）。
 /// 起動後の throw はいずれも子プロセスを停止させてから行う（孤児化回避）。run-today(uv run python) と 3b(claude -p) が共有する。
 /// Redirect*/UseShellExecute は本クラスが強制し、stdin 供給時の StandardInputEncoding は本クラスが BOM なし UTF-8 を
 /// 既定適用する（呼び手明示があれば尊重）。FileName/ArgumentList/WorkingDirectory/stdout・stderr の Encoding/
@@ -115,9 +116,10 @@ internal static class ProcessRunner
             logger.LogWarning("{Prefix} {Line}", stderrLogPrefix, e.Data);
         };
 
-        // 実行ファイル＋全引数＋cwd を保全する（診断情報の維持）。
-        logger.LogInformation("{Name} 起動: {File} {Args} (cwd={Cwd})",
-            displayName, psi.FileName, string.Join(' ', psi.ArgumentList), psi.WorkingDirectory);
+        // 実行ファイル＋全引数＋cwd を保全する（診断情報の維持）。{Name} は付けない — 起動行は File/Args/cwd で
+        // 自己記述的で、Args に script パスを含む消費者では二重表示＋動詞衝突になる（displayName は例外/警告の主語専用）。
+        logger.LogInformation("起動: {File} {Args} (cwd={Cwd})",
+            psi.FileName, string.Join(' ', psi.ArgumentList), psi.WorkingDirectory);
 
         // UseShellExecute=false の Process.Start() は実行ファイル不在時 false を返さず Win32Exception を
         // throw する（false 判定は dead-code）。例外を捕捉し原因明示で包む。修正手がかりは呼び手が
@@ -136,20 +138,22 @@ internal static class ProcessRunner
         proc.BeginErrorReadLine();
 
         // stdout/stderr の EOF（*DataReceived の最終発火）を grace 上限付きで待つ共通ヘルパ（正常経路/kill 経路で共用）。
-        // EOF 未達のまま grace 満了（TimeoutException）または外部 ct 発火（TaskCanceledException＝即打ち切り扱い）なら
-        // 受信済み分で続行し、黙殺せず警告する。TCS は TrySetResult のみで fault しないため WhenAll は成功完了のみ＝
+        // EOF 未達のまま grace 満了（TimeoutException）または打ち切りトークン発火（TaskCanceledException＝即打ち切り扱い）
+        // なら受信済み分で続行し、黙殺せず警告する。打ち切りトークンは呼び手が経路ごとに渡す — 正常経路は外部 ct
+        //（grace 窓のキャンセル即応答）、timeout kill 経路は None（bounded 保証で末尾 stderr 診断を保全）、純粋外部 ct
+        // kill 経路は ct（即打ち切り）。TCS は TrySetResult のみで fault しないため WhenAll は成功完了のみ＝
         // 下の catch フィルタが予期せぬ例外を握り潰すことはない。
-        async Task DrainOutputsAsync(TimeSpan grace)
+        async Task DrainOutputsAsync(TimeSpan grace, CancellationToken drainCt)
         {
             try
             {
-                // 打ち切りトークンは「外部 ct のみ」— timeoutCts を使うと timeout kill 経路では catch 到達時点で
-                // 既発火のため drain が 0 秒に潰れ、TimeoutException へ添付する末尾 stderr 診断が失われる。
-                await Task.WhenAll(stdoutEofTcs.Task, stderrEofTcs.Task).WaitAsync(grace, ct).ConfigureAwait(false);
+                // timeoutCts は使わない — timeout kill 経路では catch 到達時点で既発火のため drain が 0 秒に潰れ、
+                // TimeoutException へ添付する末尾 stderr 診断が失われる（呼び手が None/ct を明示的に呼び分ける）。
+                await Task.WhenAll(stdoutEofTcs.Task, stderrEofTcs.Task).WaitAsync(grace, drainCt).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is TimeoutException or OperationCanceledException)
             {
-                // grace 満了 or 外部 ct 発火（cancel 起因と孫プロセス保持起因の区別は必須でないため文言は共通）。
+                // grace 満了 or 打ち切りトークン発火（cancel 起因と孫プロセス保持起因の区別は必須でないため文言は共通）。
                 logger.LogWarning(
                     "{Name}: stdout/stderr の EOF 待ちを {Grace:0.#} 秒で打ち切りました。孫プロセスが stdout/stderr を保持している可能性があり、出力末尾が欠落しえます（受信済み分で続行）。",
                     displayName, grace.TotalSeconds);
@@ -191,44 +195,56 @@ internal static class ProcessRunner
             }
             catch (OperationCanceledException)
             {
-                // 分類（timeout か外部 ct か）は catch 冒頭＝throw 伝播直後に固定する。Kill＋最大 5 秒の drain の
-                // 後に評価すると、真正 timeout の直後にホスト shutdown 等で外部 ct が発火した場合に素の OCE へ
-                // 誤分類され TimeoutException＋stderr 診断が失われる（旧 exception filter の throw 時点評価を復元）。
-                bool isTimeout = timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested;
-                // フィルタなしで捕捉し、原因（timeout/外部 ct/理論上の spurious OCE）を問わずまず子を確実に停止する
-                //（孤児化回避）。kill の例外は握り潰さず innerException に連鎖させる（no-swallow）。
-                Exception? killEx = null;
-                try
+                // catch 到達時に子が既に終了済みなら第 3 の早期離脱カテゴリ: timeout/外部 ct の発火と正常終了の
+                // マイクロ秒競合で WaitAsync のキャンセル側が勝ったケース。kill/throw をスキップして catch を素通りし、
+                // 外側 try の正常経路（EOF drain → ProcessResult 返却）へ合流する（成功した実行＝DB 書戻し済みの
+                // 誤失敗化を防ぐ）。判定は Exited イベント（exitTcs）でなく OS プロセス状態を直接見る HasExited —
+                // 物理終了済みだがイベント未配送の残余窓も同一コストで閉じる。チェックは Kill より前が必須
+                //（Kill 後は kill 起因の終了と「timeout 前に終了」を判別できなくなる）。
+                if (!proc.HasExited)
                 {
-                    proc.Kill(entireProcessTree: true);
-                }
-                catch (Exception ex) { killEx = ex; logger.LogWarning(ex, "{Name}: 子プロセス kill 失敗（既に終了済みの可能性）。", displayName); }
+                    // 分類（timeout か外部 ct か）は早期離脱チェック直後＝throw 伝播直後に固定する。Kill＋最大 5 秒の
+                    // drain の後に評価すると、真正 timeout の直後にホスト shutdown 等で外部 ct が発火した場合に素の OCE へ
+                    // 誤分類され TimeoutException＋stderr 診断が失われる（旧 exception filter の throw 時点評価を復元）。
+                    bool isTimeout = timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested;
+                    // フィルタなしで捕捉し、原因（timeout/外部 ct/理論上の spurious OCE）を問わずまず子を確実に停止する
+                    //（孤児化回避）。kill の例外は握り潰さず innerException に連鎖させる（no-swallow）。
+                    Exception? killEx = null;
+                    try
+                    {
+                        proc.Kill(entireProcessTree: true);
+                    }
+                    catch (Exception ex) { killEx = ex; logger.LogWarning(ex, "{Name}: 子プロセス kill 失敗（既に終了済みの可能性）。", displayName); }
 
-                // kill で子ツリーのパイプは通常すぐ閉じ EOF が来る。Kill(entireProcessTree) を逃れた孫が write handle を
-                // 握るケースに備え KilledEofGrace で bounded に drain し、無限待ちを排除する。外部 ct 由来なら ct 発火済み
-                // のため drain は即 0 秒＝キャンセル即応答を優先する意図的仕様（代償: 末尾 stderr 診断が失われうる）。
-                await DrainOutputsAsync(KilledEofGrace).ConfigureAwait(false);
+                    // kill で子ツリーのパイプは通常すぐ閉じ EOF が来る。Kill(entireProcessTree) を逃れた孫が write handle を
+                    // 握るケースに備え KilledEofGrace で bounded に drain し、無限待ちを排除する。打ち切りトークンは呼び分ける:
+                    // timeout 経路は None＝ct 非連動で KilledEofGrace の bounded 保証を確保し、分類確定後に外部 ct が発火しても
+                    // TimeoutException へ添付する末尾 stderr 診断を保全する（旧同期 WaitForExit(5秒) 相当の保証。代償:
+                    // ホスト shutdown が最大 5 秒待たされうる）。純粋外部 ct 経路は ct＝発火済みのため drain は即 0 秒で
+                    // キャンセル即応答を優先する意図的仕様（代償: 末尾 stderr 診断が失われうる）。
+                    await DrainOutputsAsync(KilledEofGrace, isTimeout ? CancellationToken.None : ct).ConfigureAwait(false);
 
-                if (isTimeout)
-                {
-                    // timeout 由来。受信済み stderr を診断として例外へ添付する（トレースバック等の保持）。
-                    string tail;
-                    lock (stderrLock) { tail = stderr.ToString(); }
-                    throw new TimeoutException(
-                        $"{displayName} が {timeout.TotalMinutes:0.##} 分でタイムアウトしました\nstderr(タイムアウトまで):\n{tail}", killEx);
+                    if (isTimeout)
+                    {
+                        // timeout 由来。受信済み stderr を診断として例外へ添付する（トレースバック等の保持）。
+                        string tail;
+                        lock (stderrLock) { tail = stderr.ToString(); }
+                        throw new TimeoutException(
+                            $"{displayName} が {timeout.TotalMinutes:0.##} 分でタイムアウトしました\nstderr(タイムアウトまで):\n{tail}", killEx);
+                    }
+                    // それ以外＝実運用では外部 ct 由来（timeoutCts は linked ゆえ ct キャンセルでも発火する）。子は kill 済み。
+                    // kill 失敗は innerException 連鎖で顕在化させ、成功時は元 OCE を再スローしキャンセルを honor する。
+                    // この経路が必ず送出して終わることで、kill 済みプロセスの ProcessResult を返す事故を防ぐ。
+                    if (killEx != null)
+                        throw new OperationCanceledException("キャンセル中の子プロセス kill に失敗", killEx, ct);
+                    throw;
                 }
-                // それ以外＝実運用では外部 ct 由来（timeoutCts は linked ゆえ ct キャンセルでも発火する）。子は kill 済み。
-                // kill 失敗は innerException 連鎖で顕在化させ、成功時は元 OCE を再スローしキャンセルを honor する。
-                // この経路が必ず送出して終わることで、kill 済みプロセスの ProcessResult を返す事故を防ぐ。
-                if (killEx != null)
-                    throw new OperationCanceledException("キャンセル中の子プロセス kill に失敗", killEx, ct);
-                throw;
             }
 
             // 子は正常終了済み。WaitForExitAsync は EOF drain を timeout まで内包してしまうため exit-only 待ちに分離し、
             // EOF はここで NormalExitEofGrace を上限に bounded に待つ。grace 超過（または外部 ct 発火）でも完了済みの
             // 実行結果は破棄せず、警告のうえ受信済み分の ProcessResult を返す（新規の OCE は投げない契約）。
-            await DrainOutputsAsync(NormalExitEofGrace).ConfigureAwait(false);
+            await DrainOutputsAsync(NormalExitEofGrace, ct).ConfigureAwait(false);
 
             // EOF 到達済みなら並行 writer は不在だが、grace 打ち切り時はハンドラが遅延発火しうるため
             // 読取作法を kill 経路と統一して locked snapshot で読む。captureStdout=false は蓄積自体を

--- a/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
+++ b/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
@@ -154,6 +154,7 @@ internal static class ProcessRunner
             catch (Exception ex) when (ex is TimeoutException or OperationCanceledException)
             {
                 // grace 満了 or 打ち切りトークン発火（cancel 起因と孫プロセス保持起因の区別は必須でないため文言は共通）。
+                // 文言中の "EOF" トークンは SelfTest (7)(8) が警告発火の照合に使う — 言い換え時はテストも更新すること。
                 logger.LogWarning(
                     "{Name}: stdout/stderr の EOF 待ちを {Grace:0.#} 秒で打ち切りました。孫プロセスが stdout/stderr を保持している可能性があり、出力末尾が欠落しえます（受信済み分で続行）。",
                     displayName, grace.TotalSeconds);

--- a/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
+++ b/_Apps/TradeAnalyzer.Worker/ProcessRunner.cs
@@ -1,0 +1,170 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace TradeAnalyzer.Worker;
+
+/// <summary>プロセスが正常完了したときの結果。ExitCode≠0 も正常完了の一種として含む（致命判断は呼び手）。</summary>
+internal readonly record struct ProcessResult(int ExitCode, string Stdout, string Stderr);
+
+/// <summary>
+/// 外部プロセスを起動し stdout/stderr を捕捉、stdin 供給・timeout kill・非同期リーダ EOF flush を一元化する
+/// 共有起動点。ExitCode≠0 は throw せず <see cref="ProcessResult"/> で返す（致命/非致命ポリシーは各消費者に置く）。
+/// throw するのは「プロセスがそもそも完了しなかった」場合のみ＝起動失敗（<see cref="InvalidOperationException"/>）・
+/// timeout（<see cref="TimeoutException"/>）・外部 ct キャンセル（<see cref="OperationCanceledException"/> 再スロー）。
+/// いずれも子プロセスを停止させてから throw する（孤児化回避）。run-today(uv run python) と 3b(claude -p) が共有する。
+/// Redirect*/UseShellExecute は本クラスが強制し、FileName/ArgumentList/WorkingDirectory/Encoding/Environment は
+/// 呼び手が psi に設定する（例: Python 経路の PYTHONUTF8=1、3b の StandardInputEncoding=UTF-8）。
+/// </summary>
+internal static class ProcessRunner
+{
+    public static async Task<ProcessResult> RunAsync(
+        ProcessStartInfo psi,
+        ILogger logger,
+        int timeoutMinutes,
+        string? stdin = null,
+        string stdoutLogPrefix = "[proc]",
+        string stderrLogPrefix = "[proc:err]",
+        string displayName = "プロセス",
+        CancellationToken ct = default)
+    {
+        // redirect 設定は呼び手が忘れないようここで強制する。
+        psi.RedirectStandardOutput = true;
+        psi.RedirectStandardError = true;
+        psi.UseShellExecute = false;
+        psi.RedirectStandardInput = stdin != null;
+
+        // 実効タイムアウト。≤0 は 10 分にフォールバックし、CancelAfter と TimeoutException メッセージの双方で
+        // 同じ値を使う（生の timeoutMinutes を表示すると ≤0 渡し時に「0 分でタイムアウト」等と誤報するため）。
+        int effMin = timeoutMinutes > 0 ? timeoutMinutes : 10;
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        // StringBuilder(非スレッドセーフ) を *DataReceived の append と全読取（timeout/正常 両経路）で保護する。
+        // StringBuilder インスタンス自身を lock 対象にする公開ロックを避け、専用オブジェクトを用意する。
+        // stdout も stderr と同様に lock 保護する（3b の JSON エンベロープを torn-read させない）。
+        object stdoutLock = new();
+        object stderrLock = new();
+        using var proc = new Process { StartInfo = psi };
+        // ログレベルは stdout=Information / stderr=Warning で固定（現行 RunPythonAsync のレベルを保存）。
+        // prefix は必ずテンプレ引数として渡す（文字列連結でメッセージテンプレートを動的化しない）。
+        proc.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            lock (stdoutLock) { stdout.AppendLine(e.Data); }
+            logger.LogInformation("{Prefix} {Line}", stdoutLogPrefix, e.Data);
+        };
+        proc.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            lock (stderrLock) { stderr.AppendLine(e.Data); }
+            logger.LogWarning("{Prefix} {Line}", stderrLogPrefix, e.Data);
+        };
+
+        // 実行ファイル＋全引数＋cwd を保全する（診断情報の維持）。
+        logger.LogInformation("{Name} 起動: {File} {Args} (cwd={Cwd})",
+            displayName, psi.FileName, string.Join(' ', psi.ArgumentList), psi.WorkingDirectory);
+
+        // UseShellExecute=false の Process.Start() は実行ファイル不在時 false を返さず Win32Exception を
+        // throw する（false 判定は dead-code）。例外を捕捉し原因明示で包む。
+        try
+        {
+            proc.Start();
+        }
+        catch (Win32Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"プロセスを起動できません: {psi.FileName}（{displayName} の実行ファイルパスを確認）。", ex);
+        }
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromMinutes(effMin));
+        // BeginOutput/ErrorReadLine と CancelOutput/ErrorRead をペア化し購読寿命を明示する（finally）。
+        // 正常終了経路では下の引数なし WaitForExit() の flush 完了までにハンドラが発火し切る。
+        // timeout の bounded-drain false 経路（孫プロセス未終了で引数なし WaitForExit() を意図的にスキップ）では
+        // 読取がアクティブなまま本 finally の Cancel で明示停止する。post-EOF/Kill 後でも _output/_error は
+        // using Dispose まで非 null ゆえ Cancel は throw せず、伝播中の例外を握り潰さない。
+        // ハンドラが参照する logger は DI 管理で本メソッドより寿命が長い。
+        try
+        {
+            try
+            {
+                // stdin write は WaitForExitAsync と同じ try・同じ timeout スコープに置く: パイプ満杯で write が
+                // ハングしても timeout で解除され、下の catch(OCE) が兼ねて kill＋TimeoutException 化まで到達する
+                //（outer try 内に置くことで finally の Cancel*Read も必ず通る）。プロンプトは通常 < 64KB パイプ
+                // バッファなので実際は即完了する。
+                if (stdin != null)
+                {
+                    try
+                    {
+                        await proc.StandardInput.WriteAsync(stdin.AsMemory(), timeoutCts.Token).ConfigureAwait(false);
+                        proc.StandardInput.Close(); // EOF を明示（閉じないと子が stdin 読み待ちで永久ブロックしうる）。
+                    }
+                    catch (IOException ex)
+                    {
+                        // broken pipe: 子が stdin を読まず先に終了したケース。write を放棄して WaitForExit へ進み
+                        // ExitCode を取得する（プロセスは完了済みゆえここでは throw しない）。
+                        logger.LogWarning(ex, "{Name}: stdin 書込みに失敗（子プロセスが先に終了した可能性）。", displayName);
+                    }
+                }
+                await proc.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // フィルタなしで捕捉し、原因（timeout/外部 ct/理論上の spurious OCE）を問わずまず子を確実に停止する
+                //（孤児化回避）。kill/flush の例外は握り潰さず innerException に連鎖させる（no-swallow）。
+                Exception? killEx = null;
+                try
+                {
+                    proc.Kill(entireProcessTree: true);
+                    // WaitForExit(TimeSpan) は非同期 ErrorDataReceived の flush を保証しない（MS docs: WaitForExit(Int32)
+                    // の Remarks。true を受けた後に引数なし WaitForExit() を呼べ）。5 秒内に終了済(true)のときだけ続けて
+                    // 引数なし WaitForExit() で EOF flush を完了させる（終了済みなので即 return＝bounded 意図と両立）。
+                    // false（孫プロセス wedge で 5 秒内に未終了）なら無限ブロック回避のため引数なし呼出を避け、
+                    // 受信済み分のみ添付する。
+                    if (proc.WaitForExit(TimeSpan.FromSeconds(5)))
+                        proc.WaitForExit();
+                }
+                catch (Exception ex) { killEx = ex; logger.LogWarning(ex, "{Name}: 子プロセス kill/flush 失敗（既に終了済みの可能性）。", displayName); }
+
+                if (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+                {
+                    // timeout 由来。受信済み stderr を診断として例外へ添付する（トレースバック等の保持）。
+                    string tail;
+                    lock (stderrLock) { tail = stderr.ToString(); }
+                    throw new TimeoutException(
+                        $"{displayName} が {effMin} 分でタイムアウトしました\nstderr(タイムアウトまで):\n{tail}", killEx);
+                }
+                // それ以外＝実運用では外部 ct 由来（timeoutCts は linked ゆえ ct キャンセルでも発火する）。子は kill 済み。
+                // kill 失敗は innerException 連鎖で顕在化させ、成功時は元 OCE を再スローしキャンセルを honor する。
+                // この経路が必ず送出して終わることで、kill 済みプロセスの ProcessResult を返す事故を防ぐ。
+                if (killEx != null)
+                    throw new OperationCanceledException("キャンセル中の子プロセス kill に失敗", killEx, ct);
+                throw;
+            }
+
+            // WaitForExitAsync は非同期 stdout/stderr リーダの EOF flush を保証しない（stderr 末尾＝トレースバック
+            // 最重要行が欠落しうる）。引数なし同期 WaitForExit() を1回呼び、非同期バッファを完全 flush してから
+            // ExitCode/出力を参照する（正常終了済みなので即時 return）。
+            proc.WaitForExit();
+
+            // 直前の引数なし WaitForExit() が非同期イベント処理の完了を保証するため並行 writer は不在だが、
+            // 読取作法を timeout 経路と統一して locked snapshot で読む。
+            string stdoutSnap, stderrSnap;
+            lock (stdoutLock) { stdoutSnap = stdout.ToString(); }
+            lock (stderrLock) { stderrSnap = stderr.ToString(); }
+            return new ProcessResult(proc.ExitCode, stdoutSnap, stderrSnap);
+        }
+        finally
+        {
+            // Begin/Cancel をペア化し購読寿命を明示。post-EOF/Kill 後でも _output/_error は using Dispose まで
+            // 非 null（Begin* は Start 後・proc.Start の Win32Exception catch は Begin 前に throw）ゆえ
+            // Cancel は throw せず、伝播中の例外を握り潰さない。
+            proc.CancelOutputRead();
+            proc.CancelErrorRead();
+        }
+    }
+}

--- a/_Apps/TradeAnalyzer.Worker/PythonOptions.cs
+++ b/_Apps/TradeAnalyzer.Worker/PythonOptions.cs
@@ -3,7 +3,8 @@ namespace TradeAnalyzer.Worker;
 /// <summary>
 /// 段階3a の Python 採点プロセス起動設定（<c>uv run python predict.py …</c>）。
 /// Python 関心は Worker 固有（Core/Data は Python を知らない）のため Worker プロジェクトに置く。
-/// プロパティはプレーンに保ち、MlDir の絶対化・TimeoutMinutes のフォールバックは消費側（RunPythonAsync）で行う。
+/// プロパティはプレーンに保ち、MlDir の絶対化は消費側（RunPythonAsync）で行う。TimeoutMinutes は非正値だと
+/// ProcessRunner.RunAsync が ArgumentOutOfRangeException（fail-fast。黙示フォールバックはしない）。
 /// </summary>
 public class PythonOptions
 {
@@ -19,6 +20,7 @@ public class PythonOptions
     /// <summary>採点スクリプト名（既定 <c>predict.py</c>）。</summary>
     public string PredictScript { get; set; } = "predict.py";
 
-    /// <summary>Python 実行のタイムアウト（分）。0 以下は消費側で既定 10 にフォールバック。</summary>
+    /// <summary>Python 実行のタイムアウト（分）。0 以下は ProcessRunner.RunAsync が
+    /// ArgumentOutOfRangeException（fail-fast＝設定ミスの顕在化。黙示フォールバックはしない）。</summary>
     public int TimeoutMinutes { get; set; } = 10;
 }

--- a/_Apps/TradeAnalyzer.Worker/PythonOptions.cs
+++ b/_Apps/TradeAnalyzer.Worker/PythonOptions.cs
@@ -3,8 +3,10 @@ namespace TradeAnalyzer.Worker;
 /// <summary>
 /// 段階3a の Python 採点プロセス起動設定（<c>uv run python predict.py …</c>）。
 /// Python 関心は Worker 固有（Core/Data は Python を知らない）のため Worker プロジェクトに置く。
-/// プロパティはプレーンに保ち、MlDir の絶対化は消費側（RunPythonAsync）で行う。TimeoutMinutes は非正値だと
-/// ProcessRunner.RunAsync が ArgumentOutOfRangeException（fail-fast。黙示フォールバックはしない）。
+/// プロパティはプレーンに保ち、MlDir の絶対化は消費側（RunPythonAsync）で行う。TimeoutMinutes は非正値・
+/// 上限（ProcessRunner.MaxTimeout）超過だと ProcessRunner.RunAsync が ArgumentOutOfRangeException
+///（fail-fast。黙示フォールバックはしない）。run-today は起動直後に ValidatePythonConfig が
+/// config キー名（Python:TimeoutMinutes）つきで事前検証する。
 /// </summary>
 public class PythonOptions
 {
@@ -20,7 +22,8 @@ public class PythonOptions
     /// <summary>採点スクリプト名（既定 <c>predict.py</c>）。</summary>
     public string PredictScript { get; set; } = "predict.py";
 
-    /// <summary>Python 実行のタイムアウト（分）。0 以下は ProcessRunner.RunAsync が
-    /// ArgumentOutOfRangeException（fail-fast＝設定ミスの顕在化。黙示フォールバックはしない）。</summary>
+    /// <summary>Python 実行のタイムアウト（分）。0 以下・上限（ProcessRunner.MaxTimeout）超過は
+    /// ProcessRunner.RunAsync が ArgumentOutOfRangeException（fail-fast＝設定ミスの顕在化。黙示フォールバックは
+    /// しない）。run-today は起動直後に ValidatePythonConfig が config キー名つきで事前検証する。</summary>
     public int TimeoutMinutes { get; set; } = 10;
 }

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -46,6 +47,7 @@ public static class SelfTest
         failed += await RunAsNoTrackingReflectsUpdateTestAsync();
         failed += await RunEdinetMetaCollisionTestAsync();
         failed += RunResolveTodayJstTests();
+        failed += await RunProcessRunnerTestsAsync();
 
         if (failed == 0) Console.WriteLine("SelfTest: 全テスト PASS");
         else
@@ -835,6 +837,117 @@ public static class SelfTest
         f += Assert("DI: EdinetClient 解決", edinet is not null);
         f += Assert("DI: JQuantsClient 解決", jq is not null);
         return f;
+    }
+
+    /// <summary>
+    /// process-runner F5: ProcessRunner.RunAsync の堅牢コア回帰（cmd/findstr/ping ベース・API キー不要）。
+    /// timeout kill・bounded EOF drain・ExitCode≠0・stdin 供給・非正 timeout fail-fast・起動失敗ヒントを固定する。
+    /// ケース (7)(8) は実時間 ~15s/~3s を要する（grace 満了経路検証の意図的コスト）。cmd/findstr/ping は
+    /// Windows 専用だが本 Worker は de-facto Windows（cp932 対策・run-today.ps1）のため許容。
+    /// </summary>
+    private static async Task<int> RunProcessRunnerTestsAsync()
+    {
+        int f = 0;
+        var log = NullLogger.Instance;
+        var min1 = TimeSpan.FromMinutes(1);
+
+        static ProcessStartInfo Cmd(string commandLine)
+        {
+            var psi = new ProcessStartInfo { FileName = "cmd" };
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add(commandLine);
+            return psi;
+        }
+
+        // (1) 正常終了 → ExitCode=0（timeout は必須 positional のため主眼でないケースも十分大きい正値を渡す）。
+        var r1 = await ProcessRunner.RunAsync(Cmd("exit 0"), log, min1);
+        f += Assert("Proc: exit 0 → ExitCode=0", r1.ExitCode == 0);
+
+        // (2) ExitCode≠0 は throw せず結果で返り、stdout/stderr を捕捉する（Stdout 読取は captureStdout 明示）。
+        //     cmd の echo は & 直前の空白を保持し AppendLine が改行を足すため、assert は Contains で書く。
+        var r2 = await ProcessRunner.RunAsync(Cmd("echo out & echo err 1>&2 & exit 3"), log, min1, captureStdout: true);
+        f += Assert("Proc: exit 3 → ExitCode=3", r2.ExitCode == 3);
+        f += Assert("Proc: stdout 捕捉", r2.Stdout.Contains("out"));
+        f += Assert("Proc: stderr 捕捉", r2.Stderr.Contains("err"));
+
+        // (3) timeout → TimeoutException（kill 完了）。長時間実行の手段は ping（timeout コマンドは非対話 stdin
+        //     環境で "Input redirection not supported" になりうるため、実行環境に依存しない ping が安定）。
+        bool timedOut = false;
+        try { await ProcessRunner.RunAsync(Cmd("ping -n 600 localhost"), log, TimeSpan.FromSeconds(2)); }
+        catch (TimeoutException) { timedOut = true; }
+        f += Assert("Proc: timeout → TimeoutException", timedOut);
+
+        // (4) stdin 供給（3b claude -p 経路の先行検証）: findstr は stdin の一致行を echo back して ExitCode=0
+        //     （全行非一致だと ExitCode=1 になる点に注意）。echo back の確認は Stdout 読取＝captureStdout: true。
+        var psiFind = new ProcessStartInfo { FileName = "findstr" };
+        psiFind.ArgumentList.Add("hello");
+        var r4 = await ProcessRunner.RunAsync(psiFind, log, min1, stdin: "hello world\r\nignore me\r\n", captureStdout: true);
+        f += Assert("Proc: stdin → findstr ExitCode=0", r4.ExitCode == 0);
+        f += Assert("Proc: stdin → 一致行 echo back", r4.Stdout.Contains("hello world"));
+
+        // (5) 非正 timeout は起動前に fail-fast（F4: silent 10 分フォールバック撤廃の回帰固定。
+        //     SelectTopPicks topN<=0 / AtrPeriod<=0 ガードテストと同型）。プロセスは起動されない。
+        bool guardThrew = false;
+        try { await ProcessRunner.RunAsync(Cmd("exit 0"), log, TimeSpan.Zero); }
+        catch (ArgumentOutOfRangeException) { guardThrew = true; }
+        f += Assert("Proc: timeout<=0 は ArgumentOutOfRangeException", guardThrew);
+
+        // (6) 起動失敗（実行ファイル不在）は InvalidOperationException で包み、startErrorHint がメッセージに
+        //     載る（F2 回帰）。実プロセスは起動されない。
+        bool startFailed = false;
+        try
+        {
+            await ProcessRunner.RunAsync(new ProcessStartInfo { FileName = "nonexistent-exe-selftest" }, log, min1,
+                startErrorHint: "テスト用ヒント");
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("テスト用ヒント")) { startFailed = true; }
+        f += Assert("Proc: 起動失敗 → InvalidOperationException + startErrorHint", startFailed);
+
+        // (7) grace 満了経路（F1 回帰）: start /b の孫 ping が継承した stdout write handle を ~29 秒保持するため
+        //     EOF が来ず、NormalExitEofGrace(15s) 満了の警告＋受信済み分で成功復帰する。所要時間の下限 13s は
+        //     タイマ解像度・丸めの境界一致による偽 FAIL 防止の 2s スラック、上限 25s は旧実装（WaitForExitAsync の
+        //     内包 EOF drain で ~29s）との判別。孤児 ping は ~30 秒で自然消滅しプロセスリークしない。
+        var warnLog7 = new WarnRecordingLogger();
+        var sw = Stopwatch.StartNew();
+        var r7 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), warnLog7, min1);
+        sw.Stop();
+        f += Assert("Proc: 孫の handle 保持でも成功復帰(ExitCode=0)", r7.ExitCode == 0);
+        f += Assert($"Proc: 所要 13-25s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
+            sw.Elapsed >= TimeSpan.FromSeconds(13) && sw.Elapsed < TimeSpan.FromSeconds(25));
+        f += Assert("Proc: grace 満了の警告発火", warnLog7.Warnings.Any(w => w.Contains("EOF")));
+
+        // (8) grace 窓中の外部 ct 発火（F1 B 案契約の回帰固定）: 親 cmd は即終了＝exit-only 待ちは ct 発火の
+        //     はるか前に完了済み（kill 経路に入らない）。~3s 時点の ct が drain を即打ち切り、OCE を投げず
+        //     警告＋完了済み ProcessResult を返す。
+        var warnLog8 = new WarnRecordingLogger();
+        using var cts8 = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        sw.Restart();
+        bool oceThrown = false;
+        ProcessResult r8 = default;
+        try { r8 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), warnLog8, min1, ct: cts8.Token); }
+        catch (OperationCanceledException) { oceThrown = true; }
+        sw.Stop();
+        f += Assert("Proc: grace 窓中の ct でも OCE を投げない", !oceThrown);
+        f += Assert("Proc: ct 打ち切りでも完了済み結果(ExitCode=0)", r8.ExitCode == 0);
+        f += Assert($"Proc: ct が drain を即打ち切り <10s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
+            sw.Elapsed < TimeSpan.FromSeconds(10));
+        f += Assert("Proc: ct 打ち切りの警告発火", warnLog8.Warnings.Any(w => w.Contains("EOF")));
+        return f;
+    }
+
+    /// <summary>ケース (7)(8) 用: Warning 以上のみ整形済み文字列で蓄積する最小 ILogger。
+    /// *DataReceived ハンドラはスレッドプールから発火するため List を lock で保護する。</summary>
+    private sealed class WarnRecordingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = new();
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel < LogLevel.Warning) return;
+            lock (Warnings) { Warnings.Add(formatter(state, exception)); }
+        }
     }
 
     private static int Assert(string name, bool condition)

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -710,11 +710,15 @@ public static class SelfTest
     /// <summary>
     /// WARNING 経路検証用の最小ロガー。レベルと整形済みメッセージのみ記録する。
     /// ProcessRunner の *DataReceived ハンドラ（スレッドプール）からも Add されるため lock で保護する。
-    /// 並行 writer がありうるケース（(7)(8)）の読取は lock 下で ToList スナップショットを取ってから評価すること。
+    /// 並行 writer がありうるケース（(7)(8)）の読取は Snapshot() を使うこと。
     /// </summary>
     private sealed class CapturingLogger<T> : ILogger<T>
     {
         public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        /// <summary>並行 writer 下の安全な読取: lock 下で ToList スナップショットを取って返す。</summary>
+        public List<(LogLevel Level, string Message)> Snapshot() { lock (Entries) { return Entries.ToList(); } }
+
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
@@ -909,23 +913,31 @@ public static class SelfTest
         catch (InvalidOperationException ex) when (ex.Message.Contains("テスト用ヒント")) { startFailed = true; }
         f += Assert("Proc: 起動失敗 → InvalidOperationException + startErrorHint", startFailed);
 
-        // (7) grace 満了経路（F1 回帰）: start /b の孫 ping が継承した stdout write handle を ~29 秒保持するため
-        //     EOF が来ず、NormalExitEofGrace 満了の警告＋受信済み分で成功復帰する。所要時間の下限（grace−2s）は
-        //     タイマ解像度・丸めの境界一致による偽 FAIL 防止のスラック、上限（grace＋10s）は旧実装（WaitForExitAsync の
-        //     内包 EOF drain で ~29s）との判別。孤児 ping は ~30 秒で自然消滅しプロセスリークしない。
+        // (7)(8) 共通の handle 保持手段: start /b の孫 ping が継承した stdout write handle を保持し EOF を遅らせる。
+        //     "ping -n N" は 1s 間隔 ×(N−1) ≈ 29s 保持（pingHold）。Cmd へは pingCount を補間し、時間前提
+        //     （grace/ctDelay が保持満了より先着すること）は pingHold から導出して生リテラルの二重管理を排除する。
+        int pingCount = 30;
+        var pingHold = TimeSpan.FromSeconds(pingCount - 1);
+
+        // (7) grace 満了経路（F1 回帰）: 孫 ping の handle 保持で EOF が来ず、NormalExitEofGrace 満了の警告＋
+        //     受信済み分で成功復帰する。所要時間の下限（grace−2s）はタイマ解像度・丸めの境界一致による偽 FAIL
+        //     防止のスラック、上限（grace＋10s）は旧実装（WaitForExitAsync の内包 EOF drain で ~pingHold）との判別。
+        //     孤児 ping は pingHold 経過で自然消滅しプロセスリークしない。
         var log7 = new CapturingLogger<TradeAnalyzer.Core.Backtest.BacktestService>();
         var lower7 = ProcessRunner.NormalExitEofGrace - TimeSpan.FromSeconds(2);
         var upper7 = ProcessRunner.NormalExitEofGrace + TimeSpan.FromSeconds(10);
+        // 前提: grace 満了が孫 ping の EOF（pingHold）より判別余地（5s — (8) の「grace−3s」と同水準の壁時計スラック）
+        // をもって先着すること。破れると警告 assert だけが原因不明 FAIL するため、ここで自明に FAIL させる。
+        f += Assert("(7) 前提: grace は ping 保持より判別余地をもって小さい",
+            ProcessRunner.NormalExitEofGrace <= pingHold - TimeSpan.FromSeconds(5));
         var sw = Stopwatch.StartNew();
-        var r7 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), log7, min1);
+        var r7 = await ProcessRunner.RunAsync(Cmd($"start /b ping -n {pingCount} localhost & exit"), log7, min1);
         sw.Stop();
         f += Assert("Proc: 孫の handle 保持でも成功復帰(ExitCode=0)", r7.ExitCode == 0);
         f += Assert($"Proc: 所要 {lower7.TotalSeconds:0}-{upper7.TotalSeconds:0}s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
             sw.Elapsed >= lower7 && sw.Elapsed < upper7);
-        List<(LogLevel Level, string Message)> entries7;
-        lock (log7.Entries) { entries7 = log7.Entries.ToList(); }
         f += Assert("Proc: grace 満了の警告発火",
-            entries7.Any(e => e.Level >= LogLevel.Warning && e.Message.Contains("EOF")));
+            log7.Snapshot().Any(e => e.Level >= LogLevel.Warning && e.Message.Contains("EOF")));
 
         // (8) grace 窓中の外部 ct 発火（F1 B 案契約の回帰固定）: 親 cmd は即終了＝exit-only 待ちは ct 発火の
         //     はるか前に完了済み（kill 経路に入らない）。~8s 時点の ct が drain を即打ち切り、OCE を投げず
@@ -939,21 +951,22 @@ public static class SelfTest
         // ct 発火がこの上限未満であることが (8) の前提 — 破れたら時間 assert の偽 FAIL でなくここで自明に FAIL させる。
         var drainCutoff8 = ProcessRunner.NormalExitEofGrace - TimeSpan.FromSeconds(3);
         f += Assert("(8) 前提: ctDelay は判別上限（grace−3s）未満", ctDelay < drainCutoff8);
+        // 前提: ct 発火時点で孫 ping がまだ handle を保持していること（保持満了なら EOF 完了で警告不発になる）。
+        f += Assert("(8) 前提: ctDelay は ping 保持より判別余地をもって小さい",
+            ctDelay < pingHold - TimeSpan.FromSeconds(5));
         using var cts8 = new CancellationTokenSource(ctDelay);
         sw.Restart();
         bool oceThrown = false;
         ProcessResult r8 = default;
-        try { r8 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), log8, min1, ct: cts8.Token); }
+        try { r8 = await ProcessRunner.RunAsync(Cmd($"start /b ping -n {pingCount} localhost & exit"), log8, min1, ct: cts8.Token); }
         catch (OperationCanceledException) { oceThrown = true; }
         sw.Stop();
         f += Assert("Proc: grace 窓中の ct でも OCE を投げない", !oceThrown);
         f += Assert("Proc: ct 打ち切りでも完了済み結果(ExitCode=0)", r8.ExitCode == 0);
         f += Assert($"Proc: ct が drain を即打ち切り <{drainCutoff8.TotalSeconds:0}s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
             sw.Elapsed < drainCutoff8);
-        List<(LogLevel Level, string Message)> entries8;
-        lock (log8.Entries) { entries8 = log8.Entries.ToList(); }
         f += Assert("Proc: ct 打ち切りの警告発火",
-            entries8.Any(e => e.Level >= LogLevel.Warning && e.Message.Contains("EOF")));
+            log8.Snapshot().Any(e => e.Level >= LogLevel.Warning && e.Message.Contains("EOF")));
 
         // (9) timeout 上限超過（> MaxTimeout ≈ 49.7 日）も起動前に fail-fast（F1 R2 回帰）。paramName まで検査する:
         //     型のみだと冒頭ガードを外しても起動後の CancelAfter が同型 AOORE（paramName=delay・孤児化経路）を

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -708,6 +709,8 @@ public static class SelfTest
 
     /// <summary>
     /// WARNING 経路検証用の最小ロガー。レベルと整形済みメッセージのみ記録する。
+    /// ProcessRunner の *DataReceived ハンドラ（スレッドプール）からも Add されるため lock で保護する。
+    /// 並行 writer がありうるケース（(7)(8)）の読取は lock 下で ToList スナップショットを取ってから評価すること。
     /// </summary>
     private sealed class CapturingLogger<T> : ILogger<T>
     {
@@ -716,7 +719,9 @@ public static class SelfTest
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
             Func<TState, Exception?, string> formatter)
-            => Entries.Add((logLevel, formatter(state, exception)));
+        {
+            lock (Entries) { Entries.Add((logLevel, formatter(state, exception))); }
+        }
     }
 
     /// <summary>
@@ -841,9 +846,10 @@ public static class SelfTest
 
     /// <summary>
     /// process-runner F5: ProcessRunner.RunAsync の堅牢コア回帰（cmd/findstr/ping ベース・API キー不要）。
-    /// timeout kill・bounded EOF drain・ExitCode≠0・stdin 供給・非正 timeout fail-fast・起動失敗ヒントを固定する。
-    /// ケース (7)(8) は実時間 ~15s/~3s を要する（grace 満了経路検証の意図的コスト）。cmd/findstr/ping は
-    /// Windows 専用だが本 Worker は de-facto Windows（cp932 対策・run-today.ps1）のため許容。
+    /// timeout kill・bounded EOF drain・ExitCode≠0・stdin 供給・非正/上限超過 timeout fail-fast・
+    /// stdin encoding 不整合 fail-fast・起動失敗ヒントを固定する。ケース (7)(8) は実時間 ~15s/~8s を要する
+    ///（grace 満了経路検証の意図的コスト）。cmd/findstr/ping は Windows 専用だが本 Worker は de-facto
+    /// Windows（cp932 対策・run-today.ps1）のため許容。
     /// </summary>
     private static async Task<int> RunProcessRunnerTestsAsync()
     {
@@ -904,50 +910,70 @@ public static class SelfTest
         f += Assert("Proc: 起動失敗 → InvalidOperationException + startErrorHint", startFailed);
 
         // (7) grace 満了経路（F1 回帰）: start /b の孫 ping が継承した stdout write handle を ~29 秒保持するため
-        //     EOF が来ず、NormalExitEofGrace(15s) 満了の警告＋受信済み分で成功復帰する。所要時間の下限 13s は
-        //     タイマ解像度・丸めの境界一致による偽 FAIL 防止の 2s スラック、上限 25s は旧実装（WaitForExitAsync の
+        //     EOF が来ず、NormalExitEofGrace 満了の警告＋受信済み分で成功復帰する。所要時間の下限（grace−2s）は
+        //     タイマ解像度・丸めの境界一致による偽 FAIL 防止のスラック、上限（grace＋10s）は旧実装（WaitForExitAsync の
         //     内包 EOF drain で ~29s）との判別。孤児 ping は ~30 秒で自然消滅しプロセスリークしない。
-        var warnLog7 = new WarnRecordingLogger();
+        var log7 = new CapturingLogger<TradeAnalyzer.Core.Backtest.BacktestService>();
+        var lower7 = ProcessRunner.NormalExitEofGrace - TimeSpan.FromSeconds(2);
+        var upper7 = ProcessRunner.NormalExitEofGrace + TimeSpan.FromSeconds(10);
         var sw = Stopwatch.StartNew();
-        var r7 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), warnLog7, min1);
+        var r7 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), log7, min1);
         sw.Stop();
         f += Assert("Proc: 孫の handle 保持でも成功復帰(ExitCode=0)", r7.ExitCode == 0);
-        f += Assert($"Proc: 所要 13-25s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
-            sw.Elapsed >= TimeSpan.FromSeconds(13) && sw.Elapsed < TimeSpan.FromSeconds(25));
-        f += Assert("Proc: grace 満了の警告発火", warnLog7.Warnings.Any(w => w.Contains("EOF")));
+        f += Assert($"Proc: 所要 {lower7.TotalSeconds:0}-{upper7.TotalSeconds:0}s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
+            sw.Elapsed >= lower7 && sw.Elapsed < upper7);
+        List<(LogLevel Level, string Message)> entries7;
+        lock (log7.Entries) { entries7 = log7.Entries.ToList(); }
+        f += Assert("Proc: grace 満了の警告発火",
+            entries7.Any(e => e.Level >= LogLevel.Warning && e.Message.Contains("EOF")));
 
         // (8) grace 窓中の外部 ct 発火（F1 B 案契約の回帰固定）: 親 cmd は即終了＝exit-only 待ちは ct 発火の
-        //     はるか前に完了済み（kill 経路に入らない）。~3s 時点の ct が drain を即打ち切り、OCE を投げず
-        //     警告＋完了済み ProcessResult を返す。
-        var warnLog8 = new WarnRecordingLogger();
-        using var cts8 = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        //     はるか前に完了済み（kill 経路に入らない）。~8s 時点の ct が drain を即打ち切り、OCE を投げず
+        //     警告＋完了済み ProcessResult を返す。ct 遅延 8s は cmd spawn スラック（spawn がこれを超えると
+        //     exit-only 待ち未完了のまま kill 経路に入り偽 FAIL）で、R1 確定の ~10s スラック水準に揃えた値。
+        //     grace からは導出しない — 8s は spawn 由来で grace とは不等式の関係しかなく、導出すると grace
+        //     引下げ時にスラックが黙って縮む偽の依存になる。
+        var log8 = new CapturingLogger<TradeAnalyzer.Core.Backtest.BacktestService>();
+        var ctDelay = TimeSpan.FromSeconds(8);
+        // 「drain 即打ち切り」の判別上限は grace 満了経路（≥grace）と 3s の判別余地を置いた grace−3s。
+        // ct 発火がこの上限未満であることが (8) の前提 — 破れたら時間 assert の偽 FAIL でなくここで自明に FAIL させる。
+        var drainCutoff8 = ProcessRunner.NormalExitEofGrace - TimeSpan.FromSeconds(3);
+        f += Assert("(8) 前提: ctDelay は判別上限（grace−3s）未満", ctDelay < drainCutoff8);
+        using var cts8 = new CancellationTokenSource(ctDelay);
         sw.Restart();
         bool oceThrown = false;
         ProcessResult r8 = default;
-        try { r8 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), warnLog8, min1, ct: cts8.Token); }
+        try { r8 = await ProcessRunner.RunAsync(Cmd("start /b ping -n 30 localhost & exit"), log8, min1, ct: cts8.Token); }
         catch (OperationCanceledException) { oceThrown = true; }
         sw.Stop();
         f += Assert("Proc: grace 窓中の ct でも OCE を投げない", !oceThrown);
         f += Assert("Proc: ct 打ち切りでも完了済み結果(ExitCode=0)", r8.ExitCode == 0);
-        f += Assert($"Proc: ct が drain を即打ち切り <10s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
-            sw.Elapsed < TimeSpan.FromSeconds(10));
-        f += Assert("Proc: ct 打ち切りの警告発火", warnLog8.Warnings.Any(w => w.Contains("EOF")));
-        return f;
-    }
+        f += Assert($"Proc: ct が drain を即打ち切り <{drainCutoff8.TotalSeconds:0}s（実測 {sw.Elapsed.TotalSeconds:0.#}s）",
+            sw.Elapsed < drainCutoff8);
+        List<(LogLevel Level, string Message)> entries8;
+        lock (log8.Entries) { entries8 = log8.Entries.ToList(); }
+        f += Assert("Proc: ct 打ち切りの警告発火",
+            entries8.Any(e => e.Level >= LogLevel.Warning && e.Message.Contains("EOF")));
 
-    /// <summary>ケース (7)(8) 用: Warning 以上のみ整形済み文字列で蓄積する最小 ILogger。
-    /// *DataReceived ハンドラはスレッドプールから発火するため List を lock で保護する。</summary>
-    private sealed class WarnRecordingLogger : ILogger
-    {
-        public List<string> Warnings { get; } = new();
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-        public bool IsEnabled(LogLevel logLevel) => true;
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            if (logLevel < LogLevel.Warning) return;
-            lock (Warnings) { Warnings.Add(formatter(state, exception)); }
-        }
+        // (9) timeout 上限超過（> MaxTimeout ≈ 49.7 日）も起動前に fail-fast（F1 R2 回帰）。paramName まで検査する:
+        //     型のみだと冒頭ガードを外しても起動後の CancelAfter が同型 AOORE（paramName=delay・孤児化経路）を
+        //     投げて緑のままになり、回帰を固定できない。プロセスは起動されない。
+        bool upperGuardThrew = false;
+        try { await ProcessRunner.RunAsync(Cmd("exit 0"), log, TimeSpan.FromMilliseconds(uint.MaxValue)); }
+        catch (ArgumentOutOfRangeException ex) { upperGuardThrew = ex.ParamName == "timeout"; }
+        f += Assert("Proc: timeout>上限 は起動前 ArgumentOutOfRangeException（paramName=timeout）", upperGuardThrew);
+
+        // (10) stdin なし＋StandardInputEncoding 設定は起動前に ArgumentException で fail-fast（F4 R2 回帰:
+        //      stdin 渡し忘れの顕在化。silent リセットしない）。timeout は有効値を渡す — 非正値だと隣接の
+        //      timeout ガード（AOORE）が先に発火し検証対象がすり替わる。この Encoding.UTF8 は書込み前に
+        //      throw させる検証専用値のため BOM 混入とは無関係。プロセスは起動されない。
+        var psi10 = Cmd("exit 0");
+        psi10.StandardInputEncoding = Encoding.UTF8;
+        bool encGuardThrew = false;
+        try { await ProcessRunner.RunAsync(psi10, log, min1); }
+        catch (ArgumentException ex) { encGuardThrew = ex is not ArgumentOutOfRangeException; }
+        f += Assert("Proc: stdin なし＋StandardInputEncoding は ArgumentException", encGuardThrew);
+        return f;
     }
 
     private static int Assert(string name, bool condition)

--- a/_Apps/TradeAnalyzer.Worker/appsettings.json
+++ b/_Apps/TradeAnalyzer.Worker/appsettings.json
@@ -38,7 +38,6 @@
   },
   "Python": {
     "UvPath": "uv",
-    "PredictScript": "predict.py",
-    "TimeoutMinutes": 10
+    "PredictScript": "predict.py"
   }
 }


### PR DESCRIPTION
## 概要

プラン [`docs/plans/app-trade-analyzer/brushed-steel-conduit.md`](https://github.com/twinbird827/TBird.Library/blob/app-trade-analyzer/docs/plans/app-trade-analyzer/brushed-steel-conduit.md) の実装。段階3b プラン（hushed-amber-scribe.md）の実装ステップ1を、ML 有望性ゲートと独立に単独で先行実装する **no-regret リファクタ**。

`Commands.RunPythonAsync` が抱える約100行の Process 堅牢化（timeout/kill/stderr 捕捉/UTF-8/非同期リーダ flush）を、3b の `claude -p` 起動と共有できる `ProcessRunner.RunAsync`（Worker, internal static）へ抽出する。

## 設計（契約）

- **正常完了なら `ProcessResult(ExitCode, Stdout, Stderr)` を返す**。ExitCode≠0 も正常完了の一種として返し throw しない＝**致命/非致命の判断は呼び手**（`RunPythonAsync` は従来どおり ExitCode≠0 で throw、3b は握って null で ML 継続予定）。
- **throw は「プロセスが完了しなかった」3経路のみ**: 起動失敗（`Win32Exception`→`InvalidOperationException`）／timeout（`TimeoutException`）／外部 `ct` キャンセル（子を kill 後に `OperationCanceledException` 再スロー）。いずれも子プロセスを停止させてから throw（孤児化回避）。
- Redirect*/UseShellExecute は `RunAsync` が強制。FileName/引数/cwd/Encoding/Environment は呼び手が psi に設定。

## 実装内容

- **新規 `_Apps/TradeAnalyzer.Worker/ProcessRunner.cs`**: 現行の堅牢化を全て保存して移設
  - stderr の torn-read 保護（lock 付き StringBuilder）＋ **stdout にも同保護を追加**（3b の JSON エンベロープ用）
  - **stdin 供給**（`WriteAsync`+`Close`=EOF。timeout と同スコープでハング解除、broken pipe は write 放棄して ExitCode 取得）
  - timeout kill（`Kill(entireProcessTree)`→bounded drain→stderr tail 添付の `TimeoutException`、kill 例外は innerException 連鎖）
  - **外部 ct キャンセル分岐を追加（U3=A）**: 子を kill してから OCE 再スロー。run-today は ct 非キャンセルで無回帰、3b が clean cancellation を得る
  - 正常終了後の引数なし `WaitForExit()` による EOF flush、`finally` での `Cancel*Read`
- **`Commands.RunPythonAsync`**: psi 構築と ExitCode≠0 fail-fast のみ残して委譲（シグネチャ不変＝`RunTodayAsync` 無改修）

## 外形挙動

run-today の成否/ExitCode/Top-K 出力/per-line `[python]`・`[python:err]` ログは**不変**。プラン §既知の制約どおり、起動ログ行と timeout/起動失敗の例外メッセージのみ汎用化で書式変更（診断情報＝実行ファイル+全引数+stderr は保全）。

## 検証（プラン §検証 1〜5）

1. ✅ `dotnet build _Apps/App.sln` — 0 warn / 0 err
2. ✅ `selftest` — 全 PASS
3. ✅ `run-today --skip-jquants` — 完走 ExitCode=0、**Top-10 が前日ログ（run-today-20260709.log）と完全一致**（MlScore 4桁まで同値＝回帰なし）
4. ✅ fail-fast: `Python:PredictScript=nonexistent.py` → `Python が ExitCode=2 で失敗しました` で throw（stderr 添付・致命判断が呼び手に残存）
5. ✅ 起動失敗: `Python:UvPath` 不在パス → `プロセスを起動できません: C:\nonexistent\uv.exe（Python 実行: predict.py の実行ファイルパスを確認）` で停止（ExitCode=1）
6. （任意の timeout 検証はスキップ。kill+drain 機構は同一コード経路。外部 ct 分岐の実発火検証はプランどおり 3b で実施）

検証後、正常系を再実行し DB の MlScore を復元済み。

## 影響範囲

`ProcessRunner` の消費者は `RunPythonAsync` 1つのみ（2つ目の `ClaudeCliAnalysisService` は 3b で追加）。単独マージ可能・単独 revert 可能。