### PR TITLE
fix(trade-analyzer): 段階3b レビュー指摘(r4)を反映

### DIFF
--- a/_Apps/TradeAnalyzer.Worker/Claude/ClaudeCliAnalysisService.cs
+++ b/_Apps/TradeAnalyzer.Worker/Claude/ClaudeCliAnalysisService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
@@ -34,7 +35,16 @@ internal sealed class ClaudeCliAnalysisService
     public async Task<ClaudeAnalysisResult?> AnalyzeAsync(ClaudeFacts facts, CancellationToken ct = default)
     {
         string prompt = ClaudePromptBuilder.Build(facts);
-        var psi = new ProcessStartInfo { FileName = _opt.ExecutablePath };
+        var psi = new ProcessStartInfo
+        {
+            FileName = _opt.ExecutablePath,
+            // ProcessRunner の契約: stdout/stderr の Encoding は呼び手が psi に設定する（RunPythonAsync と同型）。
+            // claude CLI（Node）は UTF-8 出力で、stdout はそのまま QualitativeJson の書戻しペイロード。未設定だと
+            // コンソール非接続（タスクスケジューラ/exe 直叩き）で既定 cp932 復号となり、日本語 summary の文字化け
+            // 永続化や多バイト途切れによる JSON 破壊→全銘柄スキップ（ExitCode=0）で定性層が無言死する。
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
         psi.ArgumentList.Add("-p");
         psi.ArgumentList.Add("--output-format");
         psi.ArgumentList.Add("json");
@@ -59,20 +69,31 @@ internal sealed class ClaudeCliAnalysisService
             return null;
         }
 
+        // エンベロープは1回だけパースし、候補・is_error・診断1行（result は有界化済み）をここから引き回す。
+        var (candidate, isError, errorInfo) = ParseEnvelope(result.Stdout);
+
         if (result.ExitCode != 0)
         {
             _logger.LogWarning("Claude が ExitCode={Code} で失敗（{Sym}・認証切れ/クレジット枯渇の可能性）。スキップします。\nstderr:\n{Err}\nエンベロープ: {Env}",
-                result.ExitCode, facts.Code, result.Stderr, ExtractErrorInfo(result.Stdout) ?? "（抽出不可）");
+                result.ExitCode, facts.Code, result.Stderr, errorInfo ?? "（抽出不可）");
             return null;
         }
 
-        var model = ParseModelOutput(result.Stdout);
+        if (isError)
+        {
+            // API エラーは ExitCode=0＋is_error:true で返ることもある（exit code 契約は docs 未記載）。
+            // result に brace 含みテキスト（error_during_execution の部分出力等）が載ると防御的パーサが偶然
+            // summary を取り出しエラー応答を正規結果として保存しうるため、パース前にここで受理拒否する。
+            _logger.LogWarning("Claude がエラー応答（is_error）を返しました（{Code}）。スキップします。\nエンベロープ: {Env}",
+                facts.Code, errorInfo ?? "（抽出不可）");
+            return null;
+        }
+
+        var model = ParseModelCandidate(candidate);
         if (model?.Summary is not { Length: > 0 })
         {
-            // API エラーは ExitCode=0＋is_error:true で返ることもあり（exit code 契約は docs 未記載）、
-            // その場合 summary 空でこの分岐に落ちるため、ここでもエンベロープの真因を併記する。
             _logger.LogWarning("Claude 出力をパースできませんでした（{Code}）。スキップします。\nエンベロープ: {Env}",
-                facts.Code, ExtractErrorInfo(result.Stdout) ?? "（抽出不可）");
+                facts.Code, errorInfo ?? "（抽出不可）");
             return null;
         }
 
@@ -85,27 +106,56 @@ internal sealed class ClaudeCliAnalysisService
             _opt.Model, unverified);
     }
 
-    /// <summary>エンベロープ→result→モデル JSON を防御的にパースする。失敗は null。
-    /// internal static は SelfTest が CLI 版ブレ（エンベロープ有無・フェンス・非JSON）の4フォールバックを
-    /// 直接検証するため（<see cref="Commands.ResolveTodayJst"/> の内部公開と同じ前例）。</summary>
-    internal static ModelOutput? ParseModelOutput(string stdout)
+    // 診断ログへ載せる result の上限長。パース不能分岐では「機微含むから Debug 降格」したモデル全文（数 KB の
+    // prose になりうる）が result に載るため、有界化しないと既定 Information ログへ全量流出し降格判断と矛盾する。
+    private const int ErrorResultCap = 300;
+
+    /// <summary>stdout エンベロープ（--output-format json）を1回だけパースし、モデル JSON 候補・is_error・
+    /// 診断1行（is_error/subtype/result。result は先頭 <see cref="ErrorResultCap"/> 字で有界化）をまとめて返す。
+    /// 受理拒否ゲートは「is_error プロパティが存在し true」のときのみ＝is_error を返さない版 CLI の正常系は不変。
+    /// エンベロープが JSON でない/オブジェクトでない版は stdout 全体を候補に降格し isError=false（防御）。
+    /// internal static は SelfTest が純関数として直接検証するため（<see cref="Commands.ResolveTodayJst"/> の
+    /// 内部公開と同じ前例）。</summary>
+    internal static (string Candidate, bool IsError, string? ErrorInfo) ParseEnvelope(string stdout)
     {
-        string candidate;
         try
         {
-            // 外側エンベロープ（--output-format json）から result を取り出す。CLI 版差に備え、result が無ければ
-            // stdout 全体をモデル JSON 候補として扱う（防御）。
             using var env = JsonDocument.Parse(stdout);
-            candidate = env.RootElement.ValueKind == JsonValueKind.Object
-                && env.RootElement.TryGetProperty("result", out var r) && r.ValueKind == JsonValueKind.String
-                    ? r.GetString() ?? stdout
-                    : stdout;
+            if (env.RootElement.ValueKind != JsonValueKind.Object) return (stdout, false, null);
+
+            string candidate = stdout;
+            bool isError = false;
+            var parts = new List<string>();
+            if (env.RootElement.TryGetProperty("is_error", out var e))
+            {
+                isError = e.ValueKind == JsonValueKind.True;
+                parts.Add("is_error=" + e.GetRawText());
+            }
+            if (env.RootElement.TryGetProperty("subtype", out var s) && s.ValueKind == JsonValueKind.String)
+                parts.Add("subtype=" + s.GetString());
+            if (env.RootElement.TryGetProperty("result", out var r) && r.ValueKind == JsonValueKind.String)
+            {
+                candidate = r.GetString() ?? stdout;
+                parts.Add("result=" + (candidate.Length > ErrorResultCap ? candidate[..ErrorResultCap] + "…" : candidate));
+            }
+            return (candidate, isError, parts.Count > 0 ? string.Join(" ", parts) : null);
         }
         catch (JsonException)
         {
-            candidate = stdout; // エンベロープが JSON でない版もありうる＝素の出力から抽出を試す。
+            return (stdout, false, null); // エンベロープが JSON でない版もありうる＝素の出力から抽出を試す。
         }
+    }
 
+    /// <summary>エンベロープ→result→モデル JSON を防御的にパースする。失敗は null。
+    /// internal static は SelfTest が CLI 版ブレ（エンベロープ有無・フェンス・非JSON）の4フォールバックを
+    /// 直接検証するため（実行時の AnalyzeAsync は ParseEnvelope を1回だけ呼び、候補を
+    /// <see cref="ParseModelCandidate"/> へ渡す）。</summary>
+    internal static ModelOutput? ParseModelOutput(string stdout) =>
+        ParseModelCandidate(ParseEnvelope(stdout).Candidate);
+
+    /// <summary>モデル JSON 候補（エンベロープ解決済み）からフェンス除去＋抽出＋デシリアライズ。失敗は null。</summary>
+    private static ModelOutput? ParseModelCandidate(string candidate)
+    {
         string? json = ExtractJsonObject(candidate);
         if (json == null) return null;
         try
@@ -129,28 +179,10 @@ internal sealed class ClaudeCliAnalysisService
     /// <summary>非 success 経路の診断用に、stdout エンベロープから is_error/subtype/result を1行へ抽出する。
     /// 失敗理由（認証切れ authentication_failed・クレジット枯渇 billing_error・model_not_found）は stderr でなく
     /// stdout の JSON エンベロープ側に載り、stdout は Debug 降格済み＝既定 Information ログに出ないため、
-    /// 警告へ真因のみ併記する（stdout 全体の盲目切詰めは serialize 順次第で result が切れるので抽出方式）。
-    /// internal static は SelfTest が純関数として直接検証するため（ParseModelOutput の内部公開と同じ前例）。
-    /// エンベロープが JSON でない/対象キーが無いときは null。</summary>
-    internal static string? ExtractErrorInfo(string stdout)
-    {
-        try
-        {
-            using var env = JsonDocument.Parse(stdout);
-            if (env.RootElement.ValueKind != JsonValueKind.Object) return null;
-            var parts = new List<string>();
-            if (env.RootElement.TryGetProperty("is_error", out var e)) parts.Add("is_error=" + e.GetRawText());
-            if (env.RootElement.TryGetProperty("subtype", out var s) && s.ValueKind == JsonValueKind.String)
-                parts.Add("subtype=" + s.GetString());
-            if (env.RootElement.TryGetProperty("result", out var r) && r.ValueKind == JsonValueKind.String)
-                parts.Add("result=" + r.GetString());
-            return parts.Count > 0 ? string.Join(" ", parts) : null;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
+    /// 警告へ真因のみ併記する（stdout 全体の盲目切詰めは serialize 順次第で result が切れるので抽出方式。
+    /// result フィールド自体も <see cref="ErrorResultCap"/> で有界化＝真因の先頭は必ず載る）。
+    /// 実体は <see cref="ParseEnvelope"/> への委譲（SelfTest 互換の seam）。</summary>
+    internal static string? ExtractErrorInfo(string stdout) => ParseEnvelope(stdout).ErrorInfo;
 
     /// <summary>コードフェンス除去＋先頭 '{'〜末尾 '}' 抽出（モデル/CLI 出力のブレに耐える）。
     /// 既知限界: prose 中に別の brace ペアが混在すると抽出範囲が不正 JSON 化し per-銘柄スキップに落ちる

--- a/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
+++ b/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
@@ -40,7 +40,11 @@ internal static class ClaudeFactGatherer
             .OrderByDescending(f => f.DiscloseDate)
             .FirstOrDefaultAsync(ct).ConfigureAwait(false);
 
-        double? adjClose = bar?.AdjClose ?? bar?.Close;
+        // 生 Close へフォールバックしない: RuleEngine（EvaluateStock）は AdjClose 非 null の bar だけで判定するため、
+        // 生値を「調整後終値」「ルール判定に使用」ラベルで注入すると実判定と食い違う事実になる。null は正直に
+        // 「データなし」/算出不可とし、生値は既存の「終値（生値）」行が示す。なお J-Quants 仕様では取引なし日は
+        // 四本値（生・調整とも）同時に Null＝「AdjClose のみ null」の帯は仕様上存在せず、通常運用は挙動不変。
+        double? adjClose = bar?.AdjClose;
 
         // 開示日〜t の間に分割（AdjustmentFactor≠1）があったか。あれば EPS/BPS の株数基準が AdjClose と食い違うため
         // PER/PBR の算出を見送る（この DB では係数補正が不整合で信頼できない）。
@@ -103,5 +107,7 @@ internal static class ClaudeFactGatherer
     private static string? FmtNum(double? v, string unit, string format = "N0") =>
         v is double d ? d.ToString(format, CultureInfo.InvariantCulture) + " " + unit : null;
 
-    private static string? FmtDate(DateOnly? d) => d?.ToString("yyyy-MM-dd");
+    // InvariantCulture 必須: "yyyy" は現在カルチャの暦の年を出すため、非グレゴリオ暦カルチャ（th-TH=仏暦等）の
+    // ホストでは「2569-07-16」等の誤った年を「実データ」として注入してしまう（FmtNum/RuleScore と同じ方針）。
+    private static string? FmtDate(DateOnly? d) => d?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 }

--- a/_Apps/TradeAnalyzer.Worker/Claude/QualitativeNumberGuard.cs
+++ b/_Apps/TradeAnalyzer.Worker/Claude/QualitativeNumberGuard.cs
@@ -7,7 +7,7 @@ namespace TradeAnalyzer.Worker.Claude;
 /// <para>
 /// 注入した事実（<see cref="ClaudeFacts.Lines"/> の値）から数値集合を作り、出力側の数値がそこに照合しなければ
 /// <c>true</c>（＝注入外数値の疑い）を返す。ドロップはせず可視化フラグに使う（§数値ガード）。
-/// <b>正直な限界</b>: 丸め・単位・％・言い換えで完全一致は難しく誤検知/見逃しが残る＝airtight ではない緩和策。
+/// <b>正直な限界</b>: 丸め・単位・言い換えで完全一致は難しく誤検知/見逃しが残る＝airtight ではない緩和策。
 /// 日付値（"2026-05-14"）はトークンが 2026/05/14 に割れて許可集合を汚染するため「2026年に増益」型の捏造年が
 /// 素通りする（日付トークン汚染による見逃し）。
 /// 数値安全性がクリティカルなら SDK 経路（<c>OutputConfig.Format</c> スキーマ拘束）へ切替える。
@@ -17,8 +17,6 @@ internal static class QualitativeNumberGuard
 {
     // 数値トークン: 先頭数字＋(数字/カンマ/ピリオド)＋任意の末尾 %（半角/全角）。
     private static readonly Regex NumberToken = new(@"\d[\d,\.]*[%％]?", RegexOptions.Compiled);
-
-    private static readonly char[] PercentChars = { '%', '％' };
 
     /// <summary>出力に注入外の数値が含まれる疑いがあれば true。</summary>
     public static bool HasUnverifiedNumbers(string summary, IEnumerable<string> risks, ClaudeFacts facts)
@@ -37,14 +35,16 @@ internal static class QualitativeNumberGuard
             {
                 var norm = Normalize(m.Value);
                 // 素の1桁整数（0-9）は散文の個数表現（「2つのリスク」等）で頻出＝誤検知源のため除外する。
-                // ただし %/％ 付き（「5%改善」等の比率主張）は捏造検出対象なので、生トークン基準で判定して
-                // スキップさせない（Normalize が % を剥がした後の norm だけ見ると "5%" が素通りする）。
-                if (norm.Length <= 1 && !norm.Contains('.') && m.Value.IndexOfAny(PercentChars) < 0) continue;
+                // %/％ 付き（「5%改善」等の比率主張）は Normalize が % を保持するため norm 長 2 以上となり
+                // ここに落ちず、not-in-allowed 照合（注入値に % なし→ほぼ常に検出）へ進む。
+                if (norm.Length <= 1 && !norm.Contains('.')) continue;
                 if (!allowed.Contains(norm)) return true;
             }
         return false;
     }
 
-    // カンマと末尾 %/％ を除去して比較キーにする（表記揺れの吸収。丸め/単位差までは吸収しない＝既知の限界）。
-    private static string Normalize(string token) => token.Replace(",", "").TrimEnd('%', '％');
+    // カンマと末尾の半角ピリオド（NumberToken が文末句点を取り込んだ "1,234." 対策）を除去して比較キーにする。
+    // % は剥がさない: 注入事実に %付き値は存在しない（単位は 円/株/倍）ため、剥がすと捏造%値が非%事実へ照合成立して
+    // 素通りする（「3%成長」→"3"→RuleScore の "3"、「利益率15.2%」→PER の "15.2"）。丸め/単位差は吸収しない＝既知の限界。
+    private static string Normalize(string token) => token.Replace(",", "").TrimEnd('.');
 }

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -263,7 +263,7 @@ public static class Commands
         await RunPythonAsync(pythonOptions.Value, logger, predictScript, new[]
         {
             ("--db", dbPath),
-            ("--date", t.ToString("yyyy-MM-dd")),
+            ("--date", t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
         });
 
         // 5. null 検査＋6. Top-K 読取を AsNoTracking で1回にまとめる。
@@ -283,7 +283,8 @@ public static class Commands
         //    件数は当日 Top-K＝バックテスト TopN（同一概念。F11 で統合）の単一ノブを使う。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        Console.WriteLine($"=== {t:yyyy-MM-dd} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
+        // 日付は Invariant 明示（explain-today ヘッダと同型。非グレゴリオ暦カルチャ対策・表示専用）。
+        Console.WriteLine($"=== {t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
         Console.WriteLine($"{"Code",-8} {"MlScore",10} {"RuleScore",9}  Rationale");
         foreach (var s in top)
             Console.WriteLine($"{s.Code,-8} {s.MlScore!.Value,10:F4} {s.RuleScore,9}  {s.Rationale}");
@@ -348,11 +349,10 @@ public static class Commands
         // 3. Top-K（run-today と同一の純粋関数で並べ替え）。Claude に回すのは Top-K のみ＝コスト/クレジットを bound。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        // JST の生成時刻（provenance）。書戻し JSON に含める。
-        var generatedAt = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), Jst);
-
         var results = new Dictionary<string, ClaudeAnalysisResult>();
         var reused = new HashSet<string>();
+        // --force 再生成失敗だが旧 QualitativeJson が残存（last-good 保持）した銘柄数。表示と DB 状態の一致用。
+        int kept = 0;
         foreach (var signal in top)
         {
             // 生成済み銘柄は既定でスキップ（--force で上書き再生成）。部分失敗の回復・二重トリガの再実行で
@@ -365,8 +365,17 @@ public static class Commands
             // 4. 実データ収集（DB 実数＋C# 派生指標）。
             var facts = await ClaudeFactGatherer.GatherAsync(db, t, signal);
             // 5. Claude 採点。null（失敗）なら当該銘柄はスキップ（ML のみ・ログのみ）。1 銘柄の失敗が他を止めない。
+            //    旧 JSON あり（--force 再生成失敗）なら DB は last-good を保持したまま＝「保持」として集計する。
             var res = await claude.AnalyzeAsync(facts);
-            if (res == null) continue;
+            if (res == null)
+            {
+                if (signal.QualitativeJson != null) kept++;
+                continue;
+            }
+
+            // JST の生成時刻（provenance）。銘柄ごとに書戻し直前で評価する（Claude 実行は 1 銘柄あたり最大
+            // TimeoutMinutes かかるため、ループ前の一括取得では後半の銘柄で実生成時刻と大きくずれる）。
+            var generatedAt = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), Jst);
 
             // 6. 根拠文の書戻し（追跡回避 UPDATE。AsNoTracking で読んだ行の部分更新）。
             string json = JsonSerializer.Serialize(new
@@ -386,8 +395,11 @@ public static class Commands
             results[signal.Code] = res;
         }
 
-        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。
-        Console.WriteLine($"=== {t:yyyy-MM-dd} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件）===");
+        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。日付は Invariant 明示（非グレゴリオ暦
+        //    カルチャのホストで年が仏暦等になるのを防ぐ。r4-F4 と同機序・表示専用）。
+        string tStr = t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        string keptSuffix = kept > 0 ? $"・保持(再生成失敗) {kept} 件" : "";
+        Console.WriteLine($"=== {tStr} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件{keptSuffix}）===");
         foreach (var s in top)
         {
             Console.WriteLine($"\n[{s.Code}] MlScore={s.MlScore!.Value:F4} RuleScore={s.RuleScore}");
@@ -400,6 +412,12 @@ public static class Commands
             else if (reused.Contains(s.Code))
             {
                 Console.WriteLine("  （既存生成あり・再利用。--force で再生成）");
+            }
+            else if (s.QualitativeJson != null)
+            {
+                // --force 再生成失敗。DB は旧 JSON（last-good）を保持したまま＝「生成なし」ではない。
+                // 失敗理由は ClaudeCliAnalysisService の per-銘柄 LogWarning 側にある。
+                Console.WriteLine("  （再生成失敗・既存生成を保持。ログ参照）");
             }
             else
             {

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -37,6 +37,7 @@ public static class Commands
           [--skip-jquants]                   当日 ingest 済みの再実行時のみ（当日 bar を足さず既存 DB 最新営業日を採点）
   explain-today                              段階3b 当日定性層: run-today 後の Top-K に実データ注入→Claude 根拠文生成→QualitativeJson 書戻し
           [--date YYYY-MM-DD]                対象日を明示（既定は直近営業日）。要 run-today 済み（MlScore 充足）
+          [--force]                          生成済み（QualitativeJson あり）銘柄も再生成（既定は再利用スキップ＝クレジット節約）
   selftest                                   APIキー不要の単体検証（指標/ルール/先読み防止）
 
 例:
@@ -293,16 +294,21 @@ public static class Commands
     /// 根拠文／リスクを生成し、<see cref="Signal.QualitativeJson"/> へ書戻して標準出力に付す。run-today と別コマンド
     /// ＝フォールバック隔離（Claude が落ちても ML パイプラインは無傷）。Claude 失敗は throw せず当該銘柄スキップ
     /// （非必須層＝フォールバック契約）。ただしデータ前提未達（取引日なし）は run-today と同型に fail-fast（ExitCode=1）。
+    /// 同一 t への再実行は生成済み（QualitativeJson あり）銘柄を既定でスキップし <c>--force</c> で再生成
+    /// （facts は同一 t で決定論的＝再生成は情報利得ゼロのクレジット消費。run-today 再実行は date 単位
+    /// delete→insert で QualitativeJson=null に戻るため、このスキップは run-today を挟まない再実行でのみ発動）。
     /// </summary>
     public static async Task ExplainTodayAsync(IServiceProvider sp, string[] args)
     {
         var opts = ParseOptions(args);
+        bool force = opts.ContainsKey("force");
 
         var db = sp.GetRequiredService<AppDbContext>();
         int topN = sp.GetRequiredService<IOptions<BacktestOptions>>().Value.TopN;
         var claudeOpt = sp.GetRequiredService<IOptions<ClaudeOptions>>().Value;
         var claude = sp.GetRequiredService<ClaudeCliAnalysisService>();
         var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("explain-today");
+        var timeProvider = sp.GetService<TimeProvider>() ?? TimeProvider.System;
 
         // Claude 設定はループ前に config キー名つきで fail-fast（誤設定を per-銘柄 catch が飲んで全銘柄スキップ→
         // ExitCode=0 に偽装するのを防ぐ。config 誤設定=fatal／Claude 実行時失敗=非致命）。
@@ -310,13 +316,12 @@ public static class Commands
 
         // 1. 対象日 t の解決（--date 指定 or 直近営業日＝run-today と共通ヘルパ）。取引日皆無は前提破綻＝fail-fast。
         DateOnly t;
-        if (opts.TryGetValue("date", out _))
+        if (opts.ContainsKey("date"))
         {
             t = RequireDate(opts, "date");
         }
         else
         {
-            var timeProvider = sp.GetService<TimeProvider>() ?? TimeProvider.System;
             var today = ResolveTodayJst(timeProvider);
             t = await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
         }
@@ -344,12 +349,19 @@ public static class Commands
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
         // JST の生成時刻（provenance）。書戻し JSON に含める。
-        var generatedAt = TimeZoneInfo.ConvertTime(
-            (sp.GetService<TimeProvider>() ?? TimeProvider.System).GetUtcNow(), Jst);
+        var generatedAt = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), Jst);
 
         var results = new Dictionary<string, ClaudeAnalysisResult>();
+        var reused = new HashSet<string>();
         foreach (var signal in top)
         {
+            // 生成済み銘柄は既定でスキップ（--force で上書き再生成）。部分失敗の回復・二重トリガの再実行で
+            // 成功済み銘柄まで Claude を払い直さない（クレジット節約）＋残存 JSON と表示の食い違いも防ぐ。
+            if (!force && signal.QualitativeJson != null)
+            {
+                reused.Add(signal.Code);
+                continue;
+            }
             // 4. 実データ収集（DB 実数＋C# 派生指標）。
             var facts = await ClaudeFactGatherer.GatherAsync(db, t, signal);
             // 5. Claude 採点。null（失敗）なら当該銘柄はスキップ（ML のみ・ログのみ）。1 銘柄の失敗が他を止めない。
@@ -375,7 +387,7 @@ public static class Commands
         }
 
         // 7. Top-K 出力（summary/risks/numericUnverified を付す）。
-        Console.WriteLine($"=== {t:yyyy-MM-dd} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成）===");
+        Console.WriteLine($"=== {t:yyyy-MM-dd} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件）===");
         foreach (var s in top)
         {
             Console.WriteLine($"\n[{s.Code}] MlScore={s.MlScore!.Value:F4} RuleScore={s.RuleScore}");
@@ -384,6 +396,10 @@ public static class Commands
                 Console.WriteLine($"  要約: {res.Summary}");
                 foreach (var risk in res.Risks) Console.WriteLine($"  リスク: {risk}");
                 if (res.NumericUnverified) Console.WriteLine("  ⚠ numericUnverified（注入外の数値が混入した疑い）");
+            }
+            else if (reused.Contains(s.Code))
+            {
+                Console.WriteLine("  （既存生成あり・再利用。--force で再生成）");
             }
             else
             {

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
@@ -590,7 +591,7 @@ public static class SelfTest
             // Python 書戻しを模した生 SQL UPDATE（C# の追跡外で MlScore を埋める経路）。DateOnly は TEXT(yyyy-MM-dd)。
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t:yyyy-MM-dd}' AND Code = 'AAA'";
+                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}' AND Code = 'AAA'";
                 f += Assert("AsNoTracking 罠: 生 SQL UPDATE が 1 行", cmd.ExecuteNonQuery() == 1);
             }
 

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1007,6 +1007,8 @@ public static class SelfTest
             new("最新株価", "1,234 円"),
             new("株価日付", "2026-05-14"),
             new("ルール通過理由", "トレンドOK(SMA25>75)"),
+            // RuleScore は 0〜3 で必ず注入される＝許可集合に素の "3" が常在する（r4-F1 の照合素通り再現に必須）。
+            new("ルールスコア（通過ゲート数）", "3"),
         });
         f += Assert("NumberGuard: 注入数値のみは false",
             !QualitativeNumberGuard.HasUnverifiedNumbers(
@@ -1019,12 +1021,22 @@ public static class SelfTest
         f += Assert("NumberGuard: 銘柄コード/会社名の引用は false",
             !QualitativeNumberGuard.HasUnverifiedNumbers(
                 "銘柄7203（トヨタ）は順張り局面。", Array.Empty<string>(), facts));
-        // r3-F1 回帰: 1桁%は散文1桁スキップに落とさず捏造として検出する（norm 基準だと "5%"→"5"→continue で素通り）。
-        // 全角％も NumberToken/Normalize の両方で対称に扱う（半角のみだと「8％」がスキップに落ちる）。
+        // r3-F1 回帰: 1桁%は散文1桁スキップに落とさず捏造として検出する（Normalize が % を保持するため
+        // norm="5%" は長さ2→スキップに落ちず not-in-allowed 経路で true）。全角％も NumberToken が対称に取り込む。
         f += Assert("NumberGuard: 捏造の1桁%（5%）は true",
             QualitativeNumberGuard.HasUnverifiedNumbers("営業利益率が5%改善した。", Array.Empty<string>(), facts));
         f += Assert("NumberGuard: 捏造の全角1桁％（8％）も true",
             QualitativeNumberGuard.HasUnverifiedNumbers("ROEは8％と高い。", Array.Empty<string>(), facts));
+        // r4-F1 回帰: Normalize は % を剥がさない。剥がすと捏造%値が非%事実へ照合成立して素通りする
+        // （「3%成長」→"3"→常在の RuleScore "3"、「利益率15.2%」→PER の "15.2"）。
+        f += Assert("NumberGuard: 捏造%がRuleScoreの素値に照合されない（3%成長は true）",
+            QualitativeNumberGuard.HasUnverifiedNumbers("売上は3%成長した。", Array.Empty<string>(), facts));
+        f += Assert("NumberGuard: 捏造%がPERの素値に照合されない（利益率15.2%は true）",
+            QualitativeNumberGuard.HasUnverifiedNumbers("利益率15.2%を確保。", Array.Empty<string>(), facts));
+        // r4-F1 回帰: NumberToken は文末の半角ピリオドまで取り込む（"1,234."）ため、末尾 '.' を除去しないと
+        // 正当な引用が不一致になる FP（トークン化起因・文書化済み限界とは別）。
+        f += Assert("NumberGuard: 文末ピリオドを取り込んだ正当引用（株価は1,234.）は false",
+            !QualitativeNumberGuard.HasUnverifiedNumbers("株価は1,234.", Array.Empty<string>(), facts));
         // r3-F3 回帰: 株価日付は Label でなく Value（許可集合）に注入されるため、忠実な日付引用は誤発火しない。
         f += Assert("NumberGuard: 注入済み株価日付の引用は false",
             !QualitativeNumberGuard.HasUnverifiedNumbers(
@@ -1128,6 +1140,19 @@ public static class SelfTest
         // (3) 対象キーが無い JSON オブジェクト → null（cost/session 等のノイズを警告へ流さない）。
         f += Assert("ExtractErrorInfo: 対象キー無し→null",
             ClaudeCliAnalysisService.ExtractErrorInfo("{\"session_id\":\"x\",\"cost_usd\":0.1}") == null);
+
+        // r4-F2 回帰: is_error は受理拒否ゲート（AnalyzeAsync がパース前に拒否）。result に brace 含みテキストが
+        // 載っても防御的パーサが偶然 summary を取り出しエラー応答を正規結果化しない（1回パース集約の要）。
+        var env = ClaudeCliAnalysisService.ParseEnvelope(
+            "{\"is_error\":true,\"subtype\":\"error_during_execution\",\"result\":\"{\\\"summary\\\":\\\"偽\\\"}\"}");
+        f += Assert("ParseEnvelope: is_error:true をゲートへ返す（候補が summary 含みでも受理拒否可能）", env.IsError);
+        f += Assert("ParseEnvelope: is_error 無しの正常エンベロープは IsError=false",
+            !ClaudeCliAnalysisService.ParseEnvelope("{\"result\":\"{\\\"summary\\\":\\\"正\\\"}\"}").IsError);
+        // r4-F2 回帰: パース不能分岐で Debug 降格済みの result 全文（数 KB になりうる）が警告へ無制限流出しない。
+        var longEnv = ClaudeCliAnalysisService.ParseEnvelope(
+            "{\"is_error\":true,\"result\":\"" + new string('x', 2000) + "\"}");
+        f += Assert("ParseEnvelope: 長大 result の診断1行は有界化される",
+            longEnv.ErrorInfo != null && longEnv.ErrorInfo.Length < 400 && longEnv.ErrorInfo.EndsWith("…"));
         return f;
     }
 

--- a/_Apps/scripts/explain-today.ps1
+++ b/_Apps/scripts/explain-today.ps1
@@ -45,6 +45,13 @@ dotnet run --project $workerDir -- explain-today 2>&1 | ForEach-Object {
     Write-Log $line
 }
 $code = $LASTEXITCODE
+# dotnet コマンド解決自体の失敗（タスク実行ユーザの PATH に無い等）では $LASTEXITCODE が未設定（$null）のまま
+# 流れ、exit $null = exit 0 に化けてタスクが緑のまま QualitativeJson が永久に埋まらない。$null は 1 へ倒す
+# （ErrorActionPreference=Continue の本スクリプト固有の穴。run-today.ps1 は Stop のため -File が exit 1 を返す）。
+if ($null -eq $code) {
+    Write-Log "=== explain-today FAILED: dotnet did not start (check PATH / installation) ==="
+    exit 1
+}
 Write-Log ("=== explain-today END ExitCode={0} ({1}) ===" -f $code, (Get-Date -Format "yyyy-MM-dd HH:mm:ss"))
 
 # ExitCode をそのまま返す（run-today.ps1 と同じ）: 非致命スキップは C# が既に 0 で表現済みのため丸め不要。


### PR DESCRIPTION
## 概要
docs/plans/cr-fixes-claude-qualitative-r4.md（/code-review + deep-code-review → finding-auditor 裁定済み）の実装。AUTO-FIX F1〜F5＋Nit に加え、NEEDS-USER の F6/F7 は推奨案で実装（下記「要確認」）。

## 実装内容
### F1. NumberGuard 根本修正（QualitativeNumberGuard.cs）
Normalize の `TrimEnd('%','％')` を廃止し `Replace(",","").TrimEnd('.')` へ。注入事実に%付き値は存在しないため、%剥がしは捏造%値を非%事実へ照合成立させていた（「3%成長」→"3"→RuleScore の "3" で素通り／「利益率15.2%」→PER の "15.2"）。%保持で "5%" は長さ2となり、r3 の生トークン特例（PercentChars）を削除して1桁スキップを素の norm 基準へ単純化。末尾 '.' 除去はトークン化 FP（"1,234."）対策。SelfTest 3件追加＋既存7件 PASS 維持。

### F2. エンベロープ解釈の一機構化（ClaudeCliAnalysisService.cs）
`ParseEnvelope`（1回パース）へ集約し `(Candidate, IsError, ErrorInfo)` を返却。受理拒否は「is_error プロパティが存在し true」のときのみ＝is_error 無し版 CLI の正常系は不変。診断 result は 300 字で有界化（Debug 降格済みモデル全文の警告流出を防止・ExitCode≠0/パース不能の両分岐が同一 cap を通る）。ParseModelOutput/ExtractErrorInfo は SelfTest 互換の thin seam として維持。SelfTest 3件追加＋既存9件 PASS 維持。

### F3. claude psi に UTF-8 Encoding（同上）
`StandardOutputEncoding/StandardErrorEncoding = Encoding.UTF8`（RunPythonAsync と同型・ProcessRunner 契約の履行）。ヘッドレス実行（タスクスケジューラ等）での cp932 誤復号→QualitativeJson 文字化け/JSON 破壊を防止。[任意] の ProcessRunner 側既定化は未実施（契約 doc 変更を伴うため見送り）。

### F4. FmtDate に InvariantCulture（ClaudeFactGatherer.cs）
非グレゴリオ暦カルチャ（th-TH 等）ホストで仏暦年を「実データ」注入する穴を1トークンで閉鎖。

### F5. explain-today.ps1 の exit 0 偽装
dotnet コマンド解決失敗時（$LASTEXITCODE=$null→exit 0）を exit 1 へ。出力リテラルは本ファイルの ASCII 制約に従い英語（プラン記載の日本語文言は cp932 制約と矛盾するため変更）。run-today.ps1 は Stop のため対象外（プラン深堀どおり）。

### F6.（NEEDS-USER→案B 実装）adjClose の生 Close フォールバック廃止
`bar?.AdjClose ?? bar?.Close` → `bar?.AdjClose`。**directed lookup 完了**: 公式仕様（jpx-jquants.com/ja/spec/eq-bars-daily 留意点）に「取引が存在しない日の銘柄についての四本値、取引高と売買代金は、Nullが収録」と明記＝生・調整は同時に Null で「AdjClose のみ null」帯は仕様上存在しない → 案B は通常運用で挙動完全不変・発火時のみ誤ラベル事実でなく正直な欠損になる（下方リスクなし・案A の優位条件は消滅）。

### F7.（NEEDS-USER→案a 実装）再実行意味論の確定
QualitativeJson 生成済み銘柄はループでスキップ（「既存生成あり・再利用」表示＋件数反映）、`--force` で上書き再生成。help 文言追加。run-today 通常系（delete→insert で null リセット）は挙動不変。

### Nit
TimeProvider の冒頭1回束縛（二重解決解消）／`TryGetValue("date", out _)`→`ContainsKey`／SelfTest.cs の r3-F1 コメント stale 解消（プラン残指摘）。

## 検証
- `dotnet build` 0 warn / 0 err、`selftest` 全 PASS（NumberGuard 10・ParseModelOutput 6・ExtractErrorInfo+ParseEnvelope 6 含む）
- F3/F5 は手動確認事項: 初回手動ゲート時に headless 相当で QualitativeJson の日本語非化け／PATH から dotnet を外して ExitCode=1

## 要確認（NEEDS-USER を推奨案で実装済み — 異議あれば差し戻し可）
1. **F6=案B**: 上記の仕様確認により実質ノーリスクと判断。案A（RuleEngine と同じ AdjClose 非 null bar 採用）を望む場合は変更する。
2. **F7=案a**: 既定=スキップ再利用＋`--force`。案b（実行時一括クリア）を望む場合は変更する。

## 見送り（プラン記載どおり）
F3[任意] ProcessRunner の Encoding 既定化／r1〜r3 からの継続見送り群（プラン「見送り記録」参照）