### PR TITLE
fix(trade-analyzer): 段階3b レビュー指摘(r5)を反映

### DIFF
--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -283,7 +283,8 @@ public static class Commands
         //    件数は当日 Top-K＝バックテスト TopN（同一概念。F11 で統合）の単一ノブを使う。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        Console.WriteLine($"=== {t:yyyy-MM-dd} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
+        // 日付は Invariant 明示（explain-today ヘッダと同型。非グレゴリオ暦カルチャ対策・表示専用）。
+        Console.WriteLine($"=== {t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
         Console.WriteLine($"{"Code",-8} {"MlScore",10} {"RuleScore",9}  Rationale");
         foreach (var s in top)
             Console.WriteLine($"{s.Code,-8} {s.MlScore!.Value,10:F4} {s.RuleScore,9}  {s.Rationale}");
@@ -348,11 +349,10 @@ public static class Commands
         // 3. Top-K（run-today と同一の純粋関数で並べ替え）。Claude に回すのは Top-K のみ＝コスト/クレジットを bound。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        // JST の生成時刻（provenance）。書戻し JSON に含める。
-        var generatedAt = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), Jst);
-
         var results = new Dictionary<string, ClaudeAnalysisResult>();
         var reused = new HashSet<string>();
+        // --force 再生成失敗だが旧 QualitativeJson が残存（last-good 保持）した銘柄数。表示と DB 状態の一致用。
+        int kept = 0;
         foreach (var signal in top)
         {
             // 生成済み銘柄は既定でスキップ（--force で上書き再生成）。部分失敗の回復・二重トリガの再実行で
@@ -365,8 +365,17 @@ public static class Commands
             // 4. 実データ収集（DB 実数＋C# 派生指標）。
             var facts = await ClaudeFactGatherer.GatherAsync(db, t, signal);
             // 5. Claude 採点。null（失敗）なら当該銘柄はスキップ（ML のみ・ログのみ）。1 銘柄の失敗が他を止めない。
+            //    旧 JSON あり（--force 再生成失敗）なら DB は last-good を保持したまま＝「保持」として集計する。
             var res = await claude.AnalyzeAsync(facts);
-            if (res == null) continue;
+            if (res == null)
+            {
+                if (signal.QualitativeJson != null) kept++;
+                continue;
+            }
+
+            // JST の生成時刻（provenance）。銘柄ごとに書戻し直前で評価する（Claude 実行は 1 銘柄あたり最大
+            // TimeoutMinutes かかるため、ループ前の一括取得では後半の銘柄で実生成時刻と大きくずれる）。
+            var generatedAt = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), Jst);
 
             // 6. 根拠文の書戻し（追跡回避 UPDATE。AsNoTracking で読んだ行の部分更新）。
             string json = JsonSerializer.Serialize(new
@@ -386,8 +395,11 @@ public static class Commands
             results[signal.Code] = res;
         }
 
-        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。
-        Console.WriteLine($"=== {t:yyyy-MM-dd} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件）===");
+        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。日付は Invariant 明示（非グレゴリオ暦
+        //    カルチャのホストで年が仏暦等になるのを防ぐ。r4-F4 と同機序・表示専用）。
+        string tStr = t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        string keptSuffix = kept > 0 ? $"・保持(再生成失敗) {kept} 件" : "";
+        Console.WriteLine($"=== {tStr} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件{keptSuffix}）===");
         foreach (var s in top)
         {
             Console.WriteLine($"\n[{s.Code}] MlScore={s.MlScore!.Value:F4} RuleScore={s.RuleScore}");
@@ -400,6 +412,12 @@ public static class Commands
             else if (reused.Contains(s.Code))
             {
                 Console.WriteLine("  （既存生成あり・再利用。--force で再生成）");
+            }
+            else if (s.QualitativeJson != null)
+            {
+                // --force 再生成失敗。DB は旧 JSON（last-good）を保持したまま＝「生成なし」ではない。
+                // 失敗理由は ClaudeCliAnalysisService の per-銘柄 LogWarning 側にある。
+                Console.WriteLine("  （再生成失敗・既存生成を保持。ログ参照）");
             }
             else
             {

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -263,7 +263,7 @@ public static class Commands
         await RunPythonAsync(pythonOptions.Value, logger, predictScript, new[]
         {
             ("--db", dbPath),
-            ("--date", t.ToString("yyyy-MM-dd")),
+            ("--date", t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
         });
 
         // 5. null 検査＋6. Top-K 読取を AsNoTracking で1回にまとめる。

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
@@ -590,7 +591,7 @@ public static class SelfTest
             // Python 書戻しを模した生 SQL UPDATE（C# の追跡外で MlScore を埋める経路）。DateOnly は TEXT(yyyy-MM-dd)。
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t:yyyy-MM-dd}' AND Code = 'AAA'";
+                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}' AND Code = 'AAA'";
                 f += Assert("AsNoTracking 罠: 生 SQL UPDATE が 1 行", cmd.ExecuteNonQuery() == 1);
             }
 


### PR DESCRIPTION
## 概要
Round 5 コードレビュー（inline 標準 + deep-code-review + finding-auditor 裁定 + plan-refinement-loop 精査）の指摘を反映。
プラン: `docs/plans/cr-fixes-claude-qualitative-r5.md`（refinement COMPLETE・NEEDS-USER 解決済み）。

## 調査（レビュー結論）
- r4 修正7件＋残指摘は逐行再検証で回帰なし。SelfTest 追加回帰（NumberGuard/Flatten/ParseModelOutput/Envelope 計26件）も期待値整合を確認。
- 新規 CONFIRMED 2件＋Nit 1件のみ。いずれも `ExplainTodayAsync` 周辺の小変更で相互独立。

## 実装
### F1: --force 再生成失敗時の表示と DB 状態の食い違い（CONFIRMED）
`--force` で再生成し `AnalyzeAsync` が null（失敗）の場合、DB は旧 `QualitativeJson`（last-good）を保持するのに表示は「Claude 生成なし・ML のみ」に落ちていた。
- 表示ループ else を読取済みスナップショット `s.QualitativeJson` で二分: 旧 JSON あり →「（再生成失敗・既存生成を保持。ログ参照）」（失敗理由は `Claude/ClaudeCliAnalysisService.cs` の per-銘柄 LogWarning 側）。
- ヘッダに第3カウンタ「保持(再生成失敗) Z 件」追加（Z=0 で省略）。生成ループ失敗経路で `signal.QualitativeJson != null` のときのみ加算。**ユーザー決定 2026-07-21: 案A（ヘッダ一貫）**。
- 既定経路（非 force）は `reused` 分岐が先取りするため挙動不変。

### F2: generatedAt の per-銘柄評価（CONFIRMED・任意）
ループ前1回取得だと全銘柄が開始時刻を記録し、Top-K 後半では実生成時刻と最大 TimeoutMinutes×件数ずれる。書戻し JSON 組立の直前へ移動（JSON 契約不変）。

### Nit: ヘッダ日付の InvariantCulture 明示
`$"{t:yyyy-MM-dd}"` は CurrentCulture のため非グレゴリオ暦ホストで年が仏暦等になる（r4-F4 同機序・表示専用）。run-today（L286）と explain-today の両ヘッダを同時修正（片直しは不整合のため）。

## 検証
- `dotnet build`: 0 警告 0 エラー
- `selftest`: 全テスト PASS（F1/F2 は DB＋実 claude 依存のため SelfTest 対象外＝r4-F7 と同扱い。手動検証手順はプラン記載）

## 見送り（プラン記録済み・再提案禁止枠）
r1-F3 ct 伝播 / r1-F9 共有型 / r2-F7〜F14 / r3-F5・Nit 3件 / r4 ps1 共通ランナー化