### PR TITLE
fix(trade-analyzer): 段階3b レビュー指摘(r6)を反映

### DIFF
--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -263,7 +263,7 @@ public static class Commands
         await RunPythonAsync(pythonOptions.Value, logger, predictScript, new[]
         {
             ("--db", dbPath),
-            ("--date", t.ToString("yyyy-MM-dd")),
+            ("--date", t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
         });
 
         // 5. null 検査＋6. Top-K 読取を AsNoTracking で1回にまとめる。

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
@@ -590,7 +591,7 @@ public static class SelfTest
             // Python 書戻しを模した生 SQL UPDATE（C# の追跡外で MlScore を埋める経路）。DateOnly は TEXT(yyyy-MM-dd)。
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t:yyyy-MM-dd}' AND Code = 'AAA'";
+                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}' AND Code = 'AAA'";
                 f += Assert("AsNoTracking 罠: 生 SQL UPDATE が 1 行", cmd.ExecuteNonQuery() == 1);
             }
 


### PR DESCRIPTION
## 概要
Round 6 コードレビュー（docs/plans/cr-fixes-claude-qualitative-r6.md、ローカル管理）の CONFIRMED 指摘 1 件を反映。r5 修正 3 件は逐行再検証で回帰なし確認済み。

## F1. 日付文字列の culture 未指定（r5-Nit の横展開漏れ・データ経路）[AUTO-FIX]
`DateOnly.ToString("yyyy-MM-dd")` は CurrentCulture の暦で年を出すため、非グレゴリオ暦カルチャ（th-TH=仏暦等）のホストで誤日付になる。r4-F4 / r5-Nit で表示系は Invariant 化済みだが、データ経路 2 箇所が残存していた。

- `Commands.cs:266` — run-today が predict.py へ渡す `--date` 引数。仏暦年 "2569-07-21" が渡ると predict.py の `%Y-%m-%d` 厳格パース＋DB 照会で該当行なし → SystemExit 非 0 → throw（fail-loud だが誤日付起因で診断が誤誘導）。
- `SelfTest.cs:593` — 生 SQL 補間 `'{t:yyyy-MM-dd}'`。EF の TEXT 格納は西暦 yyyy-MM-dd のため非グレゴリオ暦ホストで UPDATE 0 行 → selftest 誤 FAIL。`using System.Globalization;` を追加。

解法は同ファイル既存イディオム（Commands.cs:287/400 等）どおり in-place で `CultureInfo.InvariantCulture` 指定 ×2。共有ヘルパ抽出は 2 サイトのみで YAGNI。グレゴリオ暦ホストでは出力バイト列不変＝挙動不変。

## 検証
- `dotnet build _Apps/App.sln`: 0 警告 0 エラー
- `selftest`: 全テスト PASS（グレゴリオ暦ホストで回帰なし）