### PR TITLE
feat(trade-analyzer): 段階3c STEP1 notify-today 配信ペイロード組み立て

### DIFF
--- a/_Apps/CLAUDE.md
+++ b/_Apps/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+このファイルは `_Apps` 配下（app-trade-analyzer ブランチ固有）で作業する際のガイド。
+
+## 概要
+
+TradeAnalyzer は日本株の「データ取得 → ルール/ML シグナル → バックテスト → 当日 EOD 推論 → Claude 定性根拠 → 配信」を行う CLI アプリ。TBird.* を参照しない独立 net10.0 複数プロジェクト構成（TBirdObject 継承・命名規則等の全体共通ルールは適用外。詳細はルート CLAUDE.md「独立アプリ例外」参照）。
+
+## 構成
+
+- `TradeAnalyzer.Data` — EF Core (SQLite) エンティティ / マイグレーション、外部 API クライアント（J-Quants / EDINET）、`AppPaths`（実行時パス解決）
+- `TradeAnalyzer.Core` — テクニカル指標、ルールエンジン、ingest、バックテスト
+- `TradeAnalyzer.Worker` — CLI エントリ（composition root）、Claude 定性層（`claude -p` 直結）、Python 採点連携（`ProcessRunner`）、`SelfTest`
+- `ml/` — Python 側 ML（LightGBM LambdaRank）。uv 管理（`pyproject.toml` / `uv.lock`、`.venv` は追跡外）。詳細は [ml/README.md](ml/README.md)
+- `scripts/` — 運用 PowerShell（`run-today.ps1` / `explain-today.ps1` / `retrain.ps1`。タスクスケジューラ登録前提）
+
+## ビルド・実行
+
+```bash
+dotnet build _Apps/App.sln
+dotnet run --project _Apps/TradeAnalyzer.Worker -- <command>
+```
+
+コマンド一覧と引数は `Commands.PrintUsage`（引数なし実行で表示）が正。概要:
+
+- `migrate` / `ingest` / `analyze` / `signals` / `backtest` — 段階1〜2（履歴データ・検証）
+- `run-today` — 段階3a: 当日 EOD 推論（ingest → analyze → Python 採点 → Top-K）
+- `explain-today` — 段階3b: Claude 根拠文生成 → `QualitativeJson` 書戻し
+- `notify-today` — 段階3c: 配信ペイロード組み立て
+- `selftest` — APIキー不要の単体検証（指標 / ルール / 先読み防止 / パーサ回帰）
+- `stats` — DB テーブル行数等の確認
+
+## 実行時状態（git 追跡外）
+
+置き場はルート CLAUDE.md のルール通り `_Tools/TradeAnalyzer/`:
+`trade.db` / `Secrets.json`（APIキー）/ `ml/models` / `logs` / bin・obj（`Directory.Build.props` の ArtifactsPath）。
+パス解決は `TradeAnalyzer.Data/AppPaths.cs`（CWD 非依存。環境変数 `TRADEANALYZER_DATA_DIR` で上書き可）。
+
+## 重要な規約
+
+- **ExitCode 契約が段階で逆向き**: `explain-today` は Claude 実行時失敗を非致命スキップ（データ前提未達のみ ExitCode=1）。`notify-today` は「届ける」ことが仕事のため送信系失敗＝ExitCode=1、Passed=0 は正常（0 件ペイロード・ExitCode=0）。コマンド内で catch して契約を潰さないこと。
+- **文字列化は InvariantCulture**: 日付・数値の補間（SQL 文字列・CLI 引数含む）は culture 明示。過去レビューで複数回再発した箇所。例外: 表示専用の数値書式（Console 出力の `:F4` 等）は CurrentCulture 容認（日付は表示でも Invariant 明示）。日付の yyyy-MM-dd 文字列化は `ToIso()`（`TradeAnalyzer.Data/DateOnlyExtensions.cs`）を使う——インライン `ToString` を書かない。
+- **Claude 出力の数値安全性**: `QualitativeNumberGuard` で検証。プロンプト側で単位換算を禁止している（換算による誤検出対策）。
+- **Configure は拡張メソッドに集約**（Core / Data）。Worker は composition root のため `Program.cs` で直接バインドしてよい。
+- プランファイル置き場: `docs/plans/app-trade-analyzer/`

--- a/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
+++ b/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
@@ -117,7 +117,7 @@ public class BacktestService
             // （double.MinValue で黙殺すると未推論銘柄が静かに最下位化し A/B 比較が無言で壊れる）。
             if (useMl && rows.Any(r => r.MlScore is null))
                 throw new InvalidOperationException(
-                    $"{t}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
+                    $"{t.ToIso()}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
                     + " 正しい順序は signals → train → (evaluate) → backtest --use-ml です。");
 
             var picks = SelectTopPicks(rows, _opt.TopN, useMl);

--- a/_Apps/TradeAnalyzer.Data/DateOnlyExtensions.cs
+++ b/_Apps/TradeAnalyzer.Data/DateOnlyExtensions.cs
@@ -1,0 +1,13 @@
+namespace TradeAnalyzer.Data;
+
+/// <summary>
+/// 日付の ISO 8601 文字列化（yyyy-MM-dd）を 1 か所へ集約する。SQL 文字列・CLI 引数・Claude 注入事実・
+/// API クエリ等、機械が読む日付補間はすべてこれを使うこと（culture 未指定の <c>$"{t}"</c> はレビューで
+/// 複数回再発した既知の欠陥クラス）。
+/// DateOnly の "O"（round-trip 指定子）は culture・暦非依存で常にグレゴリオ暦の yyyy-MM-dd を生成するため、
+/// 非グレゴリオ暦カルチャ（th-TH=仏暦等）のホストでも年がずれない（InvariantCulture 明示と出力同一）。
+/// </summary>
+public static class DateOnlyExtensions
+{
+    public static string ToIso(this DateOnly d) => d.ToString("O");
+}

--- a/_Apps/TradeAnalyzer.Data/External/Edinet/EdinetClient.cs
+++ b/_Apps/TradeAnalyzer.Data/External/Edinet/EdinetClient.cs
@@ -35,7 +35,7 @@ public class EdinetClient
     public async Task<List<EdinetDocument>> ListDocumentsAsync(DateOnly date, CancellationToken ct = default)
     {
         // 相対パス（先頭スラッシュ無し）＝ BaseAddress の /api/v2/ を保持させる。
-        var url = $"documents.json?date={Iso(date)}&type=2&{SubscriptionKeyParam}={Key()}";
+        var url = $"documents.json?date={date.ToIso()}&type=2&{SubscriptionKeyParam}={Key()}";
         var resp = await _http.GetFromJsonAsync<EdinetDocumentListResponse>(url, ct).ConfigureAwait(false);
         var results = resp?.Results ?? new();
 
@@ -88,8 +88,6 @@ public class EdinetClient
                 "EDINET Subscription-Key 未設定。`dotnet user-secrets set \"Edinet:SubscriptionKey\" <key>` を実行してください。");
         return Uri.EscapeDataString(_options.SubscriptionKey!);
     }
-
-    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static DateOnly? ParseDate(string? s)
     {

--- a/_Apps/TradeAnalyzer.Data/External/JQuants/JQuantsClient.cs
+++ b/_Apps/TradeAnalyzer.Data/External/JQuants/JQuantsClient.cs
@@ -26,7 +26,7 @@ public class JQuantsClient
         DateOnly? date = null, string? code = null, CancellationToken ct = default)
     {
         var query = new Dictionary<string, string?>();
-        if (date.HasValue) query["date"] = Iso(date.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
         if (code != null) query["code"] = code;
 
         var items = await GetAllPagesAsync<EquityMasterPage, EquityMasterItem>(
@@ -62,9 +62,9 @@ public class JQuantsClient
 
         var query = new Dictionary<string, string?>();
         if (code != null) query["code"] = code;
-        if (date.HasValue) query["date"] = Iso(date.Value);
-        if (from.HasValue) query["from"] = Iso(from.Value);
-        if (to.HasValue) query["to"] = Iso(to.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
+        if (from.HasValue) query["from"] = from.Value.ToIso();
+        if (to.HasValue) query["to"] = to.Value.ToIso();
 
         var items = await GetAllPagesAsync<DailyBarsPage, DailyBarItem>(
             "/v2/equities/bars/daily", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
@@ -95,7 +95,7 @@ public class JQuantsClient
 
         var query = new Dictionary<string, string?>();
         if (code != null) query["code"] = code;
-        if (date.HasValue) query["date"] = Iso(date.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
 
         var items = await GetAllPagesAsync<FinSummaryPage, FinSummaryItem>(
             "/v2/fins/summary", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
@@ -140,7 +140,7 @@ public class JQuantsClient
     public async Task<List<TradingCalendar>> GetCalendarAsync(
         DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        var query = new Dictionary<string, string?> { ["from"] = Iso(from), ["to"] = Iso(to) };
+        var query = new Dictionary<string, string?> { ["from"] = from.ToIso(), ["to"] = to.ToIso() };
         var items = await GetAllPagesAsync<CalendarPage, CalendarItem>(
             "/v2/markets/calendar", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
 
@@ -203,8 +203,6 @@ public class JQuantsClient
             parts.Add($"pagination_key={Uri.EscapeDataString(paginationKey!)}");
         return parts.Count == 0 ? path : $"{path}?{string.Join("&", parts)}";
     }
-
-    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static DateOnly? ParseDate(string? s)
     {

--- a/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
+++ b/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
@@ -67,11 +67,11 @@ internal static class ClaudeFactGatherer
             // 日付は Label でなく Value に置く: Label はコンパイル時定数（許可集合・Flatten の対象外）という
             // 不変条件を保ち、Claude が株価日付を引用しても許可集合（Value 側）で正当化されるようにする。
             new("最新株価（調整後終値）", FmtNum(adjClose, "円", DecimalFmt)),
-            new("株価日付", FmtDate(bar?.Date)),
+            new("株価日付", bar?.Date.ToIso()),
             new("終値（生値）", FmtNum(bar?.Close, "円", DecimalFmt)),
             new("出来高", FmtNum(bar?.Volume, "株")),
             new("売買代金", FmtNum(bar?.TurnoverValue, "円")),
-            new("財務開示日", FmtDate(fin?.DiscloseDate)),
+            new("財務開示日", fin?.DiscloseDate.ToIso()),
             new("書類種別", fin?.DocType),
             new("売上高", FmtNum(fin?.Sales, "円")),
             new("営業利益", FmtNum(fin?.OperatingProfit, "円")),
@@ -106,8 +106,4 @@ internal static class ClaudeFactGatherer
 
     private static string? FmtNum(double? v, string unit, string format = "N0") =>
         v is double d ? d.ToString(format, CultureInfo.InvariantCulture) + " " + unit : null;
-
-    // InvariantCulture 必須: "yyyy" は現在カルチャの暦の年を出すため、非グレゴリオ暦カルチャ（th-TH=仏暦等）の
-    // ホストでは「2569-07-16」等の誤った年を「実データ」として注入してしまう（FmtNum/RuleScore と同じ方針）。
-    private static string? FmtDate(DateOnly? d) => d?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 }

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -13,6 +13,7 @@ using TradeAnalyzer.Data;
 using TradeAnalyzer.Data.Entities;
 using TradeAnalyzer.Data.Options;
 using TradeAnalyzer.Worker.Claude;
+using TradeAnalyzer.Worker.Notify;
 
 namespace TradeAnalyzer.Worker;
 
@@ -38,6 +39,8 @@ public static class Commands
   explain-today                              段階3b 当日定性層: run-today 後の Top-K に実データ注入→Claude 根拠文生成→QualitativeJson 書戻し
           [--date YYYY-MM-DD]                対象日を明示（既定は直近営業日）。要 run-today 済み（MlScore 充足）
           [--force]                          生成済み（QualitativeJson あり）銘柄も再生成（既定は再利用スキップ＝クレジット節約）
+  notify-today                               段階3c 配信ペイロード: 当日 Top-K＋根拠文をチャネル非依存 DTO に組んで整形出力（送信は STEP2）
+          [--date YYYY-MM-DD]                対象日を明示（既定は直近営業日）。要 run-today 済み（MlScore 充足）
   selftest                                   APIキー不要の単体検証（指標/ルール/先読み防止）
 
 例:
@@ -422,6 +425,60 @@ public static class Commands
             else
             {
                 Console.WriteLine("  （Claude 生成なし・ML のみ）");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 段階3c STEP1 配信ペイロード組み立て。run-today（＋任意で explain-today）済みの当日 t の Top-K＋根拠文を
+    /// DB から読み、チャネル非依存の <see cref="DeliveryReport"/> に組んでコンソールへ整形出力する
+    /// （webhook 送信は STEP2 でこの後段に足す）。
+    /// ExitCode 契約は explain-today と逆向き: notify の仕事は「届ける」こと＝沈黙こそ障害。前提破綻
+    /// （Signal 行ゼロ／MlScore=null 混在）は <see cref="DeliveryReportBuilder"/> の throw をここで捕捉せず
+    /// Program.cs の外側 catch に伝播させて ExitCode=1 にする（コマンド内で catch すると ExitCode=0 に化けて
+    /// 契約が逆転する）。Passed=0 は正常（0 件ペイロード・ExitCode=0）＝無通知と故障を区別する。
+    /// </summary>
+    public static async Task NotifyTodayAsync(IServiceProvider sp, string[] args)
+    {
+        var opts = ParseOptions(args);
+        var db = sp.GetRequiredService<AppDbContext>();
+        int topN = sp.GetRequiredService<IOptions<BacktestOptions>>().Value.TopN;
+        var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("notify-today");
+        var timeProvider = sp.GetService<TimeProvider>() ?? TimeProvider.System;
+
+        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝explain-today と同型。パースは RequireDate＝Invariant 明示）。
+        DateOnly t;
+        if (opts.ContainsKey("date"))
+        {
+            t = RequireDate(opts, "date");
+        }
+        else
+        {
+            var today = ResolveTodayJst(timeProvider);
+            t = await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
+        }
+
+        // 2. 配信ペイロード組み立て（前提破綻の throw は捕捉しない＝上記 ExitCode 契約）。
+        var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, topN, logger);
+
+        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。日付は Invariant 明示
+        //    （非グレゴリオ暦カルチャ対策・表示専用）。
+        string tStr = report.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        Console.WriteLine($"=== {tStr} 配信ペイロード（Passed {report.TotalPassed} 件中 Top-{report.Items.Count} 件）===");
+        if (report.Items.Count == 0)
+            Console.WriteLine("本日シグナルなし（0 件通知）。");
+        foreach (var item in report.Items)
+        {
+            Console.WriteLine($"\n#{item.Rank} [{item.Code}] {item.CompanyName ?? "(社名不明)"} MlScore={item.MlScore!.Value:F4} RuleScore={item.RuleScore}");
+            if (item.Qualitative is { } q)
+            {
+                Console.WriteLine($"  要約: {q.Summary}");
+                foreach (var risk in q.Risks) Console.WriteLine($"  リスク: {risk}");
+                if (q.NumericUnverified) Console.WriteLine("  ⚠ numericUnverified（注入外の数値が混入した疑い）");
+            }
+            else
+            {
+                Console.WriteLine("  (定性なし)");
             }
         }
     }

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -266,7 +266,7 @@ public static class Commands
         await RunPythonAsync(pythonOptions.Value, logger, predictScript, new[]
         {
             ("--db", dbPath),
-            ("--date", t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            ("--date", t.ToIso()),
         });
 
         // 5. null 検査＋6. Top-K 読取を AsNoTracking で1回にまとめる。
@@ -279,15 +279,14 @@ public static class Commands
             .ToListAsync();
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
 
         // 6. Top-K 出力。並べ替え／件数は純粋関数 SelectTopPicks（バックテスト picks と同一規則）に共通化し、
         //    本番出力と戦略の乖離を防ぐ（ソートキーの正典は SelectTopPicks の XML doc）。
         //    件数は当日 Top-K＝バックテスト TopN（同一概念。F11 で統合）の単一ノブを使う。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        // 日付は Invariant 明示（explain-today ヘッダと同型。非グレゴリオ暦カルチャ対策・表示専用）。
-        Console.WriteLine($"=== {t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
+        Console.WriteLine($"=== {t.ToIso()} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
         Console.WriteLine($"{"Code",-8} {"MlScore",10} {"RuleScore",9}  Rationale");
         foreach (var s in top)
             Console.WriteLine($"{s.Code,-8} {s.MlScore!.Value,10:F4} {s.RuleScore,9}  {s.Rationale}");
@@ -318,17 +317,8 @@ public static class Commands
         // ExitCode=0 に偽装するのを防ぐ。config 誤設定=fatal／Claude 実行時失敗=非致命）。
         ValidateClaudeConfig(claudeOpt);
 
-        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝run-today と共通ヘルパ）。取引日皆無は前提破綻＝fail-fast。
-        DateOnly t;
-        if (opts.ContainsKey("date"))
-        {
-            t = RequireDate(opts, "date");
-        }
-        else
-        {
-            var today = ResolveTodayJst(timeProvider);
-            t = await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
-        }
+        // 1. 対象日 t の解決（--date 指定 or 直近営業日）。取引日皆無は前提破綻＝fail-fast。
+        var t = await ResolveTargetDateAsync(opts, db, timeProvider);
 
         // 2. 当日 Passed 行を AsNoTracking で読取（run-today と別プロセスなら EF 一次キャッシュの罠は無いが射影で明示）。
         var passed = await db.Signals.AsNoTracking()
@@ -346,7 +336,7 @@ public static class Commands
         // ＝この状態は常にパイプライン障害であり、警告のままだとスケジューラが緑で真の障害が見えない。
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから explain-today を再実行してください。");
 
         // 3. Top-K（run-today と同一の純粋関数で並べ替え）。Claude に回すのは Top-K のみ＝コスト/クレジットを bound。
@@ -398,9 +388,8 @@ public static class Commands
             results[signal.Code] = res;
         }
 
-        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。日付は Invariant 明示（非グレゴリオ暦
-        //    カルチャのホストで年が仏暦等になるのを防ぐ。r4-F4 と同機序・表示専用）。
-        string tStr = t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。
+        string tStr = t.ToIso();
         string keptSuffix = kept > 0 ? $"・保持(再生成失敗) {kept} 件" : "";
         Console.WriteLine($"=== {tStr} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件{keptSuffix}）===");
         foreach (var s in top)
@@ -446,30 +435,20 @@ public static class Commands
         var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("notify-today");
         var timeProvider = sp.GetService<TimeProvider>() ?? TimeProvider.System;
 
-        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝explain-today と同型。パースは RequireDate＝Invariant 明示）。
-        DateOnly t;
-        if (opts.ContainsKey("date"))
-        {
-            t = RequireDate(opts, "date");
-        }
-        else
-        {
-            var today = ResolveTodayJst(timeProvider);
-            t = await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
-        }
+        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝explain-today と共通ヘルパ）。
+        var t = await ResolveTargetDateAsync(opts, db, timeProvider);
 
         // 2. 配信ペイロード組み立て（前提破綻の throw は捕捉しない＝上記 ExitCode 契約）。
         var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, topN, logger);
 
-        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。日付は Invariant 明示
-        //    （非グレゴリオ暦カルチャ対策・表示専用）。
-        string tStr = report.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。
+        string tStr = report.Date.ToIso();
         Console.WriteLine($"=== {tStr} 配信ペイロード（Passed {report.TotalPassed} 件中 Top-{report.Items.Count} 件）===");
         if (report.Items.Count == 0)
             Console.WriteLine("本日シグナルなし（0 件通知）。");
         foreach (var item in report.Items)
         {
-            Console.WriteLine($"\n#{item.Rank} [{item.Code}] {item.CompanyName ?? "(社名不明)"} MlScore={item.MlScore!.Value:F4} RuleScore={item.RuleScore}");
+            Console.WriteLine($"\n#{item.Rank} [{item.Code}] {item.CompanyName ?? "(社名不明)"} MlScore={item.MlScore:F4} RuleScore={item.RuleScore}");
             if (item.Qualitative is { } q)
             {
                 Console.WriteLine($"  要約: {q.Summary}");
@@ -563,6 +542,20 @@ public static class Commands
             throw new InvalidOperationException(
                 "直近10暦日に DailyBar がありません（コールドスタート/DB が10日以上未更新）。" + hint);
         return tradingDays[^1];
+    }
+
+    /// <summary>
+    /// 対象日 t の解決（--date 指定＝RequireDate で Invariant パース or JST 今日から直近営業日）。
+    /// explain-today / notify-today で共有し日付解決仕様のドリフトを防ぐ（run-today は --date 分岐なし・
+    /// ingest 結合・hint 別文言のため対象外）。取引日皆無は ResolveLatestTradingDayAsync が fail-fast。
+    /// </summary>
+    private static async Task<DateOnly> ResolveTargetDateAsync(
+        Dictionary<string, string> opts, AppDbContext db, TimeProvider timeProvider)
+    {
+        if (opts.ContainsKey("date"))
+            return RequireDate(opts, "date");
+        var today = ResolveTodayJst(timeProvider);
+        return await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
     }
 
     // --- 設定検証 ---

--- a/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
+++ b/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TradeAnalyzer.Core.Backtest;
+using TradeAnalyzer.Data;
+
+namespace TradeAnalyzer.Worker.Notify;
+
+/// <summary>
+/// チャネル非依存の配信ペイロード（段階3c）。STEP2 の Discord 整形・STEP3 の REST 応答が共用する唯一の形。
+/// provenance（usedFacts/model/route/generatedAt）は現行要件に表示が無いため意図的に運ばない
+/// （必要になれば record へプロパティ追加で足りる＝内部 DTO のため後方互換問題なし）。
+/// </summary>
+public sealed record DeliveryReport(DateOnly Date, int TotalPassed, IReadOnlyList<DeliveryItem> Items);
+
+/// <summary>Top-K の 1 銘柄分。Qualitative=null は定性なし（ML のみ）＝3b フォールバック契約の下流継承。</summary>
+public sealed record DeliveryItem(
+    string Code, string? CompanyName, int Rank,
+    double? MlScore, double RuleScore, string Rationale,
+    DeliveryQualitative? Qualitative);
+
+/// <summary><see cref="TradeAnalyzer.Data.Entities.Signal.QualitativeJson"/> から抜き出す定性層の表示部分。</summary>
+public sealed record DeliveryQualitative(
+    string Summary, IReadOnlyList<string> Risks, bool NumericUnverified);
+
+/// <summary>
+/// <see cref="DeliveryReport"/> を DB から組み立てる読取専用ビルダ（送信と分離。STEP3 の REST も同じメソッドを呼ぶ）。
+/// 前提破綻の検査をここに 1 か所集約し、呼び手が ExitCode / HTTP 応答へ写像する。
+/// </summary>
+internal static class DeliveryReportBuilder
+{
+    // QualitativeJson は 3b が匿名オブジェクトで保存した camelCase JSON（再利用可能な保存 DTO クラスは無い）。
+    // System.Text.Json 既定は case-sensitive のため、CaseInsensitive を明示しないと "summary"→Summary が不一致で
+    // Summary/Risks=null に「無言で」バインドされ、try-parse では検知できない（要約が空欄のまま通知される）。
+    private static readonly JsonSerializerOptions QualitativeJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    /// <summary>
+    /// 当日 t の Top-K＋根拠文を読み取り配信ペイロードを組む。前提破綻（Signal 行ゼロ／Passed 行に MlScore=null
+    /// 混在）は <see cref="InvalidOperationException"/> で fail-loud——notify-today 経路はコマンド内で捕捉せず
+    /// Program.cs の外側 catch が ExitCode=1 に写像し、STEP3 REST は catch して HTTP 応答へ変換する契約。
+    /// Passed=0 は正常（0 件ペイロード）＝「無通知」と「故障」を区別可能にする。
+    /// null 検査は <see cref="BacktestService.SelectTopPicks"/>(useMl:true) の .Value 前に置く（呼出側検査契約）。
+    /// </summary>
+    public static async Task<DeliveryReport> BuildDeliveryReportAsync(
+        AppDbContext db, DateOnly t, int topN, ILogger logger, CancellationToken ct = default)
+    {
+        // 存在判定（AnyAsync）とデータ取得を分け、小さい Passed 集合のみ材料化する（explain-today の読取と同型）。
+        if (!await db.Signals.AsNoTracking().AnyAsync(s => s.Date == t, ct))
+            throw new InvalidOperationException(
+                $"{t}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
+
+        var passed = await db.Signals.AsNoTracking()
+            .Where(s => s.Date == t && s.Passed)
+            .ToListAsync(ct);
+        if (passed.Any(r => r.MlScore is null))
+            throw new InvalidOperationException(
+                $"{t}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                "run-today を成功させてから再実行してください。");
+
+        var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
+
+        // 会社名: AsOfDate <= t の最新スナップショット（ClaudeFactGatherer と同じ選定規則）。Top-K の code 集合に
+        // 絞り GroupBy 群毎 top-1 の 1 クエリで引く（EF Core 10 で単一 SQL に翻訳される）。
+        var codes = top.Select(s => s.Code).ToList();
+        var names = await db.Stocks.AsNoTracking()
+            .Where(s => codes.Contains(s.Code) && s.AsOfDate <= t)
+            .GroupBy(s => s.Code)
+            .Select(g => new
+            {
+                Code = g.Key,
+                Name = g.OrderByDescending(x => x.AsOfDate).Select(x => x.CompanyName).First(),
+            })
+            .ToDictionaryAsync(x => x.Code, x => x.Name, ct);
+
+        var items = new List<DeliveryItem>(top.Count);
+        for (int i = 0; i < top.Count; i++)
+        {
+            var s = top[i];
+            items.Add(new DeliveryItem(
+                s.Code, names.GetValueOrDefault(s.Code), Rank: i + 1,
+                s.MlScore, s.RuleScore, s.Rationale ?? "",
+                ParseQualitative(s.QualitativeJson, s.Code, logger)));
+        }
+        return new DeliveryReport(t, passed.Count, items);
+    }
+
+    /// <summary>
+    /// QualitativeJson を表示部分へ変換する。null（未生成/失敗）は正常の「定性なし」。構文不正は JsonException を
+    /// 捕捉して警告＋null（1 行の壊れた JSON が通知全体を殺さない）。構文妥当でも summary/risks キー欠落は
+    /// JsonException を投げず非 null 参照型へ null を無言バインドする（System.Text.Json は nullable アノテーション
+    /// 非検証）ため、デシリアライズ後の null 検査で corrupt 扱い＝警告＋null に落とす（?? "" の部分救済は
+    /// 「解析済みだが中身なし」に見えてデータ破損を隠蔽するため不採用）。SelfTest から回帰検証するため internal。
+    /// </summary>
+    internal static DeliveryQualitative? ParseQualitative(string? json, string code, ILogger logger)
+    {
+        if (json is null) return null;
+        try
+        {
+            var q = JsonSerializer.Deserialize<DeliveryQualitative>(json, QualitativeJsonOptions);
+            if (q?.Summary is null || q.Risks is null)
+            {
+                logger.LogWarning("[{Code}] QualitativeJson に summary/risks がありません（破損扱い＝定性なしで配信）。", code);
+                return null;
+            }
+            return q;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "[{Code}] QualitativeJson の解析に失敗しました（破損扱い＝定性なしで配信）。", code);
+            return null;
+        }
+    }
+}

--- a/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
+++ b/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
@@ -13,10 +13,11 @@ namespace TradeAnalyzer.Worker.Notify;
 /// </summary>
 public sealed record DeliveryReport(DateOnly Date, int TotalPassed, IReadOnlyList<DeliveryItem> Items);
 
-/// <summary>Top-K の 1 銘柄分。Qualitative=null は定性なし（ML のみ）＝3b フォールバック契約の下流継承。</summary>
+/// <summary>Top-K の 1 銘柄分。Qualitative=null は定性なし（ML のみ）＝3b フォールバック契約の下流継承。
+/// MlScore は非 null（builder が MlScore=null 混在を throw で排除済み＝消費側に `!` を強いない）。</summary>
 public sealed record DeliveryItem(
     string Code, string? CompanyName, int Rank,
-    double? MlScore, double RuleScore, string Rationale,
+    double MlScore, double RuleScore, string Rationale,
     DeliveryQualitative? Qualitative);
 
 /// <summary><see cref="TradeAnalyzer.Data.Entities.Signal.QualitativeJson"/> から抜き出す定性層の表示部分。</summary>
@@ -47,14 +48,14 @@ internal static class DeliveryReportBuilder
         // 存在判定（AnyAsync）とデータ取得を分け、小さい Passed 集合のみ材料化する（explain-today の読取と同型）。
         if (!await db.Signals.AsNoTracking().AnyAsync(s => s.Date == t, ct))
             throw new InvalidOperationException(
-                $"{t}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
+                $"{t.ToIso()}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
 
         var passed = await db.Signals.AsNoTracking()
             .Where(s => s.Date == t && s.Passed)
             .ToListAsync(ct);
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから再実行してください。");
 
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
@@ -78,7 +79,7 @@ internal static class DeliveryReportBuilder
             var s = top[i];
             items.Add(new DeliveryItem(
                 s.Code, names.GetValueOrDefault(s.Code), Rank: i + 1,
-                s.MlScore, s.RuleScore, s.Rationale ?? "",
+                s.MlScore!.Value, s.RuleScore, s.Rationale ?? "",  // null は上の throw ガードで排除済み
                 ParseQualitative(s.QualitativeJson, s.Code, logger)));
         }
         return new DeliveryReport(t, passed.Count, items);

--- a/_Apps/TradeAnalyzer.Worker/Program.cs
+++ b/_Apps/TradeAnalyzer.Worker/Program.cs
@@ -69,6 +69,9 @@ try
         case "explain-today":
             await Commands.ExplainTodayAsync(sp, args);
             break;
+        case "notify-today":
+            await Commands.NotifyTodayAsync(sp, args);
+            break;
         case "selftest":
             await SelfTest.RunAsync();
             break;

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -19,6 +19,7 @@ using TradeAnalyzer.Data.External.Edinet;
 using TradeAnalyzer.Data.External.JQuants;
 using TradeAnalyzer.Data.Options;
 using TradeAnalyzer.Worker.Claude;
+using TradeAnalyzer.Worker.Notify;
 
 namespace TradeAnalyzer.Worker;
 
@@ -51,6 +52,7 @@ public static class SelfTest
         failed += RunClaudePromptFlattenTests();
         failed += RunParseModelOutputTests();
         failed += RunExtractErrorInfoTests();
+        failed += RunParseQualitativeTests();
         failed += await RunAsNoTrackingReflectsUpdateTestAsync();
         failed += await RunEdinetMetaCollisionTestAsync();
         failed += RunResolveTodayJstTests();
@@ -708,6 +710,41 @@ public static class SelfTest
         var fake2 = new FakeTimeProvider(new DateTimeOffset(2025, 6, 27, 2, 0, 0, TimeSpan.Zero));
         f += Assert("ResolveTodayJst: UTC 02:00 → JST 同日(2025-06-27)",
             Commands.ResolveTodayJst(fake2) == new DateOnly(2025, 6, 27));
+        return f;
+    }
+
+    /// <summary>
+    /// 3c STEP1: DeliveryReportBuilder.ParseQualitative の回帰。3b の保存 JSON は camelCase＝case-insensitive
+    /// 明示が効いていること（既定 case-sensitive なら Summary=null で corrupt 扱いになり正常系が FAIL）、
+    /// 構文不正の警告降格、構文妥当でも summary/risks キー欠落は JsonException なしで null バインドされるため
+    /// デシリアライズ後の null 検査で corrupt 扱いになること、を固定する。
+    /// </summary>
+    private static int RunParseQualitativeTests()
+    {
+        int f = 0;
+        var logger = NullLogger.Instance;
+
+        // 正常系: 3b が保存する camelCase＋余剰 provenance キー（usedFacts 等）を読める。
+        var ok = DeliveryReportBuilder.ParseQualitative(
+            "{\"summary\":\"S\",\"risks\":[\"R1\",\"R2\"],\"usedFacts\":[\"F\"],\"model\":\"m\",\"route\":\"cli\"," +
+            "\"generatedAt\":\"2026-07-21T18:00:00+09:00\",\"numericUnverified\":true}",
+            "AAA", logger);
+        f += Assert("ParseQualitative: camelCase 正常系（summary/risks/numericUnverified 復元）",
+            ok is { Summary: "S", NumericUnverified: true } && ok.Risks.SequenceEqual(new[] { "R1", "R2" }));
+
+        // null（未生成/失敗）＝正常の「定性なし」。
+        f += Assert("ParseQualitative: null → null（定性なし）",
+            DeliveryReportBuilder.ParseQualitative(null, "AAA", logger) == null);
+
+        // 構文不正 → JsonException 捕捉で null（1 行の破損が通知全体を殺さない）。
+        f += Assert("ParseQualitative: 構文不正 → null",
+            DeliveryReportBuilder.ParseQualitative("{broken", "AAA", logger) == null);
+
+        // キー欠落は JsonException を投げず非 null 参照型へ null バインドされる → null 検査で corrupt 扱い。
+        f += Assert("ParseQualitative: summary 欠落 → null（corrupt 扱い）",
+            DeliveryReportBuilder.ParseQualitative("{\"risks\":[\"R\"]}", "AAA", logger) == null);
+        f += Assert("ParseQualitative: risks 欠落 → null（corrupt 扱い）",
+            DeliveryReportBuilder.ParseQualitative("{\"summary\":\"S\"}", "AAA", logger) == null);
         return f;
     }
 

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
@@ -53,6 +52,7 @@ public static class SelfTest
         failed += RunParseModelOutputTests();
         failed += RunExtractErrorInfoTests();
         failed += RunParseQualitativeTests();
+        failed += await RunBuildDeliveryReportTestsAsync();
         failed += await RunAsNoTrackingReflectsUpdateTestAsync();
         failed += await RunEdinetMetaCollisionTestAsync();
         failed += RunResolveTodayJstTests();
@@ -593,7 +593,7 @@ public static class SelfTest
             // Python 書戻しを模した生 SQL UPDATE（C# の追跡外で MlScore を埋める経路）。DateOnly は TEXT(yyyy-MM-dd)。
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}' AND Code = 'AAA'";
+                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToIso()}' AND Code = 'AAA'";
                 f += Assert("AsNoTracking 罠: 生 SQL UPDATE が 1 行", cmd.ExecuteNonQuery() == 1);
             }
 
@@ -745,6 +745,90 @@ public static class SelfTest
             DeliveryReportBuilder.ParseQualitative("{\"risks\":[\"R\"]}", "AAA", logger) == null);
         f += Assert("ParseQualitative: risks 欠落 → null（corrupt 扱い）",
             DeliveryReportBuilder.ParseQualitative("{\"summary\":\"S\"}", "AAA", logger) == null);
+        return f;
+    }
+
+    /// <summary>
+    /// 3c STEP1: DeliveryReportBuilder.BuildDeliveryReportAsync の回帰。前提破綻 throw 2 経路
+    /// （Signal 行ゼロ／Passed 行に MlScore=null 混在）、Signal 行ありかつ Passed=0 の正常 0 件ペイロード
+    /// （無通知と故障の区別）、正常系（会社名 GroupBy 群毎 top-1 クエリの SQLite 翻訳可否・
+    /// AsOfDate&lt;=t の最新スナップショット選定・MlScore 降順 Rank・TotalPassed）を固定する。
+    /// </summary>
+    private static async Task<int> RunBuildDeliveryReportTestsAsync()
+    {
+        int f = 0;
+        var logger = NullLogger.Instance;
+        var t = new DateOnly(2026, 7, 1);
+
+        // (a) Signal 行ゼロ → throw（run-today 未実行/未完了の fail-loud）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                bool threw = false;
+                try { await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger); }
+                catch (InvalidOperationException) { threw = true; }
+                f += Assert("BuildDeliveryReport: Signal 行ゼロ → throw", threw);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // (b) Passed 行に MlScore=null 混在 → throw（ML 採点未完了＝パイプライン障害の fail-loud）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                db.Signals.Add(new Signal { Date = t, Code = "AAA", Passed = true, MlScore = null, RuleScore = 1 });
+                await db.SaveChangesAsync();
+                bool threw = false;
+                try { await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger); }
+                catch (InvalidOperationException) { threw = true; }
+                f += Assert("BuildDeliveryReport: MlScore=null 混在 → throw", threw);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // (c) Signal 行ありかつ Passed=0 → 0 件ペイロード（throw しない＝全面下落局面の正常全滅）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                db.Signals.Add(new Signal { Date = t, Code = "AAA", Passed = false, RuleScore = 0 });
+                await db.SaveChangesAsync();
+                var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger);
+                f += Assert("BuildDeliveryReport: Passed=0 → Items=0/TotalPassed=0（throw しない）",
+                    report.Items.Count == 0 && report.TotalPassed == 0);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // (d) 正常系: Stocks スナップショット複数世代（AsOfDate<=t の最新が選ばれ、未来世代は無視される）＋
+        //     MlScore 降順の Rank 採番＋TotalPassed。GroupBy 群毎 top-1 クエリの SQLite 翻訳可否も同時に固定。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                db.Signals.AddRange(
+                    new Signal { Date = t, Code = "AAA", Passed = true, MlScore = 0.9, RuleScore = 3, Rationale = "rA" },
+                    new Signal { Date = t, Code = "BBB", Passed = true, MlScore = 0.5, RuleScore = 2, Rationale = "rB" });
+                db.Stocks.AddRange(
+                    new Stock { Code = "AAA", AsOfDate = t.AddDays(-10), CompanyName = "旧社名" },
+                    new Stock { Code = "AAA", AsOfDate = t.AddDays(-1), CompanyName = "新社名" },
+                    new Stock { Code = "AAA", AsOfDate = t.AddDays(1), CompanyName = "未来社名" },
+                    new Stock { Code = "BBB", AsOfDate = t, CompanyName = "B社" });
+                await db.SaveChangesAsync();
+
+                var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger);
+                f += Assert("BuildDeliveryReport: TotalPassed=2/Items=2",
+                    report.TotalPassed == 2 && report.Items.Count == 2);
+                f += Assert("BuildDeliveryReport: MlScore 降順 Rank（AAA=1, BBB=2）",
+                    report.Items[0] is { Code: "AAA", Rank: 1, MlScore: 0.9 }
+                    && report.Items[1] is { Code: "BBB", Rank: 2, MlScore: 0.5 });
+                f += Assert("BuildDeliveryReport: 会社名は AsOfDate<=t の最新（未来世代は無視）",
+                    report.Items[0].CompanyName == "新社名" && report.Items[1].CompanyName == "B社");
+            }
+            finally { conn.Dispose(); }
+        }
         return f;
     }
 


### PR DESCRIPTION
## 概要

段階3c STEP1（プラン: `docs/plans/app-trade-analyzer/quiet-copper-relay-step1-payload.md`）。
新コマンド `notify-today` を追加し、当日 t の Top-K＋根拠文を DB から読んでチャネル非依存 DTO に組み、コンソールへ整形出力する。**送信は含まない**（Discord webhook は STEP2）。

## 実装内容

- **新規 `Notify/NotifyModels.cs`**: `DeliveryReport` / `DeliveryItem` / `DeliveryQualitative`（STEP2 Discord 整形・STEP3 REST 応答が共用する唯一の形。provenance は意図的に運ばない＝2026-07-22 ユーザー決定）＋ `DeliveryReportBuilder.BuildDeliveryReportAsync`（送信と分離した読取専用ビルダ。前提破綻検査を 1 か所集約し throw 方式＝2026-07-22 ユーザー決定）
- **QualitativeJson 読取**: 3b 保存の camelCase に対し `PropertyNameCaseInsensitive` 明示（既定 case-sensitive だと無言 null バインド）。構文妥当でも summary/risks キー欠落は JsonException が出ないため、デシリアライズ後 null 検査で corrupt 扱い（案A採用・部分救済は破損隠蔽のため不採用）。破損行は警告＋当該銘柄のみ「(定性なし)」降格
- **`Commands.NotifyTodayAsync`**: t 解決（`--date` は Invariant パース／既定は直近営業日）→ builder → 整形出力（explain-today 体裁＋rank/社名追加）。builder の throw はコマンド内で捕捉せず Program.cs 外側 catch に伝播（**ExitCode 契約が explain-today と逆向き**: 前提破綻=1・Passed=0 は正常 0 件=0）
- **会社名**: `AsOfDate <= t` 最新スナップショットを Top-K code 集合の GroupBy 群毎 top-1 の 1 クエリで取得
- **SelfTest**: `ParseQualitative` 回帰 5 件追加（正常系 camelCase／null／構文不正／summary 欠落／risks 欠落）
- 残 Nit 3 件（AnyAsync 2 クエリ分割・static readonly JsonSerializerOptions）も反映済み

## 検証

| シナリオ | 結果 |
|---|---|
| 定性あり日 `--date 2026-07-17` | summary/risks/numericUnverified 表示・ExitCode=0 ✅ |
| 定性なし日（直近 2026-07-21） | 全銘柄「(定性なし)」・ExitCode=0 ✅ |
| Signal 皆無日 `--date 2020-01-06` | LogError＋ExitCode=1 ✅ |
| 破損 JSON（構文破壊／キー欠落） | SelfTest ParseQualitative で固定 ✅ |
| selftest | 全テスト PASS ✅ |

既存コマンドは無改変（Program.cs switch と PrintUsage への追記のみ）。