### PR TITLE
fix(trade-analyzer): notify-today STEP1 レビュー修正 Round 1（F1-F3+N1）

### DIFF
--- a/_Apps/CLAUDE.md
+++ b/_Apps/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+このファイルは `_Apps` 配下（app-trade-analyzer ブランチ固有）で作業する際のガイド。
+
+## 概要
+
+TradeAnalyzer は日本株の「データ取得 → ルール/ML シグナル → バックテスト → 当日 EOD 推論 → Claude 定性根拠 → 配信」を行う CLI アプリ。TBird.* を参照しない独立 net10.0 複数プロジェクト構成（TBirdObject 継承・命名規則等の全体共通ルールは適用外。詳細はルート CLAUDE.md「独立アプリ例外」参照）。
+
+## 構成
+
+- `TradeAnalyzer.Data` — EF Core (SQLite) エンティティ / マイグレーション、外部 API クライアント（J-Quants / EDINET）、`AppPaths`（実行時パス解決）
+- `TradeAnalyzer.Core` — テクニカル指標、ルールエンジン、ingest、バックテスト
+- `TradeAnalyzer.Worker` — CLI エントリ（composition root）、Claude 定性層（`claude -p` 直結）、Python 採点連携（`ProcessRunner`）、`SelfTest`
+- `ml/` — Python 側 ML（LightGBM LambdaRank）。uv 管理（`pyproject.toml` / `uv.lock`、`.venv` は追跡外）。詳細は [ml/README.md](ml/README.md)
+- `scripts/` — 運用 PowerShell（`run-today.ps1` / `explain-today.ps1` / `retrain.ps1`。タスクスケジューラ登録前提）
+
+## ビルド・実行
+
+```bash
+dotnet build _Apps/App.sln
+dotnet run --project _Apps/TradeAnalyzer.Worker -- <command>
+```
+
+コマンド一覧と引数は `Commands.PrintUsage`（引数なし実行で表示）が正。概要:
+
+- `migrate` / `ingest` / `analyze` / `signals` / `backtest` — 段階1〜2（履歴データ・検証）
+- `run-today` — 段階3a: 当日 EOD 推論（ingest → analyze → Python 採点 → Top-K）
+- `explain-today` — 段階3b: Claude 根拠文生成 → `QualitativeJson` 書戻し
+- `notify-today` — 段階3c: 配信ペイロード組み立て
+- `selftest` — APIキー不要の単体検証（指標 / ルール / 先読み防止 / パーサ回帰）
+- `stats` — DB テーブル行数等の確認
+
+## 実行時状態（git 追跡外）
+
+置き場はルート CLAUDE.md のルール通り `_Tools/TradeAnalyzer/`:
+`trade.db` / `Secrets.json`（APIキー）/ `ml/models` / `logs` / bin・obj（`Directory.Build.props` の ArtifactsPath）。
+パス解決は `TradeAnalyzer.Data/AppPaths.cs`（CWD 非依存。環境変数 `TRADEANALYZER_DATA_DIR` で上書き可）。
+
+## 重要な規約
+
+- **ExitCode 契約が段階で逆向き**: `explain-today` は Claude 実行時失敗を非致命スキップ（データ前提未達のみ ExitCode=1）。`notify-today` は「届ける」ことが仕事のため送信系失敗＝ExitCode=1、Passed=0 は正常（0 件ペイロード・ExitCode=0）。コマンド内で catch して契約を潰さないこと。
+- **文字列化は InvariantCulture**: 日付・数値の補間（SQL 文字列・CLI 引数含む）は culture 明示。過去レビューで複数回再発した箇所。例外: 表示専用の数値書式（Console 出力の `:F4` 等）は CurrentCulture 容認（日付は表示でも Invariant 明示）。
+- **Claude 出力の数値安全性**: `QualitativeNumberGuard` で検証。プロンプト側で単位換算を禁止している（換算による誤検出対策）。
+- **Configure は拡張メソッドに集約**（Core / Data）。Worker は composition root のため `Program.cs` で直接バインドしてよい。
+- プランファイル置き場: `docs/plans/app-trade-analyzer/`

--- a/_Apps/CLAUDE.md
+++ b/_Apps/CLAUDE.md
@@ -39,7 +39,7 @@ dotnet run --project _Apps/TradeAnalyzer.Worker -- <command>
 ## 重要な規約
 
 - **ExitCode 契約が段階で逆向き**: `explain-today` は Claude 実行時失敗を非致命スキップ（データ前提未達のみ ExitCode=1）。`notify-today` は「届ける」ことが仕事のため送信系失敗＝ExitCode=1、Passed=0 は正常（0 件ペイロード・ExitCode=0）。コマンド内で catch して契約を潰さないこと。
-- **文字列化は InvariantCulture**: 日付・数値の補間（SQL 文字列・CLI 引数含む）は culture 明示。過去レビューで複数回再発した箇所。例外: 表示専用の数値書式（Console 出力の `:F4` 等）は CurrentCulture 容認（日付は表示でも Invariant 明示）。
+- **文字列化は InvariantCulture**: 日付・数値の補間（SQL 文字列・CLI 引数含む）は culture 明示。過去レビューで複数回再発した箇所。例外: 表示専用の数値書式（Console 出力の `:F4` 等）は CurrentCulture 容認（日付は表示でも Invariant 明示）。日付の yyyy-MM-dd 文字列化は `ToIso()`（`TradeAnalyzer.Data/DateOnlyExtensions.cs`）を使う——インライン `ToString` を書かない。
 - **Claude 出力の数値安全性**: `QualitativeNumberGuard` で検証。プロンプト側で単位換算を禁止している（換算による誤検出対策）。
 - **Configure は拡張メソッドに集約**（Core / Data）。Worker は composition root のため `Program.cs` で直接バインドしてよい。
 - プランファイル置き場: `docs/plans/app-trade-analyzer/`

--- a/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
+++ b/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -118,7 +117,7 @@ public class BacktestService
             // （double.MinValue で黙殺すると未推論銘柄が静かに最下位化し A/B 比較が無言で壊れる）。
             if (useMl && rows.Any(r => r.MlScore is null))
                 throw new InvalidOperationException(
-                    $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
+                    $"{t.ToIso()}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
                     + " 正しい順序は signals → train → (evaluate) → backtest --use-ml です。");
 
             var picks = SelectTopPicks(rows, _opt.TopN, useMl);

--- a/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
+++ b/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -117,7 +118,7 @@ public class BacktestService
             // （double.MinValue で黙殺すると未推論銘柄が静かに最下位化し A/B 比較が無言で壊れる）。
             if (useMl && rows.Any(r => r.MlScore is null))
                 throw new InvalidOperationException(
-                    $"{t}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
+                    $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
                     + " 正しい順序は signals → train → (evaluate) → backtest --use-ml です。");
 
             var picks = SelectTopPicks(rows, _opt.TopN, useMl);

--- a/_Apps/TradeAnalyzer.Data/DateOnlyExtensions.cs
+++ b/_Apps/TradeAnalyzer.Data/DateOnlyExtensions.cs
@@ -1,0 +1,13 @@
+namespace TradeAnalyzer.Data;
+
+/// <summary>
+/// 日付の ISO 8601 文字列化（yyyy-MM-dd）を 1 か所へ集約する。SQL 文字列・CLI 引数・Claude 注入事実・
+/// API クエリ等、機械が読む日付補間はすべてこれを使うこと（culture 未指定の <c>$"{t}"</c> はレビューで
+/// 複数回再発した既知の欠陥クラス）。
+/// DateOnly の "O"（round-trip 指定子）は culture・暦非依存で常にグレゴリオ暦の yyyy-MM-dd を生成するため、
+/// 非グレゴリオ暦カルチャ（th-TH=仏暦等）のホストでも年がずれない（InvariantCulture 明示と出力同一）。
+/// </summary>
+public static class DateOnlyExtensions
+{
+    public static string ToIso(this DateOnly d) => d.ToString("O");
+}

--- a/_Apps/TradeAnalyzer.Data/External/Edinet/EdinetClient.cs
+++ b/_Apps/TradeAnalyzer.Data/External/Edinet/EdinetClient.cs
@@ -35,7 +35,7 @@ public class EdinetClient
     public async Task<List<EdinetDocument>> ListDocumentsAsync(DateOnly date, CancellationToken ct = default)
     {
         // 相対パス（先頭スラッシュ無し）＝ BaseAddress の /api/v2/ を保持させる。
-        var url = $"documents.json?date={Iso(date)}&type=2&{SubscriptionKeyParam}={Key()}";
+        var url = $"documents.json?date={date.ToIso()}&type=2&{SubscriptionKeyParam}={Key()}";
         var resp = await _http.GetFromJsonAsync<EdinetDocumentListResponse>(url, ct).ConfigureAwait(false);
         var results = resp?.Results ?? new();
 
@@ -88,8 +88,6 @@ public class EdinetClient
                 "EDINET Subscription-Key 未設定。`dotnet user-secrets set \"Edinet:SubscriptionKey\" <key>` を実行してください。");
         return Uri.EscapeDataString(_options.SubscriptionKey!);
     }
-
-    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static DateOnly? ParseDate(string? s)
     {

--- a/_Apps/TradeAnalyzer.Data/External/JQuants/JQuantsClient.cs
+++ b/_Apps/TradeAnalyzer.Data/External/JQuants/JQuantsClient.cs
@@ -26,7 +26,7 @@ public class JQuantsClient
         DateOnly? date = null, string? code = null, CancellationToken ct = default)
     {
         var query = new Dictionary<string, string?>();
-        if (date.HasValue) query["date"] = Iso(date.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
         if (code != null) query["code"] = code;
 
         var items = await GetAllPagesAsync<EquityMasterPage, EquityMasterItem>(
@@ -62,9 +62,9 @@ public class JQuantsClient
 
         var query = new Dictionary<string, string?>();
         if (code != null) query["code"] = code;
-        if (date.HasValue) query["date"] = Iso(date.Value);
-        if (from.HasValue) query["from"] = Iso(from.Value);
-        if (to.HasValue) query["to"] = Iso(to.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
+        if (from.HasValue) query["from"] = from.Value.ToIso();
+        if (to.HasValue) query["to"] = to.Value.ToIso();
 
         var items = await GetAllPagesAsync<DailyBarsPage, DailyBarItem>(
             "/v2/equities/bars/daily", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
@@ -95,7 +95,7 @@ public class JQuantsClient
 
         var query = new Dictionary<string, string?>();
         if (code != null) query["code"] = code;
-        if (date.HasValue) query["date"] = Iso(date.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
 
         var items = await GetAllPagesAsync<FinSummaryPage, FinSummaryItem>(
             "/v2/fins/summary", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
@@ -140,7 +140,7 @@ public class JQuantsClient
     public async Task<List<TradingCalendar>> GetCalendarAsync(
         DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        var query = new Dictionary<string, string?> { ["from"] = Iso(from), ["to"] = Iso(to) };
+        var query = new Dictionary<string, string?> { ["from"] = from.ToIso(), ["to"] = to.ToIso() };
         var items = await GetAllPagesAsync<CalendarPage, CalendarItem>(
             "/v2/markets/calendar", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
 
@@ -203,8 +203,6 @@ public class JQuantsClient
             parts.Add($"pagination_key={Uri.EscapeDataString(paginationKey!)}");
         return parts.Count == 0 ? path : $"{path}?{string.Join("&", parts)}";
     }
-
-    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static DateOnly? ParseDate(string? s)
     {

--- a/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
+++ b/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
@@ -67,11 +67,11 @@ internal static class ClaudeFactGatherer
             // 日付は Label でなく Value に置く: Label はコンパイル時定数（許可集合・Flatten の対象外）という
             // 不変条件を保ち、Claude が株価日付を引用しても許可集合（Value 側）で正当化されるようにする。
             new("最新株価（調整後終値）", FmtNum(adjClose, "円", DecimalFmt)),
-            new("株価日付", FmtDate(bar?.Date)),
+            new("株価日付", bar?.Date.ToIso()),
             new("終値（生値）", FmtNum(bar?.Close, "円", DecimalFmt)),
             new("出来高", FmtNum(bar?.Volume, "株")),
             new("売買代金", FmtNum(bar?.TurnoverValue, "円")),
-            new("財務開示日", FmtDate(fin?.DiscloseDate)),
+            new("財務開示日", fin?.DiscloseDate.ToIso()),
             new("書類種別", fin?.DocType),
             new("売上高", FmtNum(fin?.Sales, "円")),
             new("営業利益", FmtNum(fin?.OperatingProfit, "円")),
@@ -106,8 +106,4 @@ internal static class ClaudeFactGatherer
 
     private static string? FmtNum(double? v, string unit, string format = "N0") =>
         v is double d ? d.ToString(format, CultureInfo.InvariantCulture) + " " + unit : null;
-
-    // InvariantCulture 必須: "yyyy" は現在カルチャの暦の年を出すため、非グレゴリオ暦カルチャ（th-TH=仏暦等）の
-    // ホストでは「2569-07-16」等の誤った年を「実データ」として注入してしまう（FmtNum/RuleScore と同じ方針）。
-    private static string? FmtDate(DateOnly? d) => d?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 }

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -279,7 +279,7 @@ public static class Commands
             .ToListAsync();
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
+                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
 
         // 6. Top-K 出力。並べ替え／件数は純粋関数 SelectTopPicks（バックテスト picks と同一規則）に共通化し、
         //    本番出力と戦略の乖離を防ぐ（ソートキーの正典は SelectTopPicks の XML doc）。
@@ -318,17 +318,8 @@ public static class Commands
         // ExitCode=0 に偽装するのを防ぐ。config 誤設定=fatal／Claude 実行時失敗=非致命）。
         ValidateClaudeConfig(claudeOpt);
 
-        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝run-today と共通ヘルパ）。取引日皆無は前提破綻＝fail-fast。
-        DateOnly t;
-        if (opts.ContainsKey("date"))
-        {
-            t = RequireDate(opts, "date");
-        }
-        else
-        {
-            var today = ResolveTodayJst(timeProvider);
-            t = await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
-        }
+        // 1. 対象日 t の解決（--date 指定 or 直近営業日）。取引日皆無は前提破綻＝fail-fast。
+        var t = await ResolveTargetDateAsync(opts, db, timeProvider);
 
         // 2. 当日 Passed 行を AsNoTracking で読取（run-today と別プロセスなら EF 一次キャッシュの罠は無いが射影で明示）。
         var passed = await db.Signals.AsNoTracking()
@@ -346,7 +337,7 @@ public static class Commands
         // ＝この状態は常にパイプライン障害であり、警告のままだとスケジューラが緑で真の障害が見えない。
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから explain-today を再実行してください。");
 
         // 3. Top-K（run-today と同一の純粋関数で並べ替え）。Claude に回すのは Top-K のみ＝コスト/クレジットを bound。
@@ -446,17 +437,8 @@ public static class Commands
         var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("notify-today");
         var timeProvider = sp.GetService<TimeProvider>() ?? TimeProvider.System;
 
-        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝explain-today と同型。パースは RequireDate＝Invariant 明示）。
-        DateOnly t;
-        if (opts.ContainsKey("date"))
-        {
-            t = RequireDate(opts, "date");
-        }
-        else
-        {
-            var today = ResolveTodayJst(timeProvider);
-            t = await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
-        }
+        // 1. 対象日 t の解決（--date 指定 or 直近営業日＝explain-today と共通ヘルパ）。
+        var t = await ResolveTargetDateAsync(opts, db, timeProvider);
 
         // 2. 配信ペイロード組み立て（前提破綻の throw は捕捉しない＝上記 ExitCode 契約）。
         var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, topN, logger);
@@ -469,7 +451,7 @@ public static class Commands
             Console.WriteLine("本日シグナルなし（0 件通知）。");
         foreach (var item in report.Items)
         {
-            Console.WriteLine($"\n#{item.Rank} [{item.Code}] {item.CompanyName ?? "(社名不明)"} MlScore={item.MlScore!.Value:F4} RuleScore={item.RuleScore}");
+            Console.WriteLine($"\n#{item.Rank} [{item.Code}] {item.CompanyName ?? "(社名不明)"} MlScore={item.MlScore:F4} RuleScore={item.RuleScore}");
             if (item.Qualitative is { } q)
             {
                 Console.WriteLine($"  要約: {q.Summary}");
@@ -563,6 +545,20 @@ public static class Commands
             throw new InvalidOperationException(
                 "直近10暦日に DailyBar がありません（コールドスタート/DB が10日以上未更新）。" + hint);
         return tradingDays[^1];
+    }
+
+    /// <summary>
+    /// 対象日 t の解決（--date 指定＝RequireDate で Invariant パース or JST 今日から直近営業日）。
+    /// explain-today / notify-today で共有し日付解決仕様のドリフトを防ぐ（run-today は --date 分岐なし・
+    /// ingest 結合・hint 別文言のため対象外）。取引日皆無は ResolveLatestTradingDayAsync が fail-fast。
+    /// </summary>
+    private static async Task<DateOnly> ResolveTargetDateAsync(
+        Dictionary<string, string> opts, AppDbContext db, TimeProvider timeProvider)
+    {
+        if (opts.ContainsKey("date"))
+            return RequireDate(opts, "date");
+        var today = ResolveTodayJst(timeProvider);
+        return await ResolveLatestTradingDayAsync(db, today, "run-today 済みの DB が前提です。");
     }
 
     // --- 設定検証 ---

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -266,7 +266,7 @@ public static class Commands
         await RunPythonAsync(pythonOptions.Value, logger, predictScript, new[]
         {
             ("--db", dbPath),
-            ("--date", t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            ("--date", t.ToIso()),
         });
 
         // 5. null 検査＋6. Top-K 読取を AsNoTracking で1回にまとめる。
@@ -279,15 +279,14 @@ public static class Commands
             .ToListAsync();
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
 
         // 6. Top-K 出力。並べ替え／件数は純粋関数 SelectTopPicks（バックテスト picks と同一規則）に共通化し、
         //    本番出力と戦略の乖離を防ぐ（ソートキーの正典は SelectTopPicks の XML doc）。
         //    件数は当日 Top-K＝バックテスト TopN（同一概念。F11 で統合）の単一ノブを使う。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        // 日付は Invariant 明示（explain-today ヘッダと同型。非グレゴリオ暦カルチャ対策・表示専用）。
-        Console.WriteLine($"=== {t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
+        Console.WriteLine($"=== {t.ToIso()} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
         Console.WriteLine($"{"Code",-8} {"MlScore",10} {"RuleScore",9}  Rationale");
         foreach (var s in top)
             Console.WriteLine($"{s.Code,-8} {s.MlScore!.Value,10:F4} {s.RuleScore,9}  {s.Rationale}");
@@ -337,7 +336,7 @@ public static class Commands
         // ＝この状態は常にパイプライン障害であり、警告のままだとスケジューラが緑で真の障害が見えない。
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから explain-today を再実行してください。");
 
         // 3. Top-K（run-today と同一の純粋関数で並べ替え）。Claude に回すのは Top-K のみ＝コスト/クレジットを bound。
@@ -389,9 +388,8 @@ public static class Commands
             results[signal.Code] = res;
         }
 
-        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。日付は Invariant 明示（非グレゴリオ暦
-        //    カルチャのホストで年が仏暦等になるのを防ぐ。r4-F4 と同機序・表示専用）。
-        string tStr = t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。
+        string tStr = t.ToIso();
         string keptSuffix = kept > 0 ? $"・保持(再生成失敗) {kept} 件" : "";
         Console.WriteLine($"=== {tStr} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件{keptSuffix}）===");
         foreach (var s in top)
@@ -443,9 +441,8 @@ public static class Commands
         // 2. 配信ペイロード組み立て（前提破綻の throw は捕捉しない＝上記 ExitCode 契約）。
         var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, topN, logger);
 
-        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。日付は Invariant 明示
-        //    （非グレゴリオ暦カルチャ対策・表示専用）。
-        string tStr = report.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。
+        string tStr = report.Date.ToIso();
         Console.WriteLine($"=== {tStr} 配信ペイロード（Passed {report.TotalPassed} 件中 Top-{report.Items.Count} 件）===");
         if (report.Items.Count == 0)
             Console.WriteLine("本日シグナルなし（0 件通知）。");

--- a/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
+++ b/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -49,14 +48,14 @@ internal static class DeliveryReportBuilder
         // 存在判定（AnyAsync）とデータ取得を分け、小さい Passed 集合のみ材料化する（explain-today の読取と同型）。
         if (!await db.Signals.AsNoTracking().AnyAsync(s => s.Date == t, ct))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
+                $"{t.ToIso()}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
 
         var passed = await db.Signals.AsNoTracking()
             .Where(s => s.Date == t && s.Passed)
             .ToListAsync(ct);
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから再実行してください。");
 
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);

--- a/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
+++ b/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -13,10 +14,11 @@ namespace TradeAnalyzer.Worker.Notify;
 /// </summary>
 public sealed record DeliveryReport(DateOnly Date, int TotalPassed, IReadOnlyList<DeliveryItem> Items);
 
-/// <summary>Top-K の 1 銘柄分。Qualitative=null は定性なし（ML のみ）＝3b フォールバック契約の下流継承。</summary>
+/// <summary>Top-K の 1 銘柄分。Qualitative=null は定性なし（ML のみ）＝3b フォールバック契約の下流継承。
+/// MlScore は非 null（builder が MlScore=null 混在を throw で排除済み＝消費側に `!` を強いない）。</summary>
 public sealed record DeliveryItem(
     string Code, string? CompanyName, int Rank,
-    double? MlScore, double RuleScore, string Rationale,
+    double MlScore, double RuleScore, string Rationale,
     DeliveryQualitative? Qualitative);
 
 /// <summary><see cref="TradeAnalyzer.Data.Entities.Signal.QualitativeJson"/> から抜き出す定性層の表示部分。</summary>
@@ -47,14 +49,14 @@ internal static class DeliveryReportBuilder
         // 存在判定（AnyAsync）とデータ取得を分け、小さい Passed 集合のみ材料化する（explain-today の読取と同型）。
         if (!await db.Signals.AsNoTracking().AnyAsync(s => s.Date == t, ct))
             throw new InvalidOperationException(
-                $"{t}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
+                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
 
         var passed = await db.Signals.AsNoTracking()
             .Where(s => s.Date == t && s.Passed)
             .ToListAsync(ct);
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから再実行してください。");
 
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
@@ -78,7 +80,7 @@ internal static class DeliveryReportBuilder
             var s = top[i];
             items.Add(new DeliveryItem(
                 s.Code, names.GetValueOrDefault(s.Code), Rank: i + 1,
-                s.MlScore, s.RuleScore, s.Rationale ?? "",
+                s.MlScore!.Value, s.RuleScore, s.Rationale ?? "",  // null は上の throw ガードで排除済み
                 ParseQualitative(s.QualitativeJson, s.Code, logger)));
         }
         return new DeliveryReport(t, passed.Count, items);

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
@@ -594,7 +593,7 @@ public static class SelfTest
             // Python 書戻しを模した生 SQL UPDATE（C# の追跡外で MlScore を埋める経路）。DateOnly は TEXT(yyyy-MM-dd)。
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}' AND Code = 'AAA'";
+                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToIso()}' AND Code = 'AAA'";
                 f += Assert("AsNoTracking 罠: 生 SQL UPDATE が 1 行", cmd.ExecuteNonQuery() == 1);
             }
 

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -53,6 +53,7 @@ public static class SelfTest
         failed += RunParseModelOutputTests();
         failed += RunExtractErrorInfoTests();
         failed += RunParseQualitativeTests();
+        failed += await RunBuildDeliveryReportTestsAsync();
         failed += await RunAsNoTrackingReflectsUpdateTestAsync();
         failed += await RunEdinetMetaCollisionTestAsync();
         failed += RunResolveTodayJstTests();
@@ -745,6 +746,90 @@ public static class SelfTest
             DeliveryReportBuilder.ParseQualitative("{\"risks\":[\"R\"]}", "AAA", logger) == null);
         f += Assert("ParseQualitative: risks 欠落 → null（corrupt 扱い）",
             DeliveryReportBuilder.ParseQualitative("{\"summary\":\"S\"}", "AAA", logger) == null);
+        return f;
+    }
+
+    /// <summary>
+    /// 3c STEP1: DeliveryReportBuilder.BuildDeliveryReportAsync の回帰。前提破綻 throw 2 経路
+    /// （Signal 行ゼロ／Passed 行に MlScore=null 混在）、Signal 行ありかつ Passed=0 の正常 0 件ペイロード
+    /// （無通知と故障の区別）、正常系（会社名 GroupBy 群毎 top-1 クエリの SQLite 翻訳可否・
+    /// AsOfDate&lt;=t の最新スナップショット選定・MlScore 降順 Rank・TotalPassed）を固定する。
+    /// </summary>
+    private static async Task<int> RunBuildDeliveryReportTestsAsync()
+    {
+        int f = 0;
+        var logger = NullLogger.Instance;
+        var t = new DateOnly(2026, 7, 1);
+
+        // (a) Signal 行ゼロ → throw（run-today 未実行/未完了の fail-loud）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                bool threw = false;
+                try { await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger); }
+                catch (InvalidOperationException) { threw = true; }
+                f += Assert("BuildDeliveryReport: Signal 行ゼロ → throw", threw);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // (b) Passed 行に MlScore=null 混在 → throw（ML 採点未完了＝パイプライン障害の fail-loud）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                db.Signals.Add(new Signal { Date = t, Code = "AAA", Passed = true, MlScore = null, RuleScore = 1 });
+                await db.SaveChangesAsync();
+                bool threw = false;
+                try { await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger); }
+                catch (InvalidOperationException) { threw = true; }
+                f += Assert("BuildDeliveryReport: MlScore=null 混在 → throw", threw);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // (c) Signal 行ありかつ Passed=0 → 0 件ペイロード（throw しない＝全面下落局面の正常全滅）。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                db.Signals.Add(new Signal { Date = t, Code = "AAA", Passed = false, RuleScore = 0 });
+                await db.SaveChangesAsync();
+                var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger);
+                f += Assert("BuildDeliveryReport: Passed=0 → Items=0/TotalPassed=0（throw しない）",
+                    report.Items.Count == 0 && report.TotalPassed == 0);
+            }
+            finally { conn.Dispose(); }
+        }
+
+        // (d) 正常系: Stocks スナップショット複数世代（AsOfDate<=t の最新が選ばれ、未来世代は無視される）＋
+        //     MlScore 降順の Rank 採番＋TotalPassed。GroupBy 群毎 top-1 クエリの SQLite 翻訳可否も同時に固定。
+        {
+            var db = NewMemoryDb(out var conn);
+            try
+            {
+                db.Signals.AddRange(
+                    new Signal { Date = t, Code = "AAA", Passed = true, MlScore = 0.9, RuleScore = 3, Rationale = "rA" },
+                    new Signal { Date = t, Code = "BBB", Passed = true, MlScore = 0.5, RuleScore = 2, Rationale = "rB" });
+                db.Stocks.AddRange(
+                    new Stock { Code = "AAA", AsOfDate = t.AddDays(-10), CompanyName = "旧社名" },
+                    new Stock { Code = "AAA", AsOfDate = t.AddDays(-1), CompanyName = "新社名" },
+                    new Stock { Code = "AAA", AsOfDate = t.AddDays(1), CompanyName = "未来社名" },
+                    new Stock { Code = "BBB", AsOfDate = t, CompanyName = "B社" });
+                await db.SaveChangesAsync();
+
+                var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, 3, logger);
+                f += Assert("BuildDeliveryReport: TotalPassed=2/Items=2",
+                    report.TotalPassed == 2 && report.Items.Count == 2);
+                f += Assert("BuildDeliveryReport: MlScore 降順 Rank（AAA=1, BBB=2）",
+                    report.Items[0] is { Code: "AAA", Rank: 1, MlScore: 0.9 }
+                    && report.Items[1] is { Code: "BBB", Rank: 2, MlScore: 0.5 });
+                f += Assert("BuildDeliveryReport: 会社名は AsOfDate<=t の最新（未来世代は無視）",
+                    report.Items[0].CompanyName == "新社名" && report.Items[1].CompanyName == "B社");
+            }
+            finally { conn.Dispose(); }
+        }
         return f;
     }
 


### PR DESCRIPTION
## 概要

`docs/plans/app-trade-analyzer/cr-fixes-notify-today-r1.md` の全項目を実装（AUTO-FIX 4 件＋残指摘 Minor 2 件）。
確信度 80 以上のバグはゼロ＝全項目は動作不変の品質改善。STEP2（Discord 整形）が同じ DTO を消費する前に DTO 形状と回帰網を固める。

## 実装内容

### F1. DeliveryItem.MlScore の nullable 撤去
- `NotifyModels.cs`: `double? MlScore` → `double`。builder の items 組み立てで `s.MlScore!.Value` 変換（MlScore=null 混在 throw ガード直後＝`!` の正当化が局所で自明）。
- `Commands.cs`: 消費側 `item.MlScore!.Value:F4` → `item.MlScore:F4`。STEP2/3 への `!` 伝播を事前に断つ。

### F2. BuildDeliveryReportAsync の SelfTest 回帰網
- `RunBuildDeliveryReportTestsAsync` 追加＋実行登録（`failed +=` リストへ登録済み＝残指摘 Minor 対応）:
  - (a) Signal 行ゼロ → InvalidOperationException
  - (b) Passed 行に MlScore=null 混在 → InvalidOperationException
  - (c) Signal 行ありかつ Passed=0 → Items=0・TotalPassed=0（throw しない）
  - (d) 正常系: 会社名 GroupBy 群毎 top-1 の SQLite 翻訳・AsOfDate<=t 最新スナップショット選定（未来世代無視）・MlScore 降順 Rank・TotalPassed

### F3. 対象日解決の重複抽出
- `Commands.cs`: explain-today / notify-today の逐語 9 行コピーを `ResolveTargetDateAsync` へ抽出（net -7 行）。run-today は `--date` 分岐なし・ingest 結合のため対象外（プラン裁定通り）。

### N1. culture 未指定補間の解消（ユーザー決定 2026-07-22 反映）
- 日付: 例外メッセージの `$"{t}: ..."` を `yyyy-MM-dd` Invariant 明示化。新規 2 箇所（NotifyModels.cs）＋**既存兄弟 3 箇所へ横展開（Commands.cs run-today/explain-today・BacktestService.cs）＝スコープ拡大**（機械的 3 行修正のため本 PR に同梱）。
- `NotifyModels.cs` / `BacktestService.cs` へ `using System.Globalization;` 追加（残指摘 Minor 対応）。
- 数値: Invariant 化せず `_Apps/CLAUDE.md` に「表示専用の数値書式は CurrentCulture 容認（日付は表示でも Invariant）」を明文化し再検査ノイズを止める。

## スコープ注記

- `_Apps/CLAUDE.md` は前セッション作成の未追跡ファイルだったため、N1 の容認 1 行を追記のうえ**ファイルごと本 PR に同梱**（追記行だけの分離コミットは不可能なため）。内容は現行実装の記述で整合確認済み。
- ルート `CLAUDE.md` の未コミット +1 行（_Tools 集約ルール）は本 PR に**含めない**（無関係のドキュメント変更のため作業ツリーに残置）。

## 検証

- `dotnet build _Apps/App.sln`: 0 警告 0 エラー
- `selftest`: 全 PASS（新規 BuildDeliveryReport 6 assert 含む・実行登録確認済み）
- 実 DB E2E:
  - `notify-today`（--date なし・自動解決）: 2026-07-22 Top-10 出力・ExitCode=0・出力体裁不変
  - `notify-today --date 2026-07-21`: 正常出力
  - `notify-today --date 2020-01-05`（Signal 行なし）: throw 伝播・ExitCode=1（契約維持）
- explain-today の実行検証は省略（Claude クレジット消費リスク。日付解決は notify-today と同一ヘルパを通るため等価）