### PR TITLE
refactor(trade-analyzer): 日付 ISO 文字列化を ToIso() 拡張へ集約（notify-today R2 F1）

### DIFF
--- a/_Apps/CLAUDE.md
+++ b/_Apps/CLAUDE.md
@@ -39,7 +39,7 @@ dotnet run --project _Apps/TradeAnalyzer.Worker -- <command>
 ## 重要な規約
 
 - **ExitCode 契約が段階で逆向き**: `explain-today` は Claude 実行時失敗を非致命スキップ（データ前提未達のみ ExitCode=1）。`notify-today` は「届ける」ことが仕事のため送信系失敗＝ExitCode=1、Passed=0 は正常（0 件ペイロード・ExitCode=0）。コマンド内で catch して契約を潰さないこと。
-- **文字列化は InvariantCulture**: 日付・数値の補間（SQL 文字列・CLI 引数含む）は culture 明示。過去レビューで複数回再発した箇所。例外: 表示専用の数値書式（Console 出力の `:F4` 等）は CurrentCulture 容認（日付は表示でも Invariant 明示）。
+- **文字列化は InvariantCulture**: 日付・数値の補間（SQL 文字列・CLI 引数含む）は culture 明示。過去レビューで複数回再発した箇所。例外: 表示専用の数値書式（Console 出力の `:F4` 等）は CurrentCulture 容認（日付は表示でも Invariant 明示）。日付の yyyy-MM-dd 文字列化は `ToIso()`（`TradeAnalyzer.Data/DateOnlyExtensions.cs`）を使う——インライン `ToString` を書かない。
 - **Claude 出力の数値安全性**: `QualitativeNumberGuard` で検証。プロンプト側で単位換算を禁止している（換算による誤検出対策）。
 - **Configure は拡張メソッドに集約**（Core / Data）。Worker は composition root のため `Program.cs` で直接バインドしてよい。
 - プランファイル置き場: `docs/plans/app-trade-analyzer/`

--- a/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
+++ b/_Apps/TradeAnalyzer.Core/Backtest/BacktestService.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -118,7 +117,7 @@ public class BacktestService
             // （double.MinValue で黙殺すると未推論銘柄が静かに最下位化し A/B 比較が無言で壊れる）。
             if (useMl && rows.Any(r => r.MlScore is null))
                 throw new InvalidOperationException(
-                    $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
+                    $"{t.ToIso()}: MlScore 未設定の Passed 行があります。signals 未実行/期間不一致/Python 未書戻しの可能性。"
                     + " 正しい順序は signals → train → (evaluate) → backtest --use-ml です。");
 
             var picks = SelectTopPicks(rows, _opt.TopN, useMl);

--- a/_Apps/TradeAnalyzer.Data/DateOnlyExtensions.cs
+++ b/_Apps/TradeAnalyzer.Data/DateOnlyExtensions.cs
@@ -1,0 +1,13 @@
+namespace TradeAnalyzer.Data;
+
+/// <summary>
+/// 日付の ISO 8601 文字列化（yyyy-MM-dd）を 1 か所へ集約する。SQL 文字列・CLI 引数・Claude 注入事実・
+/// API クエリ等、機械が読む日付補間はすべてこれを使うこと（culture 未指定の <c>$"{t}"</c> はレビューで
+/// 複数回再発した既知の欠陥クラス）。
+/// DateOnly の "O"（round-trip 指定子）は culture・暦非依存で常にグレゴリオ暦の yyyy-MM-dd を生成するため、
+/// 非グレゴリオ暦カルチャ（th-TH=仏暦等）のホストでも年がずれない（InvariantCulture 明示と出力同一）。
+/// </summary>
+public static class DateOnlyExtensions
+{
+    public static string ToIso(this DateOnly d) => d.ToString("O");
+}

--- a/_Apps/TradeAnalyzer.Data/External/Edinet/EdinetClient.cs
+++ b/_Apps/TradeAnalyzer.Data/External/Edinet/EdinetClient.cs
@@ -35,7 +35,7 @@ public class EdinetClient
     public async Task<List<EdinetDocument>> ListDocumentsAsync(DateOnly date, CancellationToken ct = default)
     {
         // 相対パス（先頭スラッシュ無し）＝ BaseAddress の /api/v2/ を保持させる。
-        var url = $"documents.json?date={Iso(date)}&type=2&{SubscriptionKeyParam}={Key()}";
+        var url = $"documents.json?date={date.ToIso()}&type=2&{SubscriptionKeyParam}={Key()}";
         var resp = await _http.GetFromJsonAsync<EdinetDocumentListResponse>(url, ct).ConfigureAwait(false);
         var results = resp?.Results ?? new();
 
@@ -88,8 +88,6 @@ public class EdinetClient
                 "EDINET Subscription-Key 未設定。`dotnet user-secrets set \"Edinet:SubscriptionKey\" <key>` を実行してください。");
         return Uri.EscapeDataString(_options.SubscriptionKey!);
     }
-
-    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static DateOnly? ParseDate(string? s)
     {

--- a/_Apps/TradeAnalyzer.Data/External/JQuants/JQuantsClient.cs
+++ b/_Apps/TradeAnalyzer.Data/External/JQuants/JQuantsClient.cs
@@ -26,7 +26,7 @@ public class JQuantsClient
         DateOnly? date = null, string? code = null, CancellationToken ct = default)
     {
         var query = new Dictionary<string, string?>();
-        if (date.HasValue) query["date"] = Iso(date.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
         if (code != null) query["code"] = code;
 
         var items = await GetAllPagesAsync<EquityMasterPage, EquityMasterItem>(
@@ -62,9 +62,9 @@ public class JQuantsClient
 
         var query = new Dictionary<string, string?>();
         if (code != null) query["code"] = code;
-        if (date.HasValue) query["date"] = Iso(date.Value);
-        if (from.HasValue) query["from"] = Iso(from.Value);
-        if (to.HasValue) query["to"] = Iso(to.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
+        if (from.HasValue) query["from"] = from.Value.ToIso();
+        if (to.HasValue) query["to"] = to.Value.ToIso();
 
         var items = await GetAllPagesAsync<DailyBarsPage, DailyBarItem>(
             "/v2/equities/bars/daily", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
@@ -95,7 +95,7 @@ public class JQuantsClient
 
         var query = new Dictionary<string, string?>();
         if (code != null) query["code"] = code;
-        if (date.HasValue) query["date"] = Iso(date.Value);
+        if (date.HasValue) query["date"] = date.Value.ToIso();
 
         var items = await GetAllPagesAsync<FinSummaryPage, FinSummaryItem>(
             "/v2/fins/summary", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
@@ -140,7 +140,7 @@ public class JQuantsClient
     public async Task<List<TradingCalendar>> GetCalendarAsync(
         DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        var query = new Dictionary<string, string?> { ["from"] = Iso(from), ["to"] = Iso(to) };
+        var query = new Dictionary<string, string?> { ["from"] = from.ToIso(), ["to"] = to.ToIso() };
         var items = await GetAllPagesAsync<CalendarPage, CalendarItem>(
             "/v2/markets/calendar", query, p => p.Data, p => p.PaginationKey, ct).ConfigureAwait(false);
 
@@ -203,8 +203,6 @@ public class JQuantsClient
             parts.Add($"pagination_key={Uri.EscapeDataString(paginationKey!)}");
         return parts.Count == 0 ? path : $"{path}?{string.Join("&", parts)}";
     }
-
-    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static DateOnly? ParseDate(string? s)
     {

--- a/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
+++ b/_Apps/TradeAnalyzer.Worker/Claude/ClaudeFactGatherer.cs
@@ -67,11 +67,11 @@ internal static class ClaudeFactGatherer
             // 日付は Label でなく Value に置く: Label はコンパイル時定数（許可集合・Flatten の対象外）という
             // 不変条件を保ち、Claude が株価日付を引用しても許可集合（Value 側）で正当化されるようにする。
             new("最新株価（調整後終値）", FmtNum(adjClose, "円", DecimalFmt)),
-            new("株価日付", FmtDate(bar?.Date)),
+            new("株価日付", bar?.Date.ToIso()),
             new("終値（生値）", FmtNum(bar?.Close, "円", DecimalFmt)),
             new("出来高", FmtNum(bar?.Volume, "株")),
             new("売買代金", FmtNum(bar?.TurnoverValue, "円")),
-            new("財務開示日", FmtDate(fin?.DiscloseDate)),
+            new("財務開示日", fin?.DiscloseDate.ToIso()),
             new("書類種別", fin?.DocType),
             new("売上高", FmtNum(fin?.Sales, "円")),
             new("営業利益", FmtNum(fin?.OperatingProfit, "円")),
@@ -106,8 +106,4 @@ internal static class ClaudeFactGatherer
 
     private static string? FmtNum(double? v, string unit, string format = "N0") =>
         v is double d ? d.ToString(format, CultureInfo.InvariantCulture) + " " + unit : null;
-
-    // InvariantCulture 必須: "yyyy" は現在カルチャの暦の年を出すため、非グレゴリオ暦カルチャ（th-TH=仏暦等）の
-    // ホストでは「2569-07-16」等の誤った年を「実データ」として注入してしまう（FmtNum/RuleScore と同じ方針）。
-    private static string? FmtDate(DateOnly? d) => d?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 }

--- a/_Apps/TradeAnalyzer.Worker/Commands.cs
+++ b/_Apps/TradeAnalyzer.Worker/Commands.cs
@@ -266,7 +266,7 @@ public static class Commands
         await RunPythonAsync(pythonOptions.Value, logger, predictScript, new[]
         {
             ("--db", dbPath),
-            ("--date", t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            ("--date", t.ToIso()),
         });
 
         // 5. null 検査＋6. Top-K 読取を AsNoTracking で1回にまとめる。
@@ -279,15 +279,14 @@ public static class Commands
             .ToListAsync();
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（Python 書戻し漏れ）。predict.py の出力を確認してください。");
 
         // 6. Top-K 出力。並べ替え／件数は純粋関数 SelectTopPicks（バックテスト picks と同一規則）に共通化し、
         //    本番出力と戦略の乖離を防ぐ（ソートキーの正典は SelectTopPicks の XML doc）。
         //    件数は当日 Top-K＝バックテスト TopN（同一概念。F11 で統合）の単一ノブを使う。
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);
 
-        // 日付は Invariant 明示（explain-today ヘッダと同型。非グレゴリオ暦カルチャ対策・表示専用）。
-        Console.WriteLine($"=== {t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
+        Console.WriteLine($"=== {t.ToIso()} Top-{topN}（MlScore 降順, Passed {passed.Count} 件中）===");
         Console.WriteLine($"{"Code",-8} {"MlScore",10} {"RuleScore",9}  Rationale");
         foreach (var s in top)
             Console.WriteLine($"{s.Code,-8} {s.MlScore!.Value,10:F4} {s.RuleScore,9}  {s.Rationale}");
@@ -337,7 +336,7 @@ public static class Commands
         // ＝この状態は常にパイプライン障害であり、警告のままだとスケジューラが緑で真の障害が見えない。
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから explain-today を再実行してください。");
 
         // 3. Top-K（run-today と同一の純粋関数で並べ替え）。Claude に回すのは Top-K のみ＝コスト/クレジットを bound。
@@ -389,9 +388,8 @@ public static class Commands
             results[signal.Code] = res;
         }
 
-        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。日付は Invariant 明示（非グレゴリオ暦
-        //    カルチャのホストで年が仏暦等になるのを防ぐ。r4-F4 と同機序・表示専用）。
-        string tStr = t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        // 7. Top-K 出力（summary/risks/numericUnverified を付す）。
+        string tStr = t.ToIso();
         string keptSuffix = kept > 0 ? $"・保持(再生成失敗) {kept} 件" : "";
         Console.WriteLine($"=== {tStr} Top-{topN} 定性レビュー（Passed {passed.Count} 件中・{results.Count}/{top.Count} 件生成・既存再利用 {reused.Count} 件{keptSuffix}）===");
         foreach (var s in top)
@@ -443,9 +441,8 @@ public static class Commands
         // 2. 配信ペイロード組み立て（前提破綻の throw は捕捉しない＝上記 ExitCode 契約）。
         var report = await DeliveryReportBuilder.BuildDeliveryReportAsync(db, t, topN, logger);
 
-        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。日付は Invariant 明示
-        //    （非グレゴリオ暦カルチャ対策・表示専用）。
-        string tStr = report.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        // 3. コンソール整形出力（explain-today の出力体裁を踏襲し rank/社名を追加）。
+        string tStr = report.Date.ToIso();
         Console.WriteLine($"=== {tStr} 配信ペイロード（Passed {report.TotalPassed} 件中 Top-{report.Items.Count} 件）===");
         if (report.Items.Count == 0)
             Console.WriteLine("本日シグナルなし（0 件通知）。");

--- a/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
+++ b/_Apps/TradeAnalyzer.Worker/Notify/NotifyModels.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -49,14 +48,14 @@ internal static class DeliveryReportBuilder
         // 存在判定（AnyAsync）とデータ取得を分け、小さい Passed 集合のみ材料化する（explain-today の読取と同型）。
         if (!await db.Signals.AsNoTracking().AnyAsync(s => s.Date == t, ct))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
+                $"{t.ToIso()}: Signal 行がありません（run-today 未実行/未完了）。run-today を成功させてから再実行してください。");
 
         var passed = await db.Signals.AsNoTracking()
             .Where(s => s.Date == t && s.Passed)
             .ToListAsync(ct);
         if (passed.Any(r => r.MlScore is null))
             throw new InvalidOperationException(
-                $"{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
+                $"{t.ToIso()}: MlScore 未設定の Passed 行があります（run-today の ML 採点が未完了＝パイプライン障害）。" +
                 "run-today を成功させてから再実行してください。");
 
         var top = BacktestService.SelectTopPicks(passed, topN, useMl: true);

--- a/_Apps/TradeAnalyzer.Worker/SelfTest.cs
+++ b/_Apps/TradeAnalyzer.Worker/SelfTest.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Data.Sqlite;
@@ -594,7 +593,7 @@ public static class SelfTest
             // Python 書戻しを模した生 SQL UPDATE（C# の追跡外で MlScore を埋める経路）。DateOnly は TEXT(yyyy-MM-dd)。
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}' AND Code = 'AAA'";
+                cmd.CommandText = $"UPDATE Signals SET MlScore = 0.42 WHERE Date = '{t.ToIso()}' AND Code = 'AAA'";
                 f += Assert("AsNoTracking 罠: 生 SQL UPDATE が 1 行", cmd.ExecuteNonQuery() == 1);
             }
 


### PR DESCRIPTION
## 背景

notify-today STEP1 の R2 レビュー（`docs/plans/app-trade-analyzer/cr-fixes-notify-today-r2.md`）反映。必須指摘ゼロ・[任意] 2 件のうち F1 を採用、N1 を見送り。

## F1: ISO 日付文字列化の共通ヘルパ抽出（採用・CONFIRMED）

culture 未指定の日付補間は 3b R5・R6・notify R1-N1 と 3 ラウンド連続で再発した指摘クラス。根本原因は「正しい 45 文字の決まり文句が面倒」という構造のため、共通ヘルパで正しい書き方を最短にして再発クラスを遮断する。

- `TradeAnalyzer.Data/DateOnlyExtensions.cs` 新設: `ToIso()` = `d.ToString("O")`。DateOnly の round-trip 指定子 "O" は culture・暦非依存で常に ISO 8601 `yyyy-MM-dd` を生成（MS Learn「Standard date and time format strings」）＝ InvariantCulture 明示と出力同一で `using System.Globalization` 不要
- インライン `ToString("yyyy-MM-dd", InvariantCulture)` 10 箇所を `ToIso()` へ置換（Commands.cs ×6 / NotifyModels.cs ×2 / BacktestService.cs / SelfTest.cs 生 SQL）
- 同一機能の私製ヘルパ 3 個を削除し統一: `JQuantsClient.Iso`（呼出 7）/ `EdinetClient.Iso`（呼出 1）/ `ClaudeFactGatherer.FmtDate`（呼出 2・`DateOnly?` は `x?.Date.ToIso()` チェーンで吸収）。FmtDate の Invariant 必須コメント（仏暦問題）は ToIso の XML doc へ移設
- 不要化した `using System.Globalization` を 3 ファイルから削除（他用途で使うファイルは残置）
- `_Apps/CLAUDE.md` に「日付の yyyy-MM-dd 文字列化は `ToIso()` を使う」正典 1 行を追記

動作不変（出力文字列は同一）。`retrain.ps1` は PowerShell のため対象外。

## N1: BuildDeliveryReportAsync の CancellationToken（見送り）

`ct = default` は async 公開 API の標準作法でコストほぼゼロ。STEP3 REST が現実になれば消費者が生まれる。削除→再追加の往復の方が高くつくため現状維持（プランの反対考慮どおり）。

## 検証

- `dotnet build _Apps/App.sln` — 0 警告 0 エラー
- `selftest` — 全 PASS（SelfTest.cs:597 の生 SQL 補間も置換対象＝r6 回帰網が同時検証）

## 差分

9 files, +35 −36（動作不変・純減）