### PR TITLE
fix(core): CoreUtil.Execute/ExecuteAsync の EOF 待ちブロッキング修正 (issue #185)

### DIFF
--- a/TBird.Core/Utils/CoreUtil.cs
+++ b/TBird.Core/Utils/CoreUtil.cs
@@ -42,12 +42,15 @@ namespace TBird.Core
 		public static void Execute(params ProcessStartInfo[] pis)
 		{
 			Process? process = null;
-			foreach (var pi in pis)
+			for (var i = 0; i < pis.Length; i++)
 			{
+				var pi = pis[i];
 				pi.CreateNoWindow = true;
 				pi.UseShellExecute = false;
 				pi.RedirectStandardInput = process != null;
-				pi.RedirectStandardOutput = true;
+				// 最終ﾌﾟﾛｾｽの stdout は誰も読まないため redirect しない（redirect するとﾊﾟｲﾌﾟ満杯や
+				// 孫ﾌﾟﾛｾｽの handle 継承で WaitForExit が返らなくなりうる）。
+				pi.RedirectStandardOutput = i < pis.Length - 1;
 
 				var now = Process.Start(pi);
 
@@ -76,38 +79,55 @@ namespace TBird.Core
 			}
 		}
 
-		public static async Task<int> ExecuteAsync(ProcessStartInfo info, Action<string> action)
+		/// <summary>
+		/// EOF 待ちの上限。子ﾌﾟﾛｾｽが stdout handle を継承した孫ﾌﾟﾛｾｽを残すと EOF が成立しないため、
+		/// exit 後この時間で読み取りを打ち切り、受信済み分＋警告で続行する（無限ﾌﾞﾛｯｸ回避）。
+		/// </summary>
+		private static readonly TimeSpan EofGrace = TimeSpan.FromSeconds(15);
+
+		public static async Task<int> ExecuteAsync(ProcessStartInfo info, Action<string>? action)
 		{
-			using (var process = Process.Start(info))
+			using (var process = new Process { StartInfo = info, EnableRaisingEvents = true })
 			{
-				if (process == null) return -1;
+				// 引数なし WaitForExit() は BeginOutputReadLine 使用時に EOF まで内包待機するため使わない。
+				// exit は Exited ｲﾍﾞﾝﾄ、EOF は OutputDataReceived の null 発火で分離して待つ。
+				var exitTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+				var eofTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+				process.Exited += (_, _) => exitTcs.TrySetResult(true);
 
-				if (action != null) for (string s; (s = await process.StandardOutput.ReadLineAsync().ConfigureAwait(false)) != null;)
+				var redirect = info.RedirectStandardOutput;
+				if (redirect)
+				{
+					process.OutputDataReceived += (_, e) =>
 					{
-						action(s);
+						if (e.Data == null) { eofTcs.TrySetResult(true); return; }
+						action?.Invoke(e.Data);
+					};
+				}
+
+				if (!process.Start()) return -1;
+				if (redirect) process.BeginOutputReadLine();
+
+				try
+				{
+					await exitTcs.Task.ConfigureAwait(false);
+
+					if (redirect && await Task.WhenAny(eofTcs.Task, Task.Delay(EofGrace)).ConfigureAwait(false) != eofTcs.Task)
+					{
+						MessageService.Warn($"{info.FileName}: stdout の EOF 待ちを {EofGrace.TotalSeconds:0} 秒で打ち切りました。孫ﾌﾟﾛｾｽが stdout を保持している可能性があり、出力末尾が欠落しえます（受信済み分で続行）。");
 					}
-
-				process.WaitForExit();
-
-				return process.ExitCode;
+					return process.ExitCode;
+				}
+				finally
+				{
+					if (redirect) process.CancelOutputRead();
+				}
 			}
 		}
 
-		public static int Execute(ProcessStartInfo info, Action<string> action)
+		public static int Execute(ProcessStartInfo info, Action<string>? action)
 		{
-			using (var process = Process.Start(info))
-			{
-				if (process == null) return -1;
-
-				if (action != null) for (string s; (s = process.StandardOutput.ReadLine()) != null;)
-					{
-						action(s);
-					}
-
-				process.WaitForExit();
-
-				return process.ExitCode;
-			}
+			return ExecuteAsync(info, action).GetAwaiter().GetResult();
 		}
 
 	}


### PR DESCRIPTION
Fixes #185

## 問題

`RedirectStandardOutput=true` の子プロセスが stdout write handle を継承した孫プロセスを残して終了すると、パイプ EOF が成立せず `ReadLine(Async)` の null 待ちループと引数なし `WaitForExit()`（出力処理完了まで内包待機）が無限ブロックする。PR #184 の ProcessRunner F1 と同族（deep レビュー横展開で検出、issue #185 化）。

## 修正内容（`TBird.Core/Utils/CoreUtil.cs` のみ）

ProcessRunner（PR #184 F1 修正後）と同思想の **exit 先行待ち＋bounded EOF drain** へ置換。

- `ExecuteAsync(info, action)`: 実装本体。exit は `Exited` イベント→TCS、EOF は `OutputDataReceived` の `e.Data==null`→TCS で分離。exit 後の EOF 待ちは 15 秒 grace で打ち切り、`MessageService.Warn` を出して受信済み分で続行。`redirect=false` ならイベント購読自体をスキップ（従来は `StandardOutput` 参照で例外）。`action==null` でも読み捨て drain（パイプ満杯ハングの芽を副次修正）。
- 同期版 `Execute(info, action)`: `ExecuteAsync(...).GetAwaiter().GetResult()` のラッパ化。内部は全 await `ConfigureAwait(false)` のため UI スレッドからでもデッドロックしない。
- pipe 版 `Execute(params ProcessStartInfo[])`: 最終プロセスの stdout を非 redirect 化（`i < pis.Length - 1` のみ redirect）。誰も読まない redirect はパイプ満杯→子 write ブロック→`WaitForExit` 不帰還という別系統ハングも抱えていたため両方根治。待ち方は現行維持。

netstandard2.0 制約（`WaitForExitAsync` なし・非ジェネリック `TaskCompletionSource` なし）のため `TaskCompletionSource<bool>` + `RunContinuationsAsynchronously` を使用。引数なし `WaitForExit()` は `BeginOutputReadLine` 使用時に EOF まで内包待機するため exit 待ちには使わない。

## 外から見える挙動変化

1. pipe 版の最終プロセス stdout が親コンソールへ流れる（唯一の呼び出し元 SQLiteControl の restore 側 `sqlite3.exe "dst"` は通常無出力で実害なし）。
2. `Execute`/`ExecuteAsync` の action 実行スレッドが呼び出し元→threadpool に変わる（既存呼び出し元は `Console.WriteLine`/stdout パーサでスレッド非依存。行順序は AsyncStreamReader が直列化するため維持）。
3. grace は 15 秒固定（ProcessRunner の `NormalExitEofGrace` と同値。必要になった時点で引数化）。

スコープ外（YAGNI）: timeout/kill 機能、pipe 版中間段 `ReadToEnd()` の EOF ハザード（唯一の実利用 `sqlite3 .dump` は孫を残さない）、ProcessRunner との共通化（TradeAnalyzer.* は TBird.* 非参照方針）。

## 検証（.tmp/ の使い捨てコンソール、実施後削除）

| シナリオ | 結果 |
|---|---|
| S1 正常経路: `cmd /c echo hello` → action 受信・ExitCode=0・即時復帰 | PASS (0.0s) |
| S2 本命: 孫 (`Start-Process powershell Start-Sleep 120`) が stdout 継承 → 修正前は無限ブロック、修正後は grace で復帰 | PASS: async 15.5s / sync 15.2s、警告ログ出力確認 |
| S3 pipe 版回帰: `echo data \| findstr data` 2 段 | PASS（data が親コンソールへ・即時完了） |
| S4 ExitCode 伝搬: `cmd /c exit 3` + action=null | PASS (code=3) |
| S5 redirect=false + action 非 null → 例外なし | PASS |

ビルド: `dotnet build TBird.Library.sln` 成功。警告 6 件は全て roslyntest の net5.0 EOL 既存警告で本変更と無関係。